### PR TITLE
Sample lark empty-render log per session/type

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -74,6 +74,7 @@ const PAIRING_EXPIRY_MS = 10 * 60 * 1000;
 const LARK_MAX_UPLOAD_FILE_SIZE = 30 * 1024 * 1024;
 const LARK_FINAL_PATCH_INTERVAL_MS = 900;
 const LARK_PROGRESS_PATCH_INTERVAL_MS = 3000;
+const LARK_EMPTY_RENDER_LOG_WINDOW_MS = 5 * 60 * 1000;
 
 export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, LarkWorkspaceBinding, LarkThreadRoute, LarkTurnState> {
   // Lark returns 200340 when card action events are not enabled in the app's
@@ -82,6 +83,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
   // Keep permission state in a dedicated card to avoid mixing order in the main reply card.
   private readonly mirrorPermissionStateInMainCard = false;
   private larkModulePromise: Promise<LarkModule> | null = null;
+  private readonly emptyRenderLogWindows = new Map<string, number>();
   readonly platform = 'lark';
 
   constructor(options: LocalCoreLarkGatewayOptions) {
@@ -442,7 +444,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
           const renderedMessages = renderLarkBridgeEventMessages(turn, event);
           for (const renderedMessage of renderedMessages) {
             if (!renderedMessage.text && renderedMessage.buttonRows.length === 0) {
-              this.options.log?.(`localcore-lark bridge event produced empty render for sessionKey=${sessionKey} type=${event.type}`);
+              this.logEmptyRender(sessionKey, event.type);
               continue;
             }
             const existingMessageId = getLarkRenderedMessageId(turn, renderedMessage);
@@ -1434,6 +1436,23 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     } catch (error) {
       this.options.log?.(`localcore-lark acknowledgement reaction failed for message=${messageId}: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  private logEmptyRender(sessionKey: string, type: string) {
+    const key = `${sessionKey}|${type}`;
+    const now = Date.now();
+    const lastAt = this.emptyRenderLogWindows.get(key);
+    if (lastAt !== undefined && now - lastAt < LARK_EMPTY_RENDER_LOG_WINDOW_MS) {
+      return;
+    }
+    this.emptyRenderLogWindows.set(key, now);
+    if (this.emptyRenderLogWindows.size > 1000) {
+      const oldestKey = this.emptyRenderLogWindows.keys().next().value;
+      if (oldestKey) {
+        this.emptyRenderLogWindows.delete(oldestKey);
+      }
+    }
+    this.options.log?.(`localcore-lark bridge event produced empty render for sessionKey=${sessionKey} type=${type}`);
   }
 
 }

--- a/tests/integration/lark-gateway.test.ts
+++ b/tests/integration/lark-gateway.test.ts
@@ -2143,3 +2143,27 @@ test('lark channel keeps multiple bot instances in one workspace isolated', asyn
     ['default', 'bot-b', 'cli_b', 'running'],
   ]);
 });
+
+test('lark gateway samples empty-render log per session/type within the dedup window', () => {
+  const logs: string[] = [];
+  const gateway = new LocalCoreLarkGateway({
+    store: {} as any,
+    readConfig: async () => null,
+    getWorkspaceRouter: () => ({} as any),
+    eventBus: { emit: () => {}, on: () => () => {} } as any,
+    log: (message: string) => logs.push(message),
+  });
+  const internals = gateway as any;
+
+  for (let i = 0; i < 5; i += 1) {
+    internals.logEmptyRender('session:thread-1', 'update_message');
+  }
+  internals.logEmptyRender('session:thread-1', 'preview_start');
+  internals.logEmptyRender('session:thread-2', 'update_message');
+
+  const emptyRenderLogs = logs.filter((line) => line.includes('produced empty render'));
+  assert.equal(emptyRenderLogs.length, 3);
+  assert.ok(emptyRenderLogs[0].includes('session:thread-1') && emptyRenderLogs[0].includes('type=update_message'));
+  assert.ok(emptyRenderLogs[1].includes('type=preview_start'));
+  assert.ok(emptyRenderLogs[2].includes('session:thread-2'));
+});


### PR DESCRIPTION
## Summary
- A single chatty Lark agent session generated **2,942** `bridge event produced empty render` INFO log entries in one day (2026-06-16), all for `type=update_message` from one sessionKey. This dominated `info.log` and provided little actionable signal — empty renders are routine during streaming.
- Added a per-`(sessionKey, type)` dedup window of 5 minutes (matching the WeChat gateway's existing `logPollError` pattern). The first empty render in each window still logs; subsequent ones are silent.
- Map is capped at 1000 entries (oldest evicted) to bound memory.

## Found during daily log review
- Reviewed `~/.agentdock/logs/{error,warn,info,sys}.log` for 2026-06-15 and 2026-06-16.
- No errors today (2026-06-16); yesterday's only error was the known `gpt-5.3-codex` scheduler failure on job `9cbb033c` — already addressed by open PR #2 (auto-disable after 5 consecutive failures), not yet deployed locally per instructions.
- The `empty render` INFO spam was the loudest log-volume issue worth fixing today.

## Test plan
- [x] Added `lark gateway samples empty-render log per session/type within the dedup window` in `tests/integration/lark-gateway.test.ts` — verifies 5 calls with the same `(sessionKey, type)` produce 1 log, while a different session/type still logs.
- [x] `pnpm test` — 318 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)