### PR TITLE
Remove dead Lark/WeChat convenience wrappers in ChannelService

### DIFF
--- a/services/local-ai-core/src/runtime/channel-service.ts
+++ b/services/local-ai-core/src/runtime/channel-service.ts
@@ -1,15 +1,10 @@
 import type {
-  LocalCoreAuthorizedUser,
   LocalCoreChannelAuthorizedUser,
   LocalCoreChannelConnectionResult,
   LocalCoreChannelGatewayStatus,
   LocalCoreChannelPairingRequest,
   LocalCoreChannelQrCode,
   LocalCoreChannelQrCodeStatus,
-  LocalCoreLarkConnectionResult,
-  LocalCoreLarkGatewayStatus,
-  LocalCoreLarkQrCodeStatus,
-  LocalCorePairingRequest,
   ChannelFileSendInput,
   ChannelFileSendResult,
   ChannelOutboundMessageInput,
@@ -125,64 +120,6 @@ export class ChannelService {
       throw new Error(`Channel platform does not support QR setup: ${platform}`);
     }
     return runtime.checkQrCodeStatus(workspaceId, ticket, instanceId);
-  }
-
-  async getWeixinQrCode(workspaceId: string, instanceId?: string): Promise<LocalCoreChannelQrCode> {
-    return this.getQrCode('weixin', workspaceId, instanceId);
-  }
-
-  async checkWeixinQrCodeStatus(workspaceId: string, ticket: string, instanceId?: string): Promise<{
-    status: 'wait' | 'signed' | 'confirmed' | 'expired';
-    userName?: string;
-    userId?: string;
-  }> {
-    return this.checkQrCodeStatus('weixin', workspaceId, ticket, instanceId);
-  }
-
-  // Lark convenience wrappers
-
-  async listLarkStatuses(): Promise<LocalCoreLarkGatewayStatus[]> {
-    return this.listStatuses('lark') as Promise<LocalCoreLarkGatewayStatus[]>;
-  }
-
-  async getLarkStatus(workspaceId: string, instanceId?: string): Promise<LocalCoreLarkGatewayStatus> {
-    return this.getStatus('lark', workspaceId, instanceId) as Promise<LocalCoreLarkGatewayStatus>;
-  }
-
-  async testLarkConnection(workspaceId: string, instanceId?: string): Promise<LocalCoreLarkConnectionResult> {
-    return this.testConnection('lark', workspaceId, instanceId) as Promise<LocalCoreLarkConnectionResult>;
-  }
-
-  async enableLark(workspaceId: string, instanceId?: string): Promise<LocalCoreLarkGatewayStatus> {
-    return this.enable('lark', workspaceId, instanceId) as Promise<LocalCoreLarkGatewayStatus>;
-  }
-
-  async disableLark(workspaceId: string, instanceId?: string): Promise<LocalCoreLarkGatewayStatus> {
-    return this.disable('lark', workspaceId, instanceId) as Promise<LocalCoreLarkGatewayStatus>;
-  }
-
-  async listLarkPendingPairings(workspaceId?: string): Promise<LocalCorePairingRequest[]> {
-    return this.listPendingPairings('lark', workspaceId) as Promise<LocalCorePairingRequest[]>;
-  }
-
-  async approveLarkPairing(code: string): Promise<LocalCoreAuthorizedUser> {
-    return this.approvePairing('lark', code) as Promise<LocalCoreAuthorizedUser>;
-  }
-
-  async rejectLarkPairing(code: string) {
-    return this.rejectPairing('lark', code);
-  }
-
-  async listLarkAuthorizedUsers(workspaceId?: string): Promise<LocalCoreAuthorizedUser[]> {
-    return this.listAuthorizedUsers('lark', workspaceId) as Promise<LocalCoreAuthorizedUser[]>;
-  }
-
-  async getLarkQrCode(workspaceId: string, instanceId?: string): Promise<LocalCoreChannelQrCode> {
-    return this.getQrCode('lark', workspaceId, instanceId);
-  }
-
-  async checkLarkQrCodeStatus(workspaceId: string, ticket: string, instanceId?: string): Promise<LocalCoreLarkQrCodeStatus> {
-    return this.checkQrCodeStatus('lark', workspaceId, ticket, instanceId) as Promise<LocalCoreLarkQrCodeStatus>;
   }
 
   async refreshBindings() {


### PR DESCRIPTION
## Summary
- Removed 13 platform-specific convenience wrappers in `ChannelService` (11 Lark: `listLarkStatuses`, `getLarkStatus`, `testLarkConnection`, `enableLark`, `disableLark`, `listLarkPendingPairings`, `approveLarkPairing`, `rejectLarkPairing`, `listLarkAuthorizedUsers`, `getLarkQrCode`, `checkLarkQrCodeStatus`; 2 WeChat: `getWeixinQrCode`, `checkWeixinQrCodeStatus`).
- Also removed 5 now-unused type imports (`LocalCoreAuthorizedUser`, `LocalCoreLarkConnectionResult`, `LocalCoreLarkGatewayStatus`, `LocalCoreLarkQrCodeStatus`, `LocalCorePairingRequest`).
- Net: −63 lines.

## Category
**d — code quality (dead code).**

## Motivation
Verified via repo-wide grep that these wrappers have **zero callers** across `services/`, `tests/`, `electron/`, `src/`, `packages/`. The only consumer of `ChannelService` is `runtime/handlers/channel-handler.ts`, which uses exclusively the generic platform-parameterized methods (`listStatuses(platform)`, `getStatus(platform, ...)`, etc.) — the platform comes from the URL, not the method name. The SDK in `packages/core-sdk/src` has its own Lark-named functions that hit HTTP endpoints; they don't touch `ChannelService` directly.

Carrying these wrappers creates the false impression that adding a new channel requires a parallel `listXStatuses/getXStatus/...` family. Removing them makes the API surface match what's actually used.

## Test plan
- [x] `pnpm build:electron` — TypeScript compiles clean (no dangling references).
- [x] `pnpm test` — 317 pass, 1 fail. The failure (#141 `workspace route launches sandbox proxy when sandbox is enabled`) is pre-existing on `main` (verified earlier this week) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)