### PR TITLE
Extract shared lark card action reader

### DIFF
--- a/services/local-ai-core/src/channel/lark/cards.ts
+++ b/services/local-ai-core/src/channel/lark/cards.ts
@@ -138,13 +138,11 @@ export function extractCardActionMessageId(...payloads: Array<Record<string, unk
 }
 
 export function extractCardActionValue(payload: Record<string, unknown>) {
-  const event = ((payload as any)?.event && typeof (payload as any).event === 'object')
-    ? (payload as any).event as Record<string, unknown>
-    : payload;
-  const value = (event as any)?.action?.value;
-  if (!value || value.action !== 'permission_response') {
+  const action = readLarkCardAction(payload, 'permission_response');
+  if (!action) {
     return null;
   }
+  const { event, value } = action;
   const response = normalizePermissionResponse(String(value.response || '').trim()) || String(value.response || '').trim();
   const threadId = String(value.thread_id || '').trim();
   const sessionKey = String(value.session_key || '').trim();
@@ -153,7 +151,7 @@ export function extractCardActionValue(payload: Record<string, unknown>) {
   }
   return {
     event,
-    value: value as Record<string, unknown>,
+    value,
     response,
     threadId,
     sessionKey,
@@ -161,13 +159,11 @@ export function extractCardActionValue(payload: Record<string, unknown>) {
 }
 
 export function extractSessionCommandActionValue(payload: Record<string, unknown>) {
-  const event = ((payload as any)?.event && typeof (payload as any).event === 'object')
-    ? (payload as any).event as Record<string, unknown>
-    : payload;
-  const value = (event as any)?.action?.value;
-  if (!value || value.action !== 'session_command') {
+  const action = readLarkCardAction(payload, 'session_command');
+  if (!action) {
     return null;
   }
+  const { event, value } = action;
   const command = String(value.command || '').trim();
   const threadId = String(value.thread_id || '').trim();
   const sessionKey = String(value.session_key || '').trim();
@@ -176,11 +172,31 @@ export function extractSessionCommandActionValue(payload: Record<string, unknown
   }
   return {
     event,
-    value: value as Record<string, unknown>,
+    value,
     command,
     threadId,
     sessionKey,
   };
+}
+
+function readLarkCardAction(payload: Record<string, unknown>, expectedAction: string): { event: Record<string, unknown>; value: Record<string, unknown> } | null {
+  const eventCandidate = (payload as Record<string, unknown>).event;
+  const event = eventCandidate && typeof eventCandidate === 'object'
+    ? eventCandidate as Record<string, unknown>
+    : payload;
+  const actionCandidate = (event as Record<string, unknown>).action;
+  if (!actionCandidate || typeof actionCandidate !== 'object') {
+    return null;
+  }
+  const valueCandidate = (actionCandidate as Record<string, unknown>).value;
+  if (!valueCandidate || typeof valueCandidate !== 'object') {
+    return null;
+  }
+  const value = valueCandidate as Record<string, unknown>;
+  if (value.action !== expectedAction) {
+    return null;
+  }
+  return { event, value };
 }
 
 export function formatPermissionButtonLabel(button: { text: string; data: string }) {

--- a/services/local-ai-core/src/channel/lark/cards.ts
+++ b/services/local-ai-core/src/channel/lark/cards.ts
@@ -179,7 +179,9 @@ export function extractSessionCommandActionValue(payload: Record<string, unknown
   };
 }
 
-function readLarkCardAction(payload: Record<string, unknown>, expectedAction: string): { event: Record<string, unknown>; value: Record<string, unknown> } | null {
+type LarkCardActionKind = 'permission_response' | 'session_command';
+
+function readLarkCardAction(payload: Record<string, unknown>, expectedAction: LarkCardActionKind): { event: Record<string, unknown>; value: Record<string, unknown> } | null {
   const eventCandidate = (payload as Record<string, unknown>).event;
   const event = eventCandidate && typeof eventCandidate === 'object'
     ? eventCandidate as Record<string, unknown>


### PR DESCRIPTION
## Summary
**Category: b (Code Reuse) + d (Code Quality)**

`extractCardActionValue` and `extractSessionCommandActionValue` in `services/local-ai-core/src/channel/lark/cards.ts` both dug into `payload.event.action.value` using `as any` casts with identical navigation logic, differing only in the expected `value.action` discriminator and which fields they parsed afterward. Extracted a shared `readLarkCardAction(payload, expectedAction)` helper that:

- Handles the navigation + shape validation once
- Returns a typed `{event, value}` pair or null
- Narrows `expectedAction` to a `'permission_response' | 'session_command'` union so future action kinds get compile-time checking

Removes 6 `as any` casts and the duplicated ~8-line preamble.

## Motivation
After the recent package-boundary refactor, `as any` chains in webhook payload handling stand out as a type-safety gap. Both functions parsed the same Lark card callback shape; a shared reader centralizes the shape contract and prevents drift if Feishu adds a new action kind.

## Sub-agent review
1 round, 3 parallel agents (Reuse / Quality / Efficiency). Round 1 results:
- **Reuse**: clean — helper is at right level; `extractKnownCardActionMessageId` (different navigation pattern) correctly kept separate; no other Lark payload diggers exist.
- **Efficiency**: clean — no extra cost; helper inlines after warmup, mismatch path short-circuits same as before.
- **Quality**: one real finding — `expectedAction: string` too loose. Applied as a follow-up commit narrowing to `LarkCardActionKind` union.

Skipped a 2nd round on the 3-line type narrowing — it's exactly the fix Agent B requested.

## Test plan
- [x] `pnpm test` baseline: 369 pass / 0 fail
- [x] `pnpm test` after refactor: **369 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)