### PR TITLE
Auto-disable scheduler jobs after repeated failures

### DIFF
--- a/services/local-ai-core/src/scheduler/scheduler-service.ts
+++ b/services/local-ai-core/src/scheduler/scheduler-service.ts
@@ -6,6 +6,8 @@ import type { SchedulerExecutorRuntime, SchedulerTriggerRuntime } from './adapte
 import { toPublicScheduledJobId } from './job-id.js';
 import { SchedulerRunLifecycle } from './scheduler-run-lifecycle.js';
 
+const SCHEDULER_AUTO_DISABLE_THRESHOLD = 5;
+
 type SchedulerServiceOptions = {
   store: LocalCoreAcpStore;
   triggers: SchedulerTriggerRuntime[];
@@ -169,9 +171,34 @@ export class SchedulerService extends EventEmitter {
         this.options.eventBus.emit({ type: 'scheduler.job.updated', payload: nextJob });
       }
       this.options.log?.(`scheduler job failed ${job.id}: ${failed.error || 'unknown error'}`);
+      this.maybeAutoDisableAfterFailure(job.id);
       return failed;
     } finally {
       this.runningJobs.delete(job.id);
     }
+  }
+
+  private maybeAutoDisableAfterFailure(jobId: string) {
+    const runs = this.options.store.listScheduledJobRuns(jobId);
+    let consecutiveFailures = 0;
+    for (const run of runs) {
+      if (run.status === 'failed') {
+        consecutiveFailures += 1;
+      } else {
+        break;
+      }
+    }
+    if (consecutiveFailures < SCHEDULER_AUTO_DISABLE_THRESHOLD) {
+      return;
+    }
+    this.options.store.updateScheduledJobStatus(jobId, { enabled: false });
+    const disabled = this.options.store.getScheduledJob(jobId);
+    if (disabled) {
+      this.emit('job', disabled);
+      this.options.eventBus.emit({ type: 'scheduler.job.updated', payload: disabled });
+    }
+    this.options.log?.(
+      `scheduler auto-disabled job ${jobId} after ${consecutiveFailures} consecutive failures`,
+    );
   }
 }

--- a/tests/electron/workspace-task-store.test.ts
+++ b/tests/electron/workspace-task-store.test.ts
@@ -1013,6 +1013,67 @@ test('scheduler dispatches due jobs without waiting for long-running jobs', asyn
   }
 });
 
+test('scheduler auto-disables a job after 5 consecutive failures', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'scheduler-autodisable-'));
+  try {
+    const store = new LocalCoreAcpStore(userDataPath);
+    const created = store.createScheduledJob({
+      workspaceId: 'workspace-a',
+      platform: 'local',
+      route: { type: 'local.thread', channelId: 'workspace-a', threadId: 'thread-1' },
+      executionMode: 'side-thread',
+      triggerType: 'cron',
+      cronExpr: '* * * * *',
+      promptTemplate: 'broken',
+      description: 'always-failing job',
+      enabled: true,
+    });
+
+    const logs: string[] = [];
+    const jobUpdates: { enabled: boolean }[] = [];
+    const scheduler = new SchedulerService({
+      store,
+      triggers: [{
+        triggerTypes: ['cron'],
+        supports: () => true,
+        isDue: () => true,
+      }],
+      executors: [{
+        deliveryTargets: ['local'],
+        supports: () => true,
+        execute: async () => {
+          throw new Error("The 'gpt-5.3-codex' model is not supported");
+        },
+      }],
+      eventBus: {
+        emit: (event: any) => {
+          if (event?.type === 'scheduler.job.updated') {
+            jobUpdates.push({ enabled: event.payload.enabled });
+          }
+        },
+        on: () => () => {},
+      },
+      log: (message) => logs.push(message),
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await scheduler.runJobNow(created.id);
+    }
+
+    const jobAfter = store.getScheduledJob(created.id);
+    assert.equal(jobAfter?.enabled, false);
+    assert.ok(
+      logs.some((msg) => msg.includes('auto-disabled') && msg.includes('5 consecutive failures')),
+      `expected auto-disable log, got: ${JSON.stringify(logs)}`,
+    );
+    assert.ok(jobUpdates.some((update) => update.enabled === false));
+
+    store.close();
+  } finally {
+    rmSync(userDataPath, { recursive: true, force: true });
+  }
+});
+
 test('scheduled jobs normalize enum-like input before persistence', () => {
   const userDataPath = mkdtempSync(join(tmpdir(), 'scheduler-enum-store-'));
   try {


### PR DESCRIPTION
## Summary
- Scheduled jobs that fail on every run (e.g., misconfigured model like `gpt-5.3-codex` with a ChatGPT account) used to retry indefinitely, generating error logs every trigger without any way for the user to notice.
- After a run fails, count consecutive failures from run history. On the 5th consecutive failure, disable the job (`enabled = false`), emit `scheduler.job.updated` so the UI reflects it, and log the auto-disable reason.
- No schema change — uses the existing `scheduled_job_runs` table. A subsequent success naturally resets the consecutive count, so re-enabling a fixed job behaves correctly.

## Found during daily log review
Spotted in `~/.agentdock/logs/error.log`: scheduler job `9cbb033c` failed at 11:30, 13:00, and 18:25 today (and on prior days) with `The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.`. Each failure only produced a generic `scheduler job failed ...: Scheduled run finished with status failed` line.

A secondary log-spam issue (52k WeChat `session timeout` entries in `error.log.1` over ~1 month) was reviewed but deferred — the existing 5-minute dedup window in `logPollError` already mitigates it, and a proper fix would need backoff tuning or level reclassification, which is a larger change.

## Test plan
- [x] Added `scheduler auto-disables a job after 5 consecutive failures` in `tests/electron/workspace-task-store.test.ts` — verifies the job is disabled, an auto-disable log is emitted, and a `scheduler.job.updated` event fires with `enabled: false`.
- [x] `pnpm test` — 306 pass, 1 fail (`workspace route launches sandbox proxy when sandbox is enabled`) is pre-existing on `main` and unrelated to this change (verified by stashing the change and re-running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)