### PR TITLE
Simplify runtime config store and dedup migration helper

### DIFF
--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -96,7 +96,7 @@ export class LocalCoreAcpStore {
     this.modelProviders = new LocalModelProviderStore(this.db);
     this.external = new LocalExternalStore(this.db);
     ensureLocalCoreAcpSchema(this.db);
-    this.runtimeConfig = new LocalRuntimeConfigStore(this.db, dbPath, runtimeDir, resolveLegacyConfigPaths(runtimeDir));
+    this.runtimeConfig = new LocalRuntimeConfigStore(this.db, dbPath, resolveLegacyConfigPaths(runtimeDir));
   }
 
   close() {

--- a/services/local-ai-core/src/acp/store/runtime-config-store.ts
+++ b/services/local-ai-core/src/acp/store/runtime-config-store.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
-import type { DatabaseSync } from 'node:sqlite';
+import type { DatabaseSync, StatementSync } from 'node:sqlite';
+import { dirname } from 'node:path';
 import * as TOML from '@iarna/toml';
 import type {
   DesktopConnectConfig,
@@ -18,20 +19,40 @@ type RuntimeConfigRow = {
 };
 
 export class LocalRuntimeConfigStore {
+  private readonly baseDir: string;
+  private readonly selectStmt: StatementSync;
+  private readonly insertStmt: StatementSync;
+  private readonly updateStmt: StatementSync;
+
   constructor(
     private readonly db: DatabaseSync,
     private readonly databasePath: string,
-    private readonly baseDir: string,
     private readonly legacyConfigPaths: string[],
-  ) {}
+  ) {
+    this.baseDir = dirname(databasePath);
+    this.selectStmt = db.prepare(`
+      SELECT config_json, base_dir, migrated_from_path, updated_at
+      FROM runtime_config
+      WHERE id = ?
+    `);
+    this.insertStmt = db.prepare(`
+      INSERT INTO runtime_config (id, config_json, base_dir, migrated_from_path, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    this.updateStmt = db.prepare(`
+      UPDATE runtime_config
+      SET config_json = ?, base_dir = ?, migrated_from_path = ?, updated_at = ?
+      WHERE id = ?
+    `);
+  }
 
   read(): RuntimeConfigState {
-    const row = this.getRow();
+    const row = this.selectStmt.get(RUNTIME_CONFIG_ID) as RuntimeConfigRow | undefined;
     if (row) {
       const config = parseJson<DesktopConnectConfig>(row.config_json, {});
       const migrated = migrateDesktopConnectConfig(config);
       if (migrated.changed) {
-        return this.save(migrated.config, {
+        return this.writeRow(migrated.config, {
           migratedFromPath: row.migrated_from_path || undefined,
           warnings: migrated.warnings,
         });
@@ -44,7 +65,7 @@ export class LocalRuntimeConfigStore {
       if ('error' in legacy) {
         return this.errorState(legacy.path, legacy.error);
       }
-      return this.save(legacy.config, {
+      return this.writeRow(legacy.config, {
         migratedFromPath: legacy.path,
         warnings: legacy.warnings,
       });
@@ -58,41 +79,37 @@ export class LocalRuntimeConfigStore {
     warnings?: string[];
   } = {}): RuntimeConfigState {
     const migrated = migrateDesktopConnectConfig(config);
-    const row = this.getRow();
+    return this.writeRow(migrated.config, {
+      migratedFromPath: options.migratedFromPath,
+      warnings: [
+        ...(options.warnings || []),
+        ...migrated.warnings,
+      ],
+    });
+  }
+
+  private writeRow(config: DesktopConnectConfig, options: {
+    migratedFromPath?: string;
+    warnings?: string[];
+  } = {}): RuntimeConfigState {
+    const row = this.selectStmt.get(RUNTIME_CONFIG_ID) as RuntimeConfigRow | undefined;
     const now = new Date().toISOString();
     const migratedFromPath = options.migratedFromPath ?? row?.migrated_from_path ?? null;
+    const configJson = JSON.stringify(config);
     if (row) {
-      this.db.prepare(`
-        UPDATE runtime_config
-        SET config_json = ?, base_dir = ?, migrated_from_path = ?, updated_at = ?
-        WHERE id = ?
-      `).run(JSON.stringify(migrated.config), this.baseDir, migratedFromPath, now, RUNTIME_CONFIG_ID);
+      this.updateStmt.run(configJson, this.baseDir, migratedFromPath, now, RUNTIME_CONFIG_ID);
     } else {
-      this.db.prepare(`
-        INSERT INTO runtime_config (id, config_json, base_dir, migrated_from_path, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?)
-      `).run(RUNTIME_CONFIG_ID, JSON.stringify(migrated.config), this.baseDir, migratedFromPath, now, now);
+      this.insertStmt.run(RUNTIME_CONFIG_ID, configJson, this.baseDir, migratedFromPath, now, now);
     }
     return {
       storage: 'sqlite',
       databasePath: this.databasePath,
       baseDir: this.baseDir,
-      config: migrated.config,
+      config,
       ...(migratedFromPath ? { migratedFromPath } : {}),
       updatedAt: now,
-      warnings: [
-        ...(options.warnings || []),
-        ...migrated.warnings,
-      ].filter(Boolean),
+      warnings: (options.warnings || []).filter(Boolean),
     };
-  }
-
-  private getRow(): RuntimeConfigRow | undefined {
-    return this.db.prepare(`
-      SELECT config_json, base_dir, migrated_from_path, updated_at
-      FROM runtime_config
-      WHERE id = ?
-    `).get(RUNTIME_CONFIG_ID) as RuntimeConfigRow | undefined;
   }
 
   private toState(row: RuntimeConfigRow, config: DesktopConnectConfig, warnings: string[]): RuntimeConfigState {

--- a/services/local-ai-core/src/runtime/external-service.ts
+++ b/services/local-ai-core/src/runtime/external-service.ts
@@ -13,7 +13,7 @@ import type {
   RuntimeConfigState,
 } from '../../../../packages/contracts/src/index.js';
 import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
-import { migrateLegacyProjectProvidersToStore } from './provider-config-migration.js';
+import { applyLegacyProviderMigration } from './provider-config-migration.js';
 import type { WorkspaceRouter } from '../router/workspace-router.js';
 
 export interface ExternalServiceDeps {
@@ -194,20 +194,11 @@ export class ExternalService {
   }
 
   private async readAndMigrateConfigFile(): Promise<RuntimeConfigState> {
-    const current = await this.deps.readRuntimeConfig();
-    const migrated = migrateLegacyProjectProvidersToStore(current.config, this.store);
-    if (!migrated.changed) {
-      return current;
-    }
-    const saved = await this.deps.saveRuntimeConfig(migrated.config);
-    return {
-      ...saved,
-      warnings: [
-        ...(current.warnings || []),
-        ...(saved.warnings || []),
-        ...migrated.warnings,
-      ],
-    };
+    return applyLegacyProviderMigration(
+      await this.deps.readRuntimeConfig(),
+      this.store,
+      (config) => this.deps.saveRuntimeConfig(config),
+    );
   }
 
   private projectBasePath(userId: string, externalProjectId: string) {

--- a/services/local-ai-core/src/runtime/local-core-controller.ts
+++ b/services/local-ai-core/src/runtime/local-core-controller.ts
@@ -18,7 +18,7 @@ import type { LocalCoreRuntimeState } from './local-core-runtime-state.js';
 import type { ScheduledJobApplicationService } from '../scheduler/scheduled-job-application-service.js';
 import type { AutomationMonitorService } from '../automation/automation-monitor-service.js';
 import { RuntimeDetectionService, type RuntimeDetectionEvent } from './runtime-detection-service.js';
-import { migrateLegacyProjectProvidersToStore } from './provider-config-migration.js';
+import { applyLegacyProviderMigration, migrateLegacyProjectProvidersToStore } from './provider-config-migration.js';
 import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
 import { ChannelService } from './channel-service.js';
 import { ExternalService } from './external-service.js';
@@ -339,19 +339,10 @@ export class LocalCoreController extends EventEmitter {
   }
 
   private async readAndMigrateRuntimeConfig(): Promise<RuntimeConfigState> {
-    const current = this.store.readRuntimeConfig();
-    const migrated = migrateLegacyProjectProvidersToStore(current.config, this.store);
-    if (!migrated.changed) {
-      return current;
-    }
-    const saved = this.store.saveRuntimeConfig(migrated.config);
-    return {
-      ...saved,
-      warnings: [
-        ...(current.warnings || []),
-        ...(saved.warnings || []),
-        ...migrated.warnings,
-      ],
-    };
+    return applyLegacyProviderMigration(
+      this.store.readRuntimeConfig(),
+      this.store,
+      (config) => this.store.saveRuntimeConfig(config),
+    );
   }
 }

--- a/services/local-ai-core/src/runtime/provider-config-migration.ts
+++ b/services/local-ai-core/src/runtime/provider-config-migration.ts
@@ -1,4 +1,4 @@
-import type { DesktopConnectConfig, DesktopProjectConfig } from '../../../../packages/contracts/src/index.js';
+import type { DesktopConnectConfig, DesktopProjectConfig, RuntimeConfigState } from '../../../../packages/contracts/src/index.js';
 import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
 import { normalizeDesktopProviderForStorage } from './config-migration.js';
 
@@ -35,6 +35,26 @@ export function migrateLegacyProjectProvidersToStore(
     changed = true;
   }
   return { config, changed, warnings };
+}
+
+export async function applyLegacyProviderMigration<T extends RuntimeConfigState>(
+  current: T,
+  store: Pick<LocalCoreAcpStore, 'upsertModelProvider'>,
+  save: (config: DesktopConnectConfig) => T | Promise<T>,
+): Promise<T> {
+  const migrated = migrateLegacyProjectProvidersToStore(current.config, store);
+  if (!migrated.changed) {
+    return current;
+  }
+  const saved = await save(migrated.config);
+  return {
+    ...saved,
+    warnings: [
+      ...(current.warnings || []),
+      ...(saved.warnings || []),
+      ...migrated.warnings,
+    ],
+  };
 }
 
 function cloneConfig(input: DesktopConnectConfig): DesktopConnectConfig {

--- a/services/local-ai-core/src/scheduler/channel-execution-policy.ts
+++ b/services/local-ai-core/src/scheduler/channel-execution-policy.ts
@@ -2,6 +2,7 @@ import type { ScheduledJob } from '../../../../packages/contracts/src/index.js';
 import type { ChannelRuntime } from '../../../../packages/plugin-sdk/src/index.js';
 import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
 import type { WorkspaceRouter } from '../router/workspace-router.js';
+import { normalizeAgentType } from '../agents/shared/definition.js';
 import type { ScheduledExecutionTarget } from './adapters.js';
 import type { ScheduledExecutionPolicy } from './execution-policy.js';
 import { ScheduledBridgeSession, type ScheduledBridgeSessionHandle } from './scheduled-bridge-session.js';
@@ -118,8 +119,4 @@ class SideThreadChannelExecutionPolicy implements ScheduledExecutionPolicy {
   private threadMatchesTargetAgent(thread: { agentType?: string | null }, targetAgent: string) {
     return normalizeAgentType(thread.agentType) === targetAgent;
   }
-}
-
-function normalizeAgentType(value?: string | null) {
-  return String(value || '').trim().toLowerCase();
 }

--- a/tests/electron/sandbox-config.test.ts
+++ b/tests/electron/sandbox-config.test.ts
@@ -177,7 +177,9 @@ test('sandbox proxy env stores serialized launch config', () => {
 
 test('workspace route launches sandbox proxy when sandbox is enabled', () => {
   const root = mkdtempSync(join(tmpdir(), 'agentdock-sandbox-'));
+  const previousUserDataDir = process.env.AI_WORKSTATION_USER_DATA_DIR;
   try {
+    delete process.env.AI_WORKSTATION_USER_DATA_DIR;
     mkdirSync(join(root, 'runtime'), { recursive: true });
     const route = toLocalCoreProjectConfig(configState(join(root, 'runtime', 'config.toml')), project({
       enabled: true,
@@ -195,6 +197,9 @@ test('workspace route launches sandbox proxy when sandbox is enabled', () => {
     assert.equal(route.sandbox?.image, 'agentdock/pi-acp:local');
     assert.equal(JSON.parse(route.env.AGENTDOCK_SANDBOX_CONFIG).image, 'agentdock/pi-acp:local');
   } finally {
+    if (previousUserDataDir !== undefined) {
+      process.env.AI_WORKSTATION_USER_DATA_DIR = previousUserDataDir;
+    }
     rmSync(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Reuse existing `normalizeAgentType` from `agents/shared/definition.ts` in `scheduler/channel-execution-policy.ts`
- Extract `applyLegacyProviderMigration()` in `provider-config-migration.ts` to replace byte-identical migration blocks in `local-core-controller.ts` and `external-service.ts`
- Prepare SQLite statements once in `LocalRuntimeConfigStore` constructor (was re-preparing on every save/getRow)
- Add internal `writeRow()` so `read()` write-back skips redundant migration + row lookup
- Drop redundant `baseDir` constructor arg; derive via `dirname(databasePath)`
- Isolate sandbox proxy cwd test from `AI_WORKSTATION_USER_DATA_DIR` env

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.electron.json` — clean
- [x] `pnpm test` — 317/317 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)