### PR TITLE
Read thread messages once per ACP run start

### DIFF
--- a/services/local-ai-core/src/acp/local-core-acp-backend.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-backend.ts
@@ -401,14 +401,11 @@ export class LocalCoreAcpBackend {
         runId,
       });
       this.options.log?.(`[acp.run:${runId}] session ready in ${Date.now() - runStartedAt}ms`);
-      const priorAssistantFinalMessages = this.options.store
-        .getThread(threadId, [])
-        .messages
+      const priorThreadMessages = this.options.store.getThread(threadId, []).messages;
+      const priorAssistantFinalMessages = priorThreadMessages
         .filter((entry) => entry.role === 'assistant' && entry.kind === 'final')
         .map((entry) => entry.content);
-      const priorAssistantProgressMessages = this.options.store
-        .getThread(threadId, [])
-        .messages
+      const priorAssistantProgressMessages = priorThreadMessages
         .filter((entry) => entry.role === 'assistant' && entry.kind === 'progress')
         .map((entry) => ({
           kind: entry.bridgeKind,


### PR DESCRIPTION
## Summary
**Category: c (Efficiency)** — hot-path redundant SQLite read.

`runPrompt()` in `services/local-ai-core/src/acp/local-core-acp-backend.ts:404-416` called `this.options.store.getThread(threadId, [])` twice back-to-back to filter `final` and `progress` messages separately. Each call triggered a full SQLite roundtrip (thread row + all messages + per-message JSON parse). Read once into `priorThreadMessages`, filter in memory twice — saves one indexed lookup + one message-row scan + per-message parsing per ACP run start.

## Motivation
Every ACP prompt (scheduled job, user message, monitor trigger) was paying for two full thread snapshots when one suffices. Thread sizes grow unbounded over time, so this scales with usage.

## Sub-agent review
1 round, 3 parallel agents (Reuse / Quality / Efficiency). All 3 confirmed the diff itself is clean. Optional findings that were **not** addressed (require scope expansion):
- **Reuse / Quality**: `getThread(threadId, [])` with empty KB IDs is a leaky store-API shape — fixing needs an overload or new `listMessages(threadId)` method (touches store interface + 4 call sites + test mocks).
- **Efficiency**: `getThreadRow(threadId)` at line 384 and `getThread(threadId, [])` at line 404 both do an indexed row lookup for the same thread — fixing needs either replacing `row.*` with `detail.*` across 15+ sites in `runPrompt`, or the same new store method as above.

Both are tracked as follow-up candidates, not in this PR's scope.

## Test plan
- [x] `pnpm test` baseline: 330 pass / 0 fail
- [x] `pnpm test` after change: **330 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)