### PR TITLE
Dedupe lark/weixin channel key helpers

### DIFF
--- a/services/local-ai-core/src/channel/lark/config.ts
+++ b/services/local-ai-core/src/channel/lark/config.ts
@@ -1,20 +1,7 @@
 import type { DesktopConnectConfig } from '../../../../../packages/contracts/src/index.js';
 import { normalizeDesktopPlatformType } from '../../../../../shared/desktop.js';
+import { channelPlatformKey, normalizeChannelInstanceId } from '../shared/channel-keys.js';
 import type { LarkWorkspaceBinding } from './types.js';
-
-export function normalizeChannelInstanceId(value: unknown, fallback: string) {
-  const raw = String(value || '').trim();
-  const normalized = raw.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-+/g, '-').slice(0, 80);
-  return normalized || fallback;
-}
-
-export function channelPlatformKey(platform: string, instanceId: string) {
-  return instanceId === 'default' ? platform : `${platform}:${instanceId}`;
-}
-
-export function runtimeKey(workspaceId: string, instanceId: string) {
-  return `${workspaceId}::${instanceId}`;
-}
 
 export function collectLarkWorkspaceBindings(
   config: DesktopConnectConfig | null | undefined,

--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -41,7 +41,8 @@ import {
   renderPendingPairingCard,
   renderPermissionCard,
 } from './cards.js';
-import { channelPlatformKey, collectLarkWorkspaceBindings, runtimeKey } from './config.js';
+import { channelPlatformKey, runtimeKey } from '../shared/channel-keys.js';
+import { collectLarkWorkspaceBindings } from './config.js';
 import {
   DEFAULT_LARK_QR_EXPIRES_IN,
   getLarkOpenBase,

--- a/services/local-ai-core/src/channel/shared/channel-keys.ts
+++ b/services/local-ai-core/src/channel/shared/channel-keys.ts
@@ -1,0 +1,13 @@
+export function normalizeChannelInstanceId(value: unknown, fallback: string) {
+  const raw = String(value || '').trim();
+  const normalized = raw.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-+/g, '-').slice(0, 80);
+  return normalized || fallback;
+}
+
+export function channelPlatformKey(platform: string, instanceId: string) {
+  return instanceId === 'default' ? platform : `${platform}:${instanceId}`;
+}
+
+export function runtimeKey(workspaceId: string, instanceId: string) {
+  return `${workspaceId}::${instanceId}`;
+}

--- a/services/local-ai-core/src/channel/weixin/config.ts
+++ b/services/local-ai-core/src/channel/weixin/config.ts
@@ -2,25 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { DesktopConnectConfig } from '../../../../../packages/contracts/src/index.js';
 import { normalizeDesktopPlatformType } from '../../../../../shared/desktop.js';
+import { channelPlatformKey, normalizeChannelInstanceId } from '../shared/channel-keys.js';
 import type { WeixinCredentials, WeixinWorkspaceBinding } from './types.js';
 
 export const DEFAULT_BASE_URL = 'https://ilinkai.weixin.qq.com';
 export const DEFAULT_CDN_BASE_URL = 'https://novac2c.cdn.weixin.qq.com/c2c';
 export const LONG_POLL_TIMEOUT_MS = 35_000;
-
-export function normalizeChannelInstanceId(value: unknown, fallback: string) {
-  const raw = String(value || '').trim();
-  const normalized = raw.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-+/g, '-').slice(0, 80);
-  return normalized || fallback;
-}
-
-export function channelPlatformKey(platform: string, instanceId: string) {
-  return instanceId === 'default' ? platform : `${platform}:${instanceId}`;
-}
-
-export function runtimeKey(workspaceId: string, instanceId: string) {
-  return `${workspaceId}::${instanceId}`;
-}
 
 export function getDefaultWeixinStateDir() {
   return path.join(process.cwd(), 'weixin-monitor');

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -27,14 +27,13 @@ import { prepareChannelFile, type PreparedChannelFile } from '../shared/file-uti
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
 import { resolveChannelThreadRoute } from '../shared/thread-routing.js';
 import { BaseChannelGateway, type GatewayBinding, type GatewayRuntimeState, type GatewayThreadRoute } from '../shared/base-channel-gateway.js';
+import { channelPlatformKey, runtimeKey } from '../shared/channel-keys.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
 import {
-  channelPlatformKey,
   collectWeixinWorkspaceBindings,
   getWeixinBufPath,
   loadWeixinBuf,
-  runtimeKey,
   saveWeixinBuf,
   saveWeixinCredentials,
 } from './config.js';


### PR DESCRIPTION
## Summary
- `normalizeChannelInstanceId`, `channelPlatformKey`, and `runtimeKey` were defined byte-for-byte identically in both `channel/lark/config.ts` and `channel/weixin/config.ts`. Moved them to a new `channel/shared/channel-keys.ts` (matches the existing `channel/shared/` convention for cross-channel utilities) and updated both gateways to import from there.
- Net change: −31 lines, +18 lines.

## Category
**b — code reuse.** Pure duplication with no platform-specific behavior. These helpers do the same string-formatting work regardless of channel. Duplicated utility code is the kind of thing that has already drifted into subtle bugs elsewhere in this repo.

## Test plan
- [x] `pnpm build:electron` — TypeScript compiles clean.
- [x] `pnpm test` — 317 pass, 1 fail. The failure (`workspace route launches sandbox proxy when sandbox is enabled`, test #141) is pre-existing on `main` (verified by stashing my changes and re-running) and unrelated to this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)