### PR TITLE
Raise ACP prompt timeout to 180 min and fix object-message log leak

### DIFF
--- a/services/local-ai-core/src/acp/local-core-acp-backend.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-backend.ts
@@ -24,7 +24,7 @@ import { routeFromPlatformThreadBinding } from '../scheduler/scheduled-job-route
 import { ThreadSlashCommandDispatcher } from '../thread/thread-slash-command-dispatcher.js';
 import { formatUserError, toLocalCoreErrorInfo } from '../kernel/local-core-errors.js';
 
-const ACP_PROMPT_TIMEOUT_MS = 15 * 60 * 1000;
+const ACP_PROMPT_TIMEOUT_MS = 180 * 60 * 1000;
 
 type SendThreadMessageOptions = {
   permissionMode?: string;

--- a/services/local-ai-core/src/kernel/local-core-errors.ts
+++ b/services/local-ai-core/src/kernel/local-core-errors.ts
@@ -144,13 +144,14 @@ const DEFAULTS: Record<LocalCoreErrorCode, ErrorDefaults> = {
 export class LocalCoreError extends Error {
   readonly info: LocalCoreErrorInfo;
 
-  constructor(code: LocalCoreErrorCode, message?: string, input: Partial<Omit<LocalCoreErrorInfo, 'code' | 'message'>> = {}) {
+  constructor(code: LocalCoreErrorCode, message?: unknown, input: Partial<Omit<LocalCoreErrorInfo, 'code' | 'message'>> = {}) {
     const defaults = DEFAULTS[code];
-    super(message || defaults.userMessage);
+    const messageStr = coerceErrorMessage(message) || defaults.userMessage;
+    super(messageStr);
     this.name = 'LocalCoreError';
     this.info = {
       code,
-      message: message || defaults.userMessage,
+      message: messageStr,
       userMessage: input.userMessage || defaults.userMessage,
       severity: input.severity || defaults.severity,
       retryable: input.retryable ?? defaults.retryable,
@@ -167,9 +168,9 @@ export function toLocalCoreErrorInfo(error: unknown, fallbackCode: LocalCoreErro
   }
   const maybeInfo = (error as { info?: LocalCoreErrorInfo } | null | undefined)?.info;
   if (maybeInfo?.code && maybeInfo.message) {
-    return mergeDetails(maybeInfo, details);
+    return mergeDetails(ensureInfoMessageString(maybeInfo), details);
   }
-  const message = error instanceof Error ? error.message : String(error || '');
+  const message = coerceErrorMessage(error instanceof Error ? error.message : error);
   const classifiedCode = classifyErrorMessage(message, fallbackCode);
   return new LocalCoreError(classifiedCode, message || DEFAULTS[classifiedCode].userMessage, {
     details: Object.keys(details).length ? details : undefined,
@@ -182,7 +183,8 @@ export function formatUserError(info: LocalCoreErrorInfo) {
 
 export function formatLogError(info: LocalCoreErrorInfo) {
   const suffix = info.cause ? ` cause=${info.cause}` : '';
-  return `${info.code}: ${info.message}${suffix}`;
+  const message = typeof info.message === 'string' ? info.message : safeStringify(info.message);
+  return `${info.code}: ${message}${suffix}`;
 }
 
 export function errorInfoToHttpBody(info: LocalCoreErrorInfo) {
@@ -268,4 +270,32 @@ function mergeDetails(info: LocalCoreErrorInfo, details: Record<string, unknown>
       ...details,
     },
   };
+}
+
+function ensureInfoMessageString(info: LocalCoreErrorInfo): LocalCoreErrorInfo {
+  if (typeof info.message === 'string') {
+    return info;
+  }
+  return { ...info, message: safeStringify(info.message) };
+}
+
+function coerceErrorMessage(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return safeStringify(value);
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }

--- a/tests/integration/local-core-errors.test.ts
+++ b/tests/integration/local-core-errors.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LocalCoreError,
+  formatLogError,
+  toLocalCoreErrorInfo,
+} from '../../services/local-ai-core/src/kernel/local-core-errors.js';
+
+test('LocalCoreError coerces non-string message into a string', () => {
+  const err = new LocalCoreError('internal_error', { weird: 'shape' } as unknown as string);
+  assert.equal(typeof err.info.message, 'string');
+  assert.equal(err.message, err.info.message);
+  assert.ok(err.info.message.includes('"weird"'));
+  const line = formatLogError(err.info);
+  assert.ok(!line.includes('[object Object]'), `log line leaked [object Object]: ${line}`);
+});
+
+test('toLocalCoreErrorInfo stringifies Error whose message is an object', () => {
+  const raw = new Error('' as unknown as string);
+  raw.message = { nested: 'value' } as unknown as string;
+  const info = toLocalCoreErrorInfo(raw);
+  assert.equal(typeof info.message, 'string');
+  const line = formatLogError(info);
+  assert.ok(!line.includes('[object Object]'), `log line leaked [object Object]: ${line}`);
+});
+
+test('toLocalCoreErrorInfo preserves runtime_protocol_timeout classification for timeout string', () => {
+  const info = toLocalCoreErrorInfo(new Error('Timed out waiting for ACP session/prompt after 900000ms'));
+  assert.equal(info.code, 'runtime_protocol_timeout');
+  assert.equal(typeof info.message, 'string');
+});
+
+test('formatLogError renders cause suffix when present', () => {
+  const err = new LocalCoreError('runtime_exited', 'child crashed', { cause: 'SIGTERM' });
+  const line = formatLogError(err.info);
+  assert.equal(line, 'runtime_exited: child crashed cause=SIGTERM');
+});
+
+test('toLocalCoreErrorInfo carries details through LocalCoreError instances', () => {
+  const base = new LocalCoreError('runtime_protocol_timeout', 'Timed out waiting for ACP session/prompt after 100ms');
+  const info = toLocalCoreErrorInfo(base, 'internal_error', { threadId: 'thread-x', runtimeId: 'hermes' });
+  assert.equal(info.code, 'runtime_protocol_timeout');
+  assert.equal(info.details?.threadId, 'thread-x');
+  assert.equal(info.details?.runtimeId, 'hermes');
+});


### PR DESCRIPTION
## Summary
- **Timeout bump**: `ACP_PROMPT_TIMEOUT_MS` 15 min → 180 min in `services/local-ai-core/src/acp/local-core-acp-backend.ts:27`. The 2am scheduled job was hitting the 15-minute `session/prompt` cap while the agent was still actively streaming, cutting the task off mid-stream.
- **Log bug fix**: the failure surfaced as `[acp.run] internal_error: [object Object]` because non-string `message` values slipped through `LocalCoreError` and `toLocalCoreErrorInfo` into `formatLogError`. Coerce messages to strings at every entry point (`LocalCoreError` ctor, `toLocalCoreErrorInfo`, `formatLogError`) so errors log with their real text.

## Test plan
- [x] `pnpm test` baseline: 325 pass / 0 fail
- [x] Added 5 regression tests in `tests/integration/local-core-errors.test.ts` covering: object message coercion, `Error.message` set to object, timeout-string classification preserved, `cause` suffix rendering, `details` carry-through
- [x] `pnpm test` after changes: **330 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)