### PR TITLE
Fix lac scheduler edit clearing unprovided fields

### DIFF
--- a/services/local-ai-core/src/cli/lac.ts
+++ b/services/local-ai-core/src/cli/lac.ts
@@ -323,10 +323,10 @@ async function handleEdit(jobId: string, flags: Map<string, string[]>, env: Node
   if (cronExpr) {
     input.cronExpr = cronExpr;
   }
-  if (typeof promptTemplate === 'string') {
+  if (promptTemplate) {
     input.promptTemplate = promptTemplate;
   }
-  if (typeof description === 'string') {
+  if (description) {
     input.description = description;
   }
   if (typeof enabled === 'boolean') {

--- a/tests/electron/lac-cli.test.ts
+++ b/tests/electron/lac-cli.test.ts
@@ -599,6 +599,45 @@ test('lac scheduler edit patches a short job id and normalizes execution mode', 
   }
 });
 
+test('lac scheduler edit with only --cron does not clear message or description', async () => {
+  let capturedBody: string | null = null;
+  const { restore } = withFetchMock(async (_input, init) => {
+    if (init?.body) capturedBody = init.body as string;
+    return new Response(JSON.stringify({
+      ok: true,
+      data: {
+        id: 'job:826aff79-570b-4308-822e-18318e2c96ba',
+        workspaceId: '知识库',
+        platform: 'lark',
+        route: { type: 'channel.chat', channelId: 'chat-1', participantId: 'user-1', threadId: 'thread-1' },
+        executionMode: 'same-thread',
+        triggerType: 'cron',
+        cronExpr: '0 2 * * *',
+        promptTemplate: 'preserved message',
+        description: 'preserved desc',
+        enabled: true,
+        concurrencyPolicy: 'skip_if_running',
+        createdAt: '2026-04-22T06:00:00.000Z',
+        updatedAt: '2026-04-22T07:00:00.000Z',
+      },
+    }), { headers: { 'content-type': 'application/json' } });
+  });
+  try {
+    const { io, read } = createIo();
+    const exitCode = await runCli(
+      ['scheduler', 'edit', '826aff79', '--cron', '0 2 * * *'],
+      { LOCAL_AI_CORE_BASE: 'http://127.0.0.1:9831/api/local/v1' },
+      io,
+    );
+    assert.equal(exitCode, 0);
+    assert(capturedBody);
+    assert.deepEqual(JSON.parse(capturedBody), { cronExpr: '0 2 * * *' });
+    assert.match(read().stdout, /Updated scheduler job 826aff79/);
+  } finally {
+    restore();
+  }
+});
+
 test('lac scheduler del deletes a short job id', async () => {
   const { restore } = withFetchMock(async () => {
     return new Response(JSON.stringify({ ok: true, data: { deleted: true } }), { headers: { 'content-type': 'application/json' } });


### PR DESCRIPTION
## Summary
- `lac scheduler edit <id> --cron "..."` was zeroing out the job's `promptTemplate` and `description` even when those flags were not passed.
- Root cause: the handler checked `typeof promptTemplate === 'string'`, but `getFlag` returns `''` for missing flags, so the check always passed. Switched to truthy checks, matching the existing monitor edit and the cron/executionMode branches in the same handler.

## Test plan
- [x] Added regression test `lac scheduler edit with only --cron does not clear message or description` in `tests/electron/lac-cli.test.ts` — fails on main, passes after fix.
- [x] `pnpm test` (lac-cli suite: 14/14 pass; the unrelated `sandbox-config.test.js` "workspace route launches sandbox proxy when sandbox is enabled" failure reproduces on `main` without my changes and is environment-specific).
- [x] End-to-end against a running Local AI Core: created a job with non-empty message/description, ran `lac scheduler edit <id> --cron "0 7 * * *"` against the rebuilt CLI, confirmed both fields were preserved. Ran a second edit with `--message/--desc/--enabled/--execution-mode` together and confirmed every field updates as expected.