### PR TITLE
[codex] Split channel gateway state

### DIFF
--- a/services/local-ai-core/src/channel/lark/gateway-utils.ts
+++ b/services/local-ai-core/src/channel/lark/gateway-utils.ts
@@ -1,0 +1,80 @@
+import type { ChannelInboundContentPart } from '../../../../../packages/contracts/src/index.js';
+
+export function summarizeLarkInboundContentParts(parts: ChannelInboundContentPart[]) {
+  const text = parts
+    .filter((part): part is Extract<ChannelInboundContentPart, { type: 'text' }> => part.type === 'text')
+    .map((part) => part.text)
+    .filter(Boolean)
+    .join('\n\n')
+    .trim();
+  if (text) return text;
+  return parts
+    .map((part) => part.type === 'image'
+      ? '[Image]'
+      : part.type === 'file'
+        ? part.fileName ? `[File: ${part.fileName}]` : '[File]'
+        : '')
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function extractLarkHeaderMimeType(headers: unknown) {
+  const value = headers && typeof headers === 'object'
+    ? (headers as Record<string, unknown>)['content-type'] || (headers as Record<string, unknown>)['Content-Type']
+    : '';
+  return String(value || '').split(';')[0]?.trim() || '';
+}
+
+export function sniffLarkImageMimeType(buffer: Buffer) {
+  if (buffer[0] === 0xff && buffer[1] === 0xd8) return 'image/jpeg';
+  if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) return 'image/png';
+  if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) return 'image/gif';
+  if (buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46) return 'image/webp';
+  return 'application/octet-stream';
+}
+
+export function sniffLarkImageExtension(buffer: Buffer) {
+  const mimeType = sniffLarkImageMimeType(buffer);
+  if (mimeType === 'image/jpeg') return 'jpg';
+  if (mimeType === 'image/png') return 'png';
+  if (mimeType === 'image/gif') return 'gif';
+  if (mimeType === 'image/webp') return 'webp';
+  return 'bin';
+}
+
+function summarizeWsArgs(args: unknown[]) {
+  if (args.length === 0) return 'no-args';
+  return args.map((arg) => {
+    if (arg instanceof Error) return `${arg.name}: ${arg.message}`;
+    if (typeof arg === 'string') return arg.slice(0, 200);
+    if (arg && typeof arg === 'object') return JSON.stringify(Object.keys(arg as Record<string, unknown>));
+    return String(arg);
+  }).join(' ');
+}
+
+export function attachLarkWsDiagnostics(
+  workspaceId: string,
+  wsClient: any,
+  log?: (message: string) => void,
+) {
+  const on = typeof wsClient?.on === 'function' ? wsClient.on.bind(wsClient) : null;
+  if (!on) {
+    log?.(`localcore-lark ws diagnostics unavailable for ${workspaceId}: client has no on()`);
+    return;
+  }
+  for (const eventName of ['open', 'connect', 'connected', 'ready', 'close', 'closed', 'disconnect', 'error', 'reconnect']) {
+    try {
+      on(eventName, (...args: unknown[]) => {
+        log?.(`localcore-lark ws event ${eventName} for ${workspaceId}: ${summarizeWsArgs(args)}`);
+      });
+    } catch (error) {
+      log?.(`localcore-lark ws diagnostic hook failed for ${workspaceId} event=${eventName}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
+
+export function maskLarkAppId(appId: string) {
+  const value = String(appId || '').trim();
+  if (value.length <= 8) return value ? '***' : '';
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}

--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -71,6 +71,14 @@ import type {
 } from './types.js';
 import type { SessionCommandAction, SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
+import {
+  attachLarkWsDiagnostics,
+  extractLarkHeaderMimeType,
+  maskLarkAppId,
+  sniffLarkImageExtension,
+  sniffLarkImageMimeType,
+  summarizeLarkInboundContentParts,
+} from './gateway-utils.js';
 
 const PAIRING_EXPIRY_MS = 10 * 60 * 1000;
 const LARK_MAX_UPLOAD_FILE_SIZE = 30 * 1024 * 1024;
@@ -688,7 +696,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     this.runtime.set(key, status);
     this.notifyRuntimeStateChanged();
     try {
-      this.options.log?.(`localcore-lark starting workspace=${binding.workspaceId} app=${this.maskLarkAppId(binding.appId)} cardActions=${binding.cardActionsEnabled}`);
+      this.options.log?.(`localcore-lark starting workspace=${binding.workspaceId} app=${maskLarkAppId(binding.appId)} cardActions=${binding.cardActionsEnabled}`);
       const mod = await this.getLarkModule();
       status.client = new mod.Client({
         appId: binding.appId,
@@ -710,7 +718,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
       });
       status.eventDispatcher.register({
         'im.message.receive_v1': async (data: Record<string, unknown>) => {
-          this.options.log?.(`localcore-lark received im.message.receive_v1 for ${binding.workspaceId}/${binding.instanceId}: ${this.summarizeLarkEvent(data)}`);
+          this.options.log?.(`localcore-lark received im.message.receive_v1 for ${binding.workspaceId}/${binding.instanceId}: ${summarizeLarkInboundPayload(data)}`);
           void this.handleMessageEvent(binding.workspaceId, binding.instanceId, binding.platformKey, data).catch((error) => {
             this.options.log?.(`localcore-lark inbound message failed for ${binding.workspaceId}: ${error instanceof Error ? error.message : String(error)}`);
           });
@@ -729,7 +737,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
         domain: mod.Domain.Feishu,
         loggerLevel: mod.LoggerLevel.info,
       });
-      this.attachWsDiagnostics(binding.workspaceId, status.wsClient);
+      attachLarkWsDiagnostics(binding.workspaceId, status.wsClient, this.options.log);
       this.options.log?.(`localcore-lark ws starting for ${binding.workspaceId}`);
       await status.wsClient.start({
         eventDispatcher: status.eventDispatcher,
@@ -841,7 +849,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
       this.options.log?.(`localcore-lark ignored unsupported message for ${workspaceId}: type=${String(message.message_type || 'unknown')} contentKeys=${JSON.stringify(Object.keys(parsedContent))}`);
       return;
     }
-    const displayText = text || this.summarizeInboundContentParts(contentParts);
+    const displayText = text || summarizeLarkInboundContentParts(contentParts);
     this.options.log?.(`localcore-lark inbound message for ${workspaceId}: chat=${chatId} user=${platformUserId} chatType=${chatType || 'unknown'} mentions=${mentions.length} type=${messageType || 'unknown'} text=${JSON.stringify(displayText.slice(0, 120))}`);
     await this.handleInboundMessage({
       workspaceId,
@@ -871,7 +879,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
       displayFileName: imageKey,
       maxBytes: LARK_MAX_UPLOAD_FILE_SIZE,
       includeBase64: true,
-      finalizeStoredFileName: ({ storedFileName, prefix }) => `${storedFileName}.${this.sniffImageExtension(prefix)}`,
+      finalizeStoredFileName: ({ storedFileName, prefix }) => `${storedFileName}.${sniffLarkImageExtension(prefix)}`,
       source: {
         open: async () => {
           const resource = await state.client.im.messageResource.get({
@@ -889,7 +897,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
           }
           return {
             stream,
-            mimeType: this.extractHeaderMimeType(resource?.headers),
+            mimeType: extractLarkHeaderMimeType(resource?.headers),
           };
         },
       },
@@ -900,7 +908,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
       type: 'image',
       data: stored.data || '',
       ...(uri ? { uri } : {}),
-      mimeType: stored.mimeType || this.sniffImageMimeType(stored.prefix),
+      mimeType: stored.mimeType || sniffLarkImageMimeType(stored.prefix),
       fileName: `${imageKey}.${extension}`,
     };
   }
@@ -937,7 +945,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
           }
           return {
             stream,
-            mimeType: this.extractHeaderMimeType(resource?.headers) || 'application/octet-stream',
+            mimeType: extractLarkHeaderMimeType(resource?.headers) || 'application/octet-stream',
           };
         },
       },
@@ -986,74 +994,6 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     });
   }
 
-  private summarizeInboundContentParts(parts: ChannelInboundContentPart[]) {
-    const text = parts
-      .filter((part): part is Extract<ChannelInboundContentPart, { type: 'text' }> => part.type === 'text')
-      .map((part) => part.text)
-      .filter(Boolean)
-      .join('\n\n')
-      .trim();
-    if (text) return text;
-    const attachmentSummary = parts
-      .map((part) => {
-        if (part.type === 'image') {
-          return '[Image]';
-        }
-        if (part.type === 'file') {
-          return part.fileName ? `[File: ${part.fileName}]` : '[File]';
-        }
-        return '';
-      })
-      .filter(Boolean)
-      .join('\n');
-    return attachmentSummary;
-  }
-
-  private extractHeaderMimeType(headers: unknown) {
-    const value = headers && typeof headers === 'object'
-      ? (headers as Record<string, unknown>)['content-type'] || (headers as Record<string, unknown>)['Content-Type']
-      : '';
-    return String(value || '').split(';')[0]?.trim() || '';
-  }
-
-  private sniffImageMimeType(buffer: Buffer) {
-    if (buffer[0] === 0xff && buffer[1] === 0xd8) return 'image/jpeg';
-    if (buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) return 'image/png';
-    if (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) return 'image/gif';
-    if (buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46) return 'image/webp';
-    return 'application/octet-stream';
-  }
-
-  private sniffImageExtension(buffer: Buffer) {
-    const mimeType = this.sniffImageMimeType(buffer);
-    if (mimeType === 'image/jpeg') return 'jpg';
-    if (mimeType === 'image/png') return 'png';
-    if (mimeType === 'image/gif') return 'gif';
-    if (mimeType === 'image/webp') return 'webp';
-    return 'bin';
-  }
-
-  private attachWsDiagnostics(workspaceId: string, wsClient: any) {
-    const on = typeof wsClient?.on === 'function' ? wsClient.on.bind(wsClient) : null;
-    if (!on) {
-      this.options.log?.(`localcore-lark ws diagnostics unavailable for ${workspaceId}: client has no on()`);
-      return;
-    }
-    for (const eventName of ['open', 'connect', 'connected', 'ready', 'close', 'closed', 'disconnect', 'error', 'reconnect']) {
-      try {
-        on(eventName, (...args: unknown[]) => {
-          this.options.log?.(`localcore-lark ws event ${eventName} for ${workspaceId}: ${this.summarizeWsArgs(args)}`);
-        });
-      } catch (error) {
-        this.options.log?.(`localcore-lark ws diagnostic hook failed for ${workspaceId} event=${eventName}: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    }
-  }
-
-  private summarizeLarkEvent(data: Record<string, unknown>) {
-    return summarizeLarkInboundPayload(data);
-  }
-
   private async fetchBotOpenId(state: LarkRuntimeState) {
     const response = await state.client.request({
       url: '/open-apis/bot/v3/info',
@@ -1065,32 +1005,6 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
       throw new Error('Lark bot info response did not include bot.open_id');
     }
     return openId;
-  }
-
-  private summarizeWsArgs(args: unknown[]) {
-    if (args.length === 0) {
-      return 'no-args';
-    }
-    return args.map((arg) => {
-      if (arg instanceof Error) {
-        return `${arg.name}: ${arg.message}`;
-      }
-      if (typeof arg === 'string') {
-        return arg.slice(0, 200);
-      }
-      if (arg && typeof arg === 'object') {
-        return JSON.stringify(Object.keys(arg as Record<string, unknown>));
-      }
-      return String(arg);
-    }).join(' ');
-  }
-
-  private maskLarkAppId(appId: string) {
-    const value = String(appId || '').trim();
-    if (value.length <= 8) {
-      return value ? '***' : '';
-    }
-    return `${value.slice(0, 6)}...${value.slice(-4)}`;
   }
 
   protected makeThreadRoute(input: ChannelSessionCommandInput, threadId: string): LarkThreadRoute {

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -64,6 +64,21 @@ import type {
   WeixinTurnState,
   WeixinWorkspaceBinding,
 } from './types.js';
+import {
+  consumeWeixinBridgeEvent,
+  createWeixinTurnState,
+  getOrCreateWeixinTurnState,
+  isTerminalWeixinBridgeMessage,
+  renderWeixinTurnText,
+} from './runtime-state.js';
+import {
+  formatWeixinError,
+  splitTextByUtf8Bytes,
+  stripWeixinHtml,
+  truncateTextByUtf8Bytes,
+  utf8ByteLength,
+  waitForWeixinRetry,
+} from './text-utils.js';
 
 // ==================== Constants ====================
 
@@ -82,79 +97,6 @@ const WEIXIN_MAX_UPLOAD_FILE_SIZE = 30 * 1024 * 1024;
 const ERROR_LOG_WINDOW_MS = 5 * 60 * 1000;
 
 // ==================== Utilities ====================
-
-function stripHtml(html: string): string {
-  let result = html;
-  let prev: string;
-  do {
-    prev = result;
-    result = result.replace(/<[^>]*>/g, '');
-  } while (result !== prev);
-  return result.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ');
-}
-
-function formatError(err: unknown): string {
-  if (err instanceof Error) {
-    const cause = (err as Error & { cause?: unknown }).cause;
-    return cause !== undefined ? `${err.message}: ${String(cause)}` : err.message;
-  }
-  return String(err);
-}
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const t = setTimeout(resolve, ms);
-    const onAbort = () => { clearTimeout(t); reject(new Error('aborted')); };
-    signal?.addEventListener('abort', onAbort, { once: true });
-  });
-}
-
-function utf8ByteLength(value: string): number {
-  return Buffer.byteLength(value, 'utf-8');
-}
-
-function splitTextByUtf8Bytes(text: string, maxBytes: number): string[] {
-  const normalized = String(text || '').replace(/\r\n/g, '\n').trim();
-  if (!normalized) return [];
-  if (utf8ByteLength(normalized) <= maxBytes) return [normalized];
-
-  const chunks: string[] = [];
-  let current = '';
-  const pushCurrent = () => {
-    const trimmed = current.trim();
-    if (trimmed) chunks.push(trimmed);
-    current = '';
-  };
-  const appendPart = (part: string) => {
-    if (!part.trim()) return;
-    const separator = current ? '\n\n' : '';
-    if (current && utf8ByteLength(`${current}${separator}${part}`) <= maxBytes) {
-      current = `${current}${separator}${part}`;
-      return;
-    }
-    if (current) pushCurrent();
-    if (utf8ByteLength(part) <= maxBytes) {
-      current = part;
-      return;
-    }
-
-    let segment = '';
-    for (const char of Array.from(part)) {
-      if (segment && utf8ByteLength(`${segment}${char}`) > maxBytes) {
-        chunks.push(segment);
-        segment = '';
-      }
-      segment += char;
-    }
-    current = segment;
-  };
-
-  for (const part of normalized.split(/\n{2,}/)) {
-    appendPart(part);
-  }
-  pushCurrent();
-  return chunks;
-}
 
 export type WeixinDownloadedMedia = {
   path: string;
@@ -181,31 +123,6 @@ export function createWeixinAttachmentContentPart(att: WeixinDownloadedMedia): C
     path: att.path,
     fileName: att.name,
   };
-}
-
-function truncateTextByUtf8Bytes(text: string, maxBytes: number): string {
-  const normalized = String(text || '').replace(/\r\n/g, '\n').trim();
-  if (utf8ByteLength(normalized) <= maxBytes) return normalized;
-
-  const suffix = '\n\n（内容过长，已截断以保证微信送达）';
-  const budget = Math.max(0, maxBytes - utf8ByteLength(suffix));
-  let result = '';
-  for (const char of Array.from(normalized)) {
-    if (utf8ByteLength(`${result}${char}`) > budget) break;
-    result += char;
-  }
-  return `${result.trim()}${suffix}`;
-}
-
-function renderBridgeContentForWeixin(event: DesktopBridgeEvent): string {
-  const toolCall = event.toolCall;
-  if (!toolCall) {
-    return String(event.content || '').trim();
-  }
-  const name = String(toolCall.name || '').trim() || 'Tool update';
-  const status = String(toolCall.status || '').trim();
-  if (name === 'Tool update' && status === 'completed') return '';
-  return [name, status].filter(Boolean).join(' - ');
 }
 
 // ==================== Gateway Class ====================
@@ -427,17 +344,17 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
         const bridgeThreadId = route.threadId || binding.thread_id;
         if (this.mutedThreadBridgeCounts.has(bridgeThreadId)) return;
 
-        const turn = this.getOrCreateTurnState(sessionKey);
+        const turn = getOrCreateWeixinTurnState(this.outboundTurns, sessionKey);
         if (event.replyCtx) {
           // WeChat doesn't support reply context; ignore
         }
-        this.consumeBridgeEvent(turn, event);
+        consumeWeixinBridgeEvent(turn, event);
         if (event.type !== 'reply' && event.type !== 'buttons' && event.type !== 'status') return;
 
-        const rendered = this.renderTurnText(turn);
+        const rendered = renderWeixinTurnText(turn);
         if (!rendered) return;
         if (rendered === turn.lastSentText) return;
-        const terminalMessage = this.isTerminalBridgeMessage(event, rendered);
+        const terminalMessage = isTerminalWeixinBridgeMessage(event, rendered);
         if (binding.last_platform_message_id && !terminalMessage && turn.sentCount >= WEIXIN_PROGRESS_SEND_BUDGET) {
           turn.foldedProgressCount += 1;
           this.options.log?.(`localcore-weixin folded progress for sessionKey=${sessionKey}: sent=${turn.sentCount} folded=${turn.foldedProgressCount}`);
@@ -458,7 +375,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
           turn.lastSentText = rendered;
           this.options.log?.(`localcore-weixin sent message for sessionKey=${sessionKey} type=${event.type} sent=${turn.sentCount}/${binding.last_platform_message_id ? WEIXIN_CONTEXT_SEND_LIMIT : 'unlimited'}`);
         } catch (error) {
-          this.options.log?.(`localcore-weixin send failed for sessionKey=${sessionKey}: ${formatError(error)}`);
+          this.options.log?.(`localcore-weixin send failed for sessionKey=${sessionKey}: ${formatWeixinError(error)}`);
         }
       })
       .finally(() => {
@@ -492,7 +409,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     const previousRoute = this.threadRouting.get(input.sessionKey);
     this.threadRouting.set(input.sessionKey, route);
     if (!this.outboundTurns.has(input.sessionKey)) {
-      this.createTurnState(input.sessionKey);
+      this.outboundTurns.set(input.sessionKey, createWeixinTurnState(input.sessionKey));
     }
     return () => {
       if (previousRoute) {
@@ -842,7 +759,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
             state.consecutiveFailures = consecutiveFailures;
             state.nextRetryAt = new Date(Date.now() + retryDelayMs).toISOString();
           }
-          await sleep(retryDelayMs, signal);
+          await waitForWeixinRetry(retryDelayMs, signal);
           if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
             consecutiveFailures = MAX_CONSECUTIVE_FAILURES;
           }
@@ -901,7 +818,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
                   if (part) attachmentParts.push(part);
                 }
               } catch (dlErr) {
-                this.options.log?.(`localcore-weixin attachment download failed (${conversationId}#${idx}): ${formatError(dlErr)}`);
+                this.options.log?.(`localcore-weixin attachment download failed (${conversationId}#${idx}): ${formatWeixinError(dlErr)}`);
               }
             }
           }
@@ -938,10 +855,10 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
         }
         this.logPollError(
           binding,
-          formatError(err),
-          `localcore-weixin getUpdates error for ${binding.workspaceId} (${consecutiveFailures}): ${formatError(err)}`,
+          formatWeixinError(err),
+          `localcore-weixin getUpdates error for ${binding.workspaceId} (${consecutiveFailures}): ${formatWeixinError(err)}`,
         );
-        await sleep(retryDelayMs, signal);
+        await waitForWeixinRetry(retryDelayMs, signal);
       }
     }
   }
@@ -956,7 +873,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     options: { clientId?: string; final?: boolean } = {},
   ): Promise<void> {
     const binding = await this.getBinding(state.workspaceId);
-    const stripped = stripHtml(text);
+    const stripped = stripWeixinHtml(text);
     const chunks = contextToken
       ? [truncateTextByUtf8Bytes(stripped, WEIXIN_CONTEXT_REPLY_MAX_BYTES)].filter(Boolean)
       : splitTextByUtf8Bytes(stripped, WEIXIN_TEXT_MESSAGE_MAX_BYTES);
@@ -1159,148 +1076,6 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     if (ext === '.png') return 'image/png';
     if (ext === '.gif') return 'image/gif';
     return 'application/octet-stream';
-  }
-
-  // ==================== Private: Turn State ====================
-
-  private createTurnState(sessionKey: string): WeixinTurnState {
-    const turn: WeixinTurnState = {
-      sessionKey,
-      sentCount: 0,
-      foldedProgressCount: 0,
-      awaitingPermission: false,
-      processing: false,
-      previewText: '',
-      finalText: '',
-      thinkingSteps: [],
-      pendingThoughtText: undefined,
-      statusLines: [],
-      buttonRows: [],
-      lastSentAt: 0,
-      lastSentText: '',
-    };
-    this.outboundTurns.set(sessionKey, turn);
-    return turn;
-  }
-
-  private getOrCreateTurnState(sessionKey: string): WeixinTurnState {
-    return this.outboundTurns.get(sessionKey) || this.createTurnState(sessionKey);
-  }
-
-  private consumeBridgeEvent(turn: WeixinTurnState, event: DesktopBridgeEvent) {
-    const content = renderBridgeContentForWeixin(event);
-    const bridgeKind = this.resolveBridgeEventKind(event);
-    if (event.type === 'typing_start') {
-      turn.processing = true;
-      turn.previewText = '';
-      turn.finalText = '';
-      turn.thinkingSteps = [];
-      turn.pendingThoughtText = undefined;
-      turn.statusLines = [];
-      turn.buttonRows = [];
-      return;
-    }
-    if (event.type === 'typing_stop') {
-      turn.processing = false;
-      return;
-    }
-    if (event.type === 'preview_start' || event.type === 'update_message') {
-      if (bridgeKind === 'thought') {
-        turn.pendingThoughtText = content;
-        return;
-      }
-      turn.previewText = content;
-      return;
-    }
-    if (bridgeKind !== 'thought') {
-      this.flushPendingThought(turn);
-    }
-    if (event.type === 'status') {
-      if (content) {
-        this.pushUnique(turn.statusLines, content);
-        turn.finalText = content;
-        turn.previewText = content;
-      }
-      return;
-    }
-    if (event.type === 'buttons') {
-      turn.awaitingPermission = true;
-      turn.buttonRows = Array.isArray(event.buttonRows)
-        ? event.buttonRows
-            .map((row) =>
-              Array.isArray(row)
-                ? row.filter((b): b is { text: string; data: string } => Boolean(b?.text && b?.data))
-                    .map((b) => ({ text: b.text, data: b.data }))
-                : [])
-            .filter((row) => row.length > 0)
-        : [];
-      return;
-    }
-    if (!content) return;
-    if (bridgeKind === 'thought' || bridgeKind === 'plan') {
-      this.pushUnique(turn.thinkingSteps, content);
-      return;
-    }
-    if (bridgeKind === 'tool' || bridgeKind === 'status') {
-      this.pushUnique(turn.statusLines, content);
-      return;
-    }
-    turn.finalText = content;
-    turn.previewText = content;
-  }
-
-  private renderTurnText(turn: WeixinTurnState): string {
-    const sections: string[] = [];
-    if (turn.thinkingSteps.length > 0) {
-      sections.push(`**中间过程**\n${turn.thinkingSteps.map((step) => `• ${step.replace(/\s+/g, ' ').trim()}`).join('\n')}`);
-    }
-    if (turn.finalText) {
-      sections.push(turn.finalText);
-    } else if (turn.previewText) {
-      sections.push(turn.previewText);
-    } else if (turn.statusLines.length > 0) {
-      sections.push(`**处理中**\n${turn.statusLines.slice(-3).map((l) => `• ${l.replace(/\s+/g, ' ').trim()}`).join('\n')}`);
-    } else if (turn.processing) {
-      sections.push('**处理中**\n正在思考...');
-    }
-    if (turn.awaitingPermission) {
-      sections.push('\n回复：`allow` / `allow all` / `deny`');
-    }
-    return sections.join('\n\n').trim();
-  }
-
-  private flushPendingThought(turn: WeixinTurnState) {
-    const text = String(turn.pendingThoughtText || '').trim();
-    if (!text) return;
-    this.pushUnique(turn.thinkingSteps, text);
-    turn.pendingThoughtText = undefined;
-  }
-
-  private isTerminalBridgeMessage(event: DesktopBridgeEvent, rendered: string): boolean {
-    if (event.type === 'buttons') return true;
-    if (event.type !== 'reply') return false;
-    const bridgeKind = this.resolveBridgeEventKind(event);
-    if (bridgeKind === 'tool' || bridgeKind === 'thought' || bridgeKind === 'plan' || bridgeKind === 'status') return false;
-    const normalized = rendered.trim();
-    if (!normalized) return false;
-    return true;
-  }
-
-  private resolveBridgeEventKind(event: DesktopBridgeEvent) {
-    if (event.bridgeKind) {
-      return event.bridgeKind;
-    }
-    return event.type === 'status' ? 'status' : 'assistant';
-  }
-
-  // ==================== Private: Helpers ====================
-
-  private pushUnique(target: string[], value: string) {
-    const normalized = value.trim();
-    if (!normalized) return;
-    if (target[target.length - 1] === normalized) return;
-    target.push(normalized);
-    if (target.length > 8) target.splice(0, target.length - 8);
   }
 
   private isDuplicateInboundMessage(input: WeixinInboundMessage): boolean {

--- a/services/local-ai-core/src/channel/weixin/runtime-state.ts
+++ b/services/local-ai-core/src/channel/weixin/runtime-state.ts
@@ -1,0 +1,144 @@
+import type { DesktopBridgeEvent } from '../../../../../packages/contracts/src/index.js';
+import type { WeixinTurnState } from './types.js';
+
+function renderBridgeContent(event: DesktopBridgeEvent): string {
+  const toolCall = event.toolCall;
+  if (!toolCall) {
+    return String(event.content || '').trim();
+  }
+  const name = String(toolCall.name || '').trim() || 'Tool update';
+  const status = String(toolCall.status || '').trim();
+  if (name === 'Tool update' && status === 'completed') return '';
+  return [name, status].filter(Boolean).join(' - ');
+}
+
+function bridgeEventKind(event: DesktopBridgeEvent) {
+  return event.bridgeKind || (event.type === 'status' ? 'status' : 'assistant');
+}
+
+function pushUnique(target: string[], value: string) {
+  const normalized = value.trim();
+  if (!normalized || target[target.length - 1] === normalized) return;
+  target.push(normalized);
+  if (target.length > 8) target.splice(0, target.length - 8);
+}
+
+function flushPendingThought(turn: WeixinTurnState) {
+  const text = String(turn.pendingThoughtText || '').trim();
+  if (!text) return;
+  pushUnique(turn.thinkingSteps, text);
+  turn.pendingThoughtText = undefined;
+}
+
+export function createWeixinTurnState(sessionKey: string): WeixinTurnState {
+  return {
+    sessionKey,
+    sentCount: 0,
+    foldedProgressCount: 0,
+    awaitingPermission: false,
+    processing: false,
+    previewText: '',
+    finalText: '',
+    thinkingSteps: [],
+    pendingThoughtText: undefined,
+    statusLines: [],
+    buttonRows: [],
+    lastSentAt: 0,
+    lastSentText: '',
+  };
+}
+
+export function getOrCreateWeixinTurnState(turns: Map<string, WeixinTurnState>, sessionKey: string) {
+  const existing = turns.get(sessionKey);
+  if (existing) return existing;
+  const turn = createWeixinTurnState(sessionKey);
+  turns.set(sessionKey, turn);
+  return turn;
+}
+
+export function consumeWeixinBridgeEvent(turn: WeixinTurnState, event: DesktopBridgeEvent) {
+  const content = renderBridgeContent(event);
+  const bridgeKind = bridgeEventKind(event);
+  if (event.type === 'typing_start') {
+    Object.assign(turn, {
+      processing: true,
+      previewText: '',
+      finalText: '',
+      thinkingSteps: [],
+      pendingThoughtText: undefined,
+      statusLines: [],
+      buttonRows: [],
+    });
+    return;
+  }
+  if (event.type === 'typing_stop') {
+    turn.processing = false;
+    return;
+  }
+  if (event.type === 'preview_start' || event.type === 'update_message') {
+    if (bridgeKind === 'thought') {
+      turn.pendingThoughtText = content;
+    } else {
+      turn.previewText = content;
+    }
+    return;
+  }
+  if (bridgeKind !== 'thought') flushPendingThought(turn);
+  if (event.type === 'status') {
+    if (content) {
+      pushUnique(turn.statusLines, content);
+      turn.finalText = content;
+      turn.previewText = content;
+    }
+    return;
+  }
+  if (event.type === 'buttons') {
+    turn.awaitingPermission = true;
+    turn.buttonRows = Array.isArray(event.buttonRows)
+      ? event.buttonRows
+          .map((row) => Array.isArray(row)
+            ? row.filter((button): button is { text: string; data: string } => Boolean(button?.text && button?.data))
+                .map((button) => ({ text: button.text, data: button.data }))
+            : [])
+          .filter((row) => row.length > 0)
+      : [];
+    return;
+  }
+  if (!content) return;
+  if (bridgeKind === 'thought' || bridgeKind === 'plan') {
+    pushUnique(turn.thinkingSteps, content);
+  } else if (bridgeKind === 'tool' || bridgeKind === 'status') {
+    pushUnique(turn.statusLines, content);
+  } else {
+    turn.finalText = content;
+    turn.previewText = content;
+  }
+}
+
+export function renderWeixinTurnText(turn: WeixinTurnState): string {
+  const sections: string[] = [];
+  if (turn.thinkingSteps.length > 0) {
+    sections.push(`**中间过程**\n${turn.thinkingSteps.map((step) => `• ${step.replace(/\s+/g, ' ').trim()}`).join('\n')}`);
+  }
+  if (turn.finalText) {
+    sections.push(turn.finalText);
+  } else if (turn.previewText) {
+    sections.push(turn.previewText);
+  } else if (turn.statusLines.length > 0) {
+    sections.push(`**处理中**\n${turn.statusLines.slice(-3).map((line) => `• ${line.replace(/\s+/g, ' ').trim()}`).join('\n')}`);
+  } else if (turn.processing) {
+    sections.push('**处理中**\n正在思考...');
+  }
+  if (turn.awaitingPermission) {
+    sections.push('\n回复：`allow` / `allow all` / `deny`');
+  }
+  return sections.join('\n\n').trim();
+}
+
+export function isTerminalWeixinBridgeMessage(event: DesktopBridgeEvent, rendered: string): boolean {
+  if (event.type === 'buttons') return true;
+  if (event.type !== 'reply') return false;
+  const kind = bridgeEventKind(event);
+  if (kind === 'tool' || kind === 'thought' || kind === 'plan' || kind === 'status') return false;
+  return Boolean(rendered.trim());
+}

--- a/services/local-ai-core/src/channel/weixin/text-utils.ts
+++ b/services/local-ai-core/src/channel/weixin/text-utils.ts
@@ -1,0 +1,90 @@
+export function stripWeixinHtml(html: string): string {
+  let result = html;
+  let previous: string;
+  do {
+    previous = result;
+    result = result.replace(/<[^>]*>/g, '');
+  } while (result !== previous);
+  return result
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+export function formatWeixinError(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = (error as Error & { cause?: unknown }).cause;
+    return cause !== undefined ? `${error.message}: ${String(cause)}` : error.message;
+  }
+  return String(error);
+}
+
+export function waitForWeixinRetry(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error('aborted'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf-8');
+}
+
+export function splitTextByUtf8Bytes(text: string, maxBytes: number): string[] {
+  const normalized = String(text || '').replace(/\r\n/g, '\n').trim();
+  if (!normalized) return [];
+  if (utf8ByteLength(normalized) <= maxBytes) return [normalized];
+
+  const chunks: string[] = [];
+  let current = '';
+  const pushCurrent = () => {
+    const trimmed = current.trim();
+    if (trimmed) chunks.push(trimmed);
+    current = '';
+  };
+  const appendPart = (part: string) => {
+    if (!part.trim()) return;
+    const separator = current ? '\n\n' : '';
+    if (current && utf8ByteLength(`${current}${separator}${part}`) <= maxBytes) {
+      current = `${current}${separator}${part}`;
+      return;
+    }
+    if (current) pushCurrent();
+    if (utf8ByteLength(part) <= maxBytes) {
+      current = part;
+      return;
+    }
+    let segment = '';
+    for (const character of Array.from(part)) {
+      if (segment && utf8ByteLength(`${segment}${character}`) > maxBytes) {
+        chunks.push(segment);
+        segment = '';
+      }
+      segment += character;
+    }
+    current = segment;
+  };
+  for (const part of normalized.split(/\n{2,}/)) appendPart(part);
+  pushCurrent();
+  return chunks;
+}
+
+export function truncateTextByUtf8Bytes(text: string, maxBytes: number): string {
+  const normalized = String(text || '').replace(/\r\n/g, '\n').trim();
+  if (utf8ByteLength(normalized) <= maxBytes) return normalized;
+  const suffix = '\n\n（内容过长，已截断以保证微信送达）';
+  const budget = Math.max(0, maxBytes - utf8ByteLength(suffix));
+  let result = '';
+  for (const character of Array.from(normalized)) {
+    if (utf8ByteLength(`${result}${character}`) > budget) break;
+    result += character;
+  }
+  return `${result.trim()}${suffix}`;
+}

--- a/tests/integration/lark-gateway-utils.test.ts
+++ b/tests/integration/lark-gateway-utils.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  extractLarkHeaderMimeType,
+  sniffLarkImageExtension,
+  summarizeLarkInboundContentParts,
+} from '../../services/local-ai-core/src/channel/lark/gateway-utils.js';
+
+test('lark gateway attachment utilities preserve content summaries and mime detection', () => {
+  assert.equal(summarizeLarkInboundContentParts([{ type: 'file', fileName: 'report.pdf' }]), '[File: report.pdf]');
+  assert.equal(extractLarkHeaderMimeType({ 'Content-Type': 'image/png; charset=binary' }), 'image/png');
+  assert.equal(sniffLarkImageExtension(Buffer.from([0x89, 0x50, 0x4e, 0x47])), 'png');
+});

--- a/tests/integration/weixin-runtime-state.test.ts
+++ b/tests/integration/weixin-runtime-state.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { DesktopBridgeEvent } from '../../packages/contracts/src/index.js';
+import {
+  consumeWeixinBridgeEvent,
+  createWeixinTurnState,
+  isTerminalWeixinBridgeMessage,
+  renderWeixinTurnText,
+} from '../../services/local-ai-core/src/channel/weixin/runtime-state.js';
+
+test('weixin turn state keeps thought, tool progress, and final reply ordered', () => {
+  const turn = createWeixinTurnState('workspace:thread');
+  consumeWeixinBridgeEvent(turn, { type: 'typing_start', sessionKey: turn.sessionKey });
+  consumeWeixinBridgeEvent(turn, { type: 'update_message', sessionKey: turn.sessionKey, bridgeKind: 'thought', content: 'Inspecting' });
+  consumeWeixinBridgeEvent(turn, { type: 'reply', sessionKey: turn.sessionKey, bridgeKind: 'tool', content: 'Search - running' });
+  const finalEvent = { type: 'reply', sessionKey: turn.sessionKey, bridgeKind: 'assistant', content: 'Done' } as const;
+  consumeWeixinBridgeEvent(turn, finalEvent);
+
+  const rendered = renderWeixinTurnText(turn);
+  assert.match(rendered, /Inspecting/);
+  assert.match(rendered, /Done/);
+  assert.equal(isTerminalWeixinBridgeMessage(finalEvent, rendered), true);
+});
+
+test('weixin permission events remain terminal and render fallback actions', () => {
+  const turn = createWeixinTurnState('workspace:thread');
+  const event: DesktopBridgeEvent = {
+    type: 'buttons',
+    sessionKey: turn.sessionKey,
+    buttonRows: [[{ text: 'Allow', data: 'allow' }]],
+  };
+  consumeWeixinBridgeEvent(turn, event);
+
+  const rendered = renderWeixinTurnText(turn);
+  assert.match(rendered, /allow all/);
+  assert.equal(isTerminalWeixinBridgeMessage(event, rendered), true);
+});

--- a/tests/integration/weixin-text-utils.test.ts
+++ b/tests/integration/weixin-text-utils.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  splitTextByUtf8Bytes,
+  stripWeixinHtml,
+  truncateTextByUtf8Bytes,
+  utf8ByteLength,
+} from '../../services/local-ai-core/src/channel/weixin/text-utils.js';
+
+test('weixin text utilities preserve utf8 boundaries and decode simple html', () => {
+  assert.equal(stripWeixinHtml('<p>A&amp;B</p>'), 'A&B');
+  const chunks = splitTextByUtf8Bytes('你好世界', 6);
+  assert.deepEqual(chunks, ['你好', '世界']);
+  assert.ok(chunks.every((chunk) => utf8ByteLength(chunk) <= 6));
+  assert.ok(utf8ByteLength(truncateTextByUtf8Bytes('很长的内容'.repeat(20), 80)) <= 80);
+});


### PR DESCRIPTION
## What changed
- move WeChat bridge turn projection into a focused runtime-state module
- extract WeChat UTF-8 chunking, truncation, retry, and error helpers
- extract Lark attachment detection and websocket diagnostics
- add focused platform utility and state tests

## Why
The channel gateways mixed lifecycle orchestration with pure rendering, attachment, and transport-adjacent logic. The split lowers change risk without altering channel contracts or persistence.

## Validation
- pnpm test (341 passed)
- 49 focused Lark/WeChat integration scenarios