### PR TITLE
Drop redundant expirePendingPairings in channel status builders

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -737,7 +737,6 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
   }
 
   protected buildStatusObject(state: LarkRuntimeState, _resolved: { instanceId: string }): LocalCoreLarkGatewayStatus {
-    this.options.store.expirePendingPairings();
     const resolved = this.resolveRuntimeState(state.workspaceId, state.instanceId);
     const binding = resolved.state;
     const platformKey = binding?.platformKey || channelPlatformKey('lark', resolved.instanceId);

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -115,7 +115,6 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
   }
 
   protected buildStatusObject(state: WeixinRuntimeState, resolved: { instanceId: string }): LocalCoreChannelGatewayStatus {
-    this.options.store.expirePendingPairings();
     const platformKey = state.platformKey || channelPlatformKey('weixin', resolved.instanceId);
     const pairings = this.options.store.listPendingPairings(state.workspaceId)
       .filter((row) => row.platform === platformKey && row.expires_at >= new Date().toISOString());


### PR DESCRIPTION
## Summary
- The base `BaseChannelGateway.getStatus()` already calls `store.expirePendingPairings()` before delegating to `buildStatusObject()`. The Lark and Weixin subclass overrides were calling it again, so `listStatuses()` with N bindings triggered 2N `UPDATE platform_pairings` statements instead of N.
- Removed the duplicate call from both subclass overrides. `expirePendingPairings()` is idempotent (simple `UPDATE ... WHERE status='pending' AND expires_at < ?`), so the change is behavior-preserving — only redundant SQL roundtrips are eliminated.

## Scope verification
- `buildStatusObject` is `protected` and only invoked from `BaseChannelGateway.getStatus()` (base-channel-gateway.ts:244). No internal `this.buildStatusObject(...)` calls exist in either gateway subclass.
- Single-binding paths (`enable`, `disable`, `testConnection`) still go through `getStatus()`, so expiry still runs once per call.

## Review notes (3 parallel sub-agents)
- **Reuse**: No action — Lark/Weixin `buildStatusObject` methods have legitimately different state shapes and status fields; hoisting the shared 3-line pairings filter is not worth it.
- **Quality**: Ship as-is — `expirePendingPairings()` is idempotent, no orphaned comments, no alternate call paths bypass `getStatus()`.
- **Efficiency**: PR sufficient — confirms the 2N → N reduction. Further O(1) hoisting into `listStatuses()` is possible but out of scope for this targeted fix.

## Test plan
- [x] `pnpm test` — 369 pass / 0 fail
- [x] Diff is 2 lines removed, no logic change
- [x] No other callers of `buildStatusObject` exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)