### PR TITLE
[codex] Unify chat event refresh

### DIFF
--- a/src/api/desktop.ts
+++ b/src/api/desktop.ts
@@ -28,6 +28,7 @@ import type {
   InstalledAgentRuntime,
   WorkspaceStreamingProbeResult,
 } from '../../packages/contracts/src';
+export type { LocalCoreEvent } from '../../packages/contracts/src';
 import {
   approveChannelPairing as approveCoreChannelPairing,
   disableChannelGateway as disableCoreChannelGateway,
@@ -287,3 +288,4 @@ export const onRuntimeEvent = (listener: (runtime: DesktopRuntimeStatus) => void
 export const onRuntimeDetectionEvent = (listener: (event: LocalCoreEvent) => void) =>
   requireProvider().onRuntimeDetectionEvent(listener);
 export const onBridgeEvent = (listener: (event: DesktopBridgeEvent) => void) => requireProvider().onBridgeEvent(listener);
+export const onCoreEvent = (listener: (event: LocalCoreEvent) => void) => subscribeEvents(listener);

--- a/src/components/chat/chat-message-state.ts
+++ b/src/components/chat/chat-message-state.ts
@@ -1,0 +1,34 @@
+export interface ChatTranscriptMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp?: string;
+  kind?: 'final' | 'progress' | 'system';
+}
+
+export type ChatHistoryEntry = {
+  role: string;
+  content: string;
+  timestamp?: string;
+  kind?: string;
+};
+
+export function projectChatHistory(history: ChatHistoryEntry[] | undefined): ChatTranscriptMessage[] {
+  return (history || []).map((message, index) => ({
+    id: `${message.timestamp || index}-${message.role}-${index}`,
+    role: message.role === 'user' ? 'user' : 'assistant',
+    content: message.content,
+    timestamp: message.timestamp,
+    kind: message.kind === 'progress' || message.kind === 'system' ? message.kind : 'final',
+  }));
+}
+
+export function chatHistorySignature(history: ChatHistoryEntry[]) {
+  return history
+    .map((message) => `${message.role}:${message.kind || 'final'}:${message.timestamp || ''}:${message.content}`)
+    .join('\n');
+}
+
+export function assistantMessageCount(history: ChatHistoryEntry[]) {
+  return history.filter((message) => message.role !== 'user').length;
+}

--- a/src/components/chat/useSessionEventRefresh.ts
+++ b/src/components/chat/useSessionEventRefresh.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+import { onCoreEvent } from '@/api/desktop';
+import { shouldRefreshSessionForEvent, type ChatSessionIdentity } from '@/lib/session-chat-events';
+
+export function useSessionEventRefresh(
+  identity: ChatSessionIdentity,
+  refresh: () => Promise<unknown>,
+  enabled = true,
+) {
+  const identityRef = useRef(identity);
+  const refreshRef = useRef(refresh);
+  identityRef.current = identity;
+  refreshRef.current = refresh;
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    let refreshing = false;
+    let refreshQueued = false;
+    let disposed = false;
+
+    const runRefresh = async () => {
+      if (refreshing) {
+        refreshQueued = true;
+        return;
+      }
+      refreshing = true;
+      try {
+        do {
+          refreshQueued = false;
+          await refreshRef.current();
+        } while (!disposed && refreshQueued);
+      } catch {
+        // Event-driven refresh is opportunistic; the bounded polling fallback
+        // remains responsible for surfacing transport failures.
+      } finally {
+        refreshing = false;
+      }
+    };
+
+    const unsubscribe = onCoreEvent((event) => {
+      if (shouldRefreshSessionForEvent(event, identityRef.current)) {
+        void runRefresh();
+      }
+    });
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+}

--- a/src/lib/session-chat-events.ts
+++ b/src/lib/session-chat-events.ts
@@ -1,0 +1,39 @@
+import type { LocalCoreEvent } from '../api/desktop';
+
+export type ChatSessionIdentity = {
+  sessionId: string;
+  sessionKey?: string;
+  runId?: string;
+};
+
+function streamSessionKey(event: LocalCoreEvent) {
+  if ('stream' in event && event.stream) {
+    return event.stream.sessionKey || '';
+  }
+  return '';
+}
+
+export function shouldRefreshSessionForEvent(event: LocalCoreEvent, identity: ChatSessionIdentity) {
+  if (!identity.sessionId && !identity.sessionKey) {
+    return false;
+  }
+  if (event.type === 'run.updated') {
+    return event.run.threadId === identity.sessionId && (!identity.runId || event.run.id === identity.runId);
+  }
+  if (identity.sessionKey && streamSessionKey(event) === identity.sessionKey) {
+    return true;
+  }
+  switch (event.type) {
+    case 'thread.updated':
+      return event.thread.id === identity.sessionId;
+    case 'thread.session.activated':
+      return event.threadId === identity.sessionId;
+    case 'message.created':
+    case 'message.updated':
+      return event.threadId === identity.sessionId;
+    case 'presence.updated':
+      return event.threadId === identity.sessionId;
+    default:
+      return false;
+  }
+}

--- a/src/pages/Sessions/SessionChat.tsx
+++ b/src/pages/Sessions/SessionChat.tsx
@@ -6,6 +6,10 @@ import { Badge, Button, Textarea } from '@/components/ui';
 import { getSession, sendMessage, type SessionDetail } from '@/api/sessions';
 import { cn } from '@/lib/utils';
 import { ChatMarkdown } from '@/components/chat/ChatMarkdown';
+import { useSessionEventRefresh } from '@/components/chat/useSessionEventRefresh';
+import { api } from '@/api/client';
+import { LOCAL_AI_CORE_BASE } from '@/api/runtime-bootstrap';
+import { projectChatHistory } from '@/components/chat/chat-message-state';
 
 export default function SessionChat() {
   const { t } = useTranslation();
@@ -26,6 +30,13 @@ export default function SessionChat() {
       setLoading(false);
     }
   }, [project, id]);
+  const usesLocalCoreEvents = api.getBaseUrl().replace(/\/+$/, '') === LOCAL_AI_CORE_BASE;
+
+  useSessionEventRefresh(
+    { sessionId: id || '', sessionKey: session?.session_key },
+    fetchSession,
+    Boolean(project && id && usesLocalCoreEvents),
+  );
 
   useEffect(() => {
     fetchSession();
@@ -42,7 +53,9 @@ export default function SessionChat() {
     setSending(true);
     try {
       await sendMessage(project, { session_key: session.session_key, message: msg });
-      setTimeout(fetchSession, 1500);
+      if (!usesLocalCoreEvents) {
+        window.setTimeout(fetchSession, 1500);
+      }
     } finally {
       setSending(false);
     }
@@ -98,10 +111,10 @@ export default function SessionChat() {
           <p className="text-center text-sm text-muted-foreground py-12">{t('sessions.noMessages')}</p>
         )}
         <div className="mx-auto max-w-4xl space-y-5">
-          {session?.history?.map((msg, i) => {
+          {projectChatHistory(session?.history).map((msg) => {
             const isUser = msg.role === 'user';
             return (
-              <div key={i} className={cn('flex gap-3', isUser ? 'justify-end' : 'justify-start')}>
+              <div key={msg.id} className={cn('flex gap-3', isUser ? 'justify-end' : 'justify-start')}>
                 {!isUser && (
                   <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 dark:bg-white/[0.06]">
                     <Bot size={16} className="text-primary" />

--- a/src/pages/Threads/thread-chat-model.ts
+++ b/src/pages/Threads/thread-chat-model.ts
@@ -13,19 +13,16 @@ import {
   normalizeDesktopBridgeButtonOption,
 } from '../../../shared/desktop';
 import { sessionLabel } from '../../lib/session-utils';
+import type { ChatTranscriptMessage } from '../../components/chat/chat-message-state';
 
 export const ASSISTANT_REPLY_TIMEOUT_MS = 90000;
 
-export interface ChatMessage {
-  id: string;
-  role: 'user' | 'assistant' | 'system';
-  content: string;
+export interface ChatMessage extends ChatTranscriptMessage {
   toolCall?: DesktopBridgeToolCall;
-  kind?: 'final' | 'progress';
+  kind?: 'final' | 'progress' | 'system';
   bridgeKind?: DesktopBridgeEventKind;
   bridgeStatus?: DesktopBridgeStatus;
   order: number;
-  timestamp?: string;
   turnKey?: string;
   actions?: DesktopBridgeButtonOption[][];
   actionReplyCtx?: string;

--- a/src/pages/Web/Chat.tsx
+++ b/src/pages/Web/Chat.tsx
@@ -27,17 +27,18 @@ import {
 } from '@/api/sessions';
 import { sessionLabel, sessionMatchesSearch, sortSessionsByLiveAndUpdated, timeAgo } from '@/lib/session-utils';
 import { cn } from '@/lib/utils';
+import { useSessionEventRefresh } from '@/components/chat/useSessionEventRefresh';
+import { api } from '@/api/client';
+import { LOCAL_AI_CORE_BASE } from '@/api/runtime-bootstrap';
+import {
+  assistantMessageCount,
+  chatHistorySignature,
+  projectChatHistory,
+  type ChatTranscriptMessage,
+} from '@/components/chat/chat-message-state';
 
 const POLL_INTERVAL_MS = 1500;
 const POLL_TIMEOUT_MS = 90000;
-
-interface WebChatMessage {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  timestamp?: string;
-  kind?: string;
-}
 
 interface ActiveWebChatSession {
   id: string;
@@ -67,24 +68,6 @@ interface PollingContext {
 
 function isVirtualWebSession(sessionKey?: string) {
   return String(sessionKey || '').startsWith('web:');
-}
-
-function toMessages(history: SessionDetail['history'] | undefined): WebChatMessage[] {
-  return (history || []).map((message, index) => ({
-    id: `${message.timestamp || index}-${message.role}-${index}`,
-    role: message.role === 'user' ? 'user' : 'assistant',
-    content: message.content,
-    timestamp: message.timestamp,
-    kind: message.kind,
-  }));
-}
-
-function messageSignature(history: SessionDetail['history']) {
-  return history.map((message) => `${message.role}:${message.kind || 'final'}:${message.timestamp || ''}:${message.content}`).join('\n');
-}
-
-function assistantMessageCount(history: SessionDetail['history']) {
-  return history.filter((message) => message.role !== 'user').length;
 }
 
 function formatSessionPreview(session: Session, t: (key: string) => string) {
@@ -119,7 +102,7 @@ export default function WebChat() {
   const [selectedProject, setSelectedProject] = useState(searchParams.get('project') || '');
   const [sessions, setSessions] = useState<Session[]>([]);
   const [activeSession, setActiveSession] = useState<ActiveWebChatSession | null>(null);
-  const [messages, setMessages] = useState<WebChatMessage[]>([]);
+  const [messages, setMessages] = useState<ChatTranscriptMessage[]>([]);
   const [sessionSearch, setSessionSearch] = useState('');
   const [draft, setDraft] = useState('');
   const [loadingProjects, setLoadingProjects] = useState(true);
@@ -247,7 +230,7 @@ export default function WebChat() {
         isDraft: false,
         detail,
       });
-      setMessages(toMessages(detail.history));
+      setMessages(projectChatHistory(detail.history));
       setError('');
       return detail;
     } catch (loadError) {
@@ -261,6 +244,26 @@ export default function WebChat() {
       }
     }
   }, [syncSessionSummary, t]);
+
+  const refreshActiveSessionFromEvent = useCallback(async () => {
+    const { project, sessionId } = activeRef.current;
+    if (!project || !sessionId) {
+      return;
+    }
+    await Promise.all([
+      loadActiveSession(project, sessionId, { silent: true }),
+      refreshSessions(project),
+    ]);
+  }, [loadActiveSession, refreshSessions]);
+
+  useSessionEventRefresh(
+    {
+      sessionId: activeSession?.id || '',
+      sessionKey: activeSession?.sessionKey,
+    },
+    refreshActiveSessionFromEvent,
+    api.getBaseUrl().replace(/\/+$/, '') === LOCAL_AI_CORE_BASE,
+  );
 
   const schedulePoll = useCallback((context: PollingContext) => {
     pollContextRef.current = context;
@@ -287,7 +290,7 @@ export default function WebChat() {
         return;
       }
 
-      const signature = messageSignature(detail.history);
+      const signature = chatHistorySignature(detail.history);
       const hasAssistantReply = assistantMessageCount(detail.history) > currentContext.assistantCountBefore;
       const nextStableCount = hasAssistantReply && signature === currentContext.lastSignature
         ? currentContext.stableCount + 1
@@ -422,7 +425,7 @@ export default function WebChat() {
 
     const content = draft.trim();
     const optimisticMessageId = `${crypto.randomUUID()}-user`;
-    const optimisticMessage: WebChatMessage = {
+    const optimisticMessage: ChatTranscriptMessage = {
       id: optimisticMessageId,
       role: 'user',
       content,

--- a/tests/contracts/chat-message-state.test.ts
+++ b/tests/contracts/chat-message-state.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  assistantMessageCount,
+  chatHistorySignature,
+  projectChatHistory,
+} from '../../src/components/chat/chat-message-state.js';
+
+test('chat history projection provides a shared stable transcript shape', () => {
+  const history = [
+    { role: 'user', content: 'hello', timestamp: '2026-06-20T00:00:00Z' },
+    { role: 'assistant', content: 'working', kind: 'progress', timestamp: '2026-06-20T00:00:01Z' },
+  ];
+  const messages = projectChatHistory(history);
+
+  assert.deepEqual(messages.map(({ role, content, kind }) => ({ role, content, kind })), [
+    { role: 'user', content: 'hello', kind: 'final' },
+    { role: 'assistant', content: 'working', kind: 'progress' },
+  ]);
+  assert.equal(messages[0].id, '2026-06-20T00:00:00Z-user-0');
+  assert.equal(assistantMessageCount(history), 1);
+  assert.match(chatHistorySignature(history), /assistant:progress/);
+});

--- a/tests/contracts/session-chat-events.test.ts
+++ b/tests/contracts/session-chat-events.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { LocalCoreEvent } from '../../packages/contracts/src/index.js';
+import { shouldRefreshSessionForEvent } from '../../src/lib/session-chat-events.js';
+
+const identity = { sessionId: 'thread-1', sessionKey: 'workspace:thread-1', runId: 'run-2' };
+
+test('session event matcher accepts active thread messages and run updates', () => {
+  const message = {
+    type: 'message.created',
+    threadId: 'thread-1',
+    message: { id: 'm1', role: 'assistant', content: 'done', timestamp: '2026-06-20T00:00:00Z' },
+  } satisfies LocalCoreEvent;
+  const run = {
+    type: 'run.updated',
+    run: { id: 'run-2', threadId: 'thread-1', status: 'completed', startedAt: '', updatedAt: '' },
+  } satisfies LocalCoreEvent;
+
+  assert.equal(shouldRefreshSessionForEvent(message, identity), true);
+  assert.equal(shouldRefreshSessionForEvent(run, identity), true);
+});
+
+test('session event matcher rejects unrelated threads and superseded runs', () => {
+  const unrelated = {
+    type: 'thread.updated',
+    thread: { id: 'thread-2', workspaceId: 'workspace', title: '', live: true, updatedAt: '', createdAt: '', historyCount: 0, excerpt: '' },
+  } satisfies LocalCoreEvent;
+  const staleRun = {
+    type: 'run.updated',
+    run: { id: 'run-1', threadId: 'thread-1', status: 'completed', startedAt: '', updatedAt: '' },
+    stream: { type: 'reply', sessionKey: 'workspace:thread-1', content: 'stale' },
+  } satisfies LocalCoreEvent;
+
+  assert.equal(shouldRefreshSessionForEvent(unrelated, identity), false);
+  assert.equal(shouldRefreshSessionForEvent(staleRun, identity), false);
+});
+
+test('session event matcher accepts bridge events by session key', () => {
+  const event = {
+    type: 'stream.updated',
+    stream: { type: 'update_message', sessionKey: 'workspace:thread-1', content: 'working' },
+  } satisfies LocalCoreEvent;
+
+  assert.equal(shouldRefreshSessionForEvent(event, identity), true);
+});

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -19,6 +19,8 @@
     "services/**/*.ts",
     "src/pages/Threads/thread-chat-message-blocks.ts",
     "src/pages/Threads/thread-chat-permission.ts",
-    "src/pages/Threads/thread-chat-permission.test.ts"
+    "src/pages/Threads/thread-chat-permission.test.ts",
+    "src/lib/session-chat-events.ts",
+    "src/components/chat/chat-message-state.ts"
   ]
 }


### PR DESCRIPTION
## What changed
- share a canonical transcript message projection across chat surfaces
- refresh Web and Session chat from Local AI Core events
- keep bounded polling as the remote transport fallback
- reject unrelated and superseded run events

## Why
The chat surfaces maintained separate message projection and refresh behavior. This makes Local Core sessions event-driven while preserving remote compatibility.

## Validation
- pnpm test (337 passed)
- focused chat event and transcript contract tests