### PR TITLE
[codex] Add release workflow automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+  package-macos:
+    name: Package macOS
+    runs-on: macos-latest
+    needs: test
+    if: github.event_name == 'push'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build macOS artifacts
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+        run: pnpm dist:mac
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: AgentDock-macOS-${{ github.sha }}
+          path: |
+            release/*.dmg
+            release/*.zip
+            release/*.yml
+            release/*.blockmap
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-macos:
+    name: Release macOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Publish macOS release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+        run: pnpm exec electron-builder --mac dmg zip --arm64 --publish always

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,76 @@
+# Release Workflow
+
+This repository uses GitHub Actions for CI and release packaging.
+
+## Recommended Flow
+
+Do not create a formal GitHub Release for every commit to `main`. For a desktop app, each formal release should map to an intentional product version that users can identify, install, and roll back to.
+
+The current workflow uses two stages:
+
+1. Pull requests and `main` pushes run CI.
+2. Version tags create GitHub Releases.
+
+## CI
+
+Workflow: `.github/workflows/ci.yml`
+
+Triggers:
+
+- Pull requests
+- Pushes to `main`
+
+Jobs:
+
+- `test` runs `pnpm test` on Ubuntu.
+- `package-macos` runs on `main` pushes after tests pass, builds macOS `dmg` and `zip` artifacts, and uploads them as GitHub Actions artifacts.
+
+The `main` branch artifacts are intended for validation only. They are retained for 14 days and are not formal releases.
+
+## Release
+
+Workflow: `.github/workflows/release.yml`
+
+Triggers:
+
+- Pushes to tags matching `v*`
+- Manual `workflow_dispatch`
+
+The release job:
+
+1. Installs dependencies with `pnpm install --frozen-lockfile`.
+2. Runs `pnpm test`.
+3. Publishes macOS `dmg` and `zip` artifacts with `electron-builder --publish always`.
+
+The workflow uses `secrets.GITHUB_TOKEN` through `GH_TOKEN` and requires `contents: write` permission to create or update GitHub Releases.
+
+## Creating a Release
+
+Update `package.json` version first, then tag that commit:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Use a tag that matches the app version. For example, `package.json` version `0.1.0` should be released as `v0.1.0`.
+
+## macOS Signing
+
+The current build is unsigned. `package.json` sets `mac.identity` to `null`, and CI sets `CSC_IDENTITY_AUTO_DISCOVERY=false`.
+
+Before distributing builds to real users, add Apple Developer signing and notarization secrets, then enable signing in the Electron Builder configuration.
+
+Suggested future secrets:
+
+- `CSC_LINK`
+- `CSC_KEY_PASSWORD`
+- `APPLE_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+- `APPLE_TEAM_ID`
+
+## Notes
+
+- `pnpm` version in CI is pinned to `10.33.0`.
+- Node.js version in CI is pinned to `22`.
+- Release artifacts are macOS arm64 only because `package.json` currently defines `dist:mac` and Electron Builder mac targets for arm64.


### PR DESCRIPTION
## Summary

- Add CI workflow for pull requests and main branch validation.
- Add release workflow that publishes macOS artifacts on version tags or manual dispatch.
- Document the release process in `docs/release-workflow.md`.

## Validation

- Parsed both workflow YAML files locally with Ruby YAML loader.

## Notes

- macOS release artifacts remain unsigned because the current Electron Builder config disables signing.