### PR TITLE
Reuse shared parseSlashCommand and hoist findAwaitingPermissionThreadId

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -65,6 +65,7 @@ import type {
 } from './types.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
+import { parseSlashCommand } from '../../acp/local-core-slash-commands.js';
 import {
   attachLarkWsDiagnostics,
   maskLarkAppId,
@@ -538,7 +539,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     });
     const acknowledgement = this.createTurnState(effectiveSessionKey, msg.messageId);
     await this.addAcknowledgementReaction(msg.workspaceId, msg.messageId, acknowledgement, instanceId);
-    const slashCommand = this.parseSlashCommand(msg.text);
+    const slashCommand = parseSlashCommand(msg.text);
     const sessionCommand = await this.executeSessionCommand({
       workspaceId: msg.workspaceId,
       currentThreadId: threadId,
@@ -823,38 +824,6 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
 
   private generatePairingCode() {
     return String(randomInt(100000, 1000000));
-  }
-
-  private findAwaitingPermissionThreadId(workspaceId: string, chatId: string, platformUserId: string) {
-    for (const [sessionKey, route] of this.threadRouting.entries()) {
-      if (
-        route.workspaceId !== workspaceId
-        || route.chatId !== chatId
-        || route.platformUserId !== platformUserId
-      ) {
-        continue;
-      }
-      const turn = this.outboundTurns.get(sessionKey);
-      if (turn?.awaitingPermission && route.threadId) {
-        return route.threadId;
-      }
-    }
-    return '';
-  }
-
-  private parseSlashCommand(text: string) {
-    const normalized = String(text || '').trim();
-    if (!normalized.startsWith('/')) {
-      return null;
-    }
-    const [name = '', ...args] = normalized.slice(1).split(/\s+/);
-    if (!name) {
-      return null;
-    }
-    return {
-      name: name.trim().toLowerCase(),
-      args,
-    };
   }
 
   private createTurnState(sessionKey: string, sourceMessageId?: string) {

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -66,6 +66,10 @@ export interface GatewayThreadRoute {
   threadId: string;
 }
 
+export interface GatewayTurnState {
+  awaitingPermission?: boolean;
+}
+
 function resolveRuntimeKey(workspaceId: string, instanceId?: string): string {
   return instanceId ? `${workspaceId}::${instanceId}` : workspaceId;
 }
@@ -74,7 +78,7 @@ export abstract class BaseChannelGateway<
   TRuntimeState extends GatewayRuntimeState,
   TBinding extends GatewayBinding,
   TThreadRoute extends GatewayThreadRoute,
-  TTurnState = unknown,
+  TTurnState extends GatewayTurnState = GatewayTurnState,
 > extends EventEmitter implements ChannelRuntime {
   /** Platform identifier (e.g. 'lark', 'weixin'). */
   abstract readonly platform: string;
@@ -374,6 +378,31 @@ export abstract class BaseChannelGateway<
 
   protected async executeSessionCommand(input: ChannelSessionCommandInput) {
     return this.sessionCommandRuntime.execute(input);
+  }
+
+  protected findAwaitingPermissionThreadId(
+    workspaceId: string,
+    chatId: string,
+    platformUserId: string,
+    platformKey?: string,
+  ) {
+    for (const [sessionKey, route] of this.threadRouting.entries()) {
+      if (
+        route.workspaceId !== workspaceId
+        || route.chatId !== chatId
+        || route.platformUserId !== platformUserId
+      ) {
+        continue;
+      }
+      if (platformKey !== undefined && route.platformKey !== platformKey) {
+        continue;
+      }
+      const turn = this.outboundTurns.get(sessionKey);
+      if (turn?.awaitingPermission && route.threadId) {
+        return route.threadId;
+      }
+    }
+    return '';
   }
 
   // ==================== Runtime Management ====================

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -30,6 +30,7 @@ import { resolveInboundChannelAuthorization } from '../shared/inbound-authorizat
 import { channelPlatformKey, runtimeKey } from '../shared/channel-keys.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
+import { parseSlashCommand } from '../../acp/local-core-slash-commands.js';
 import {
   collectWeixinWorkspaceBindings,
   getWeixinBufPath,
@@ -522,7 +523,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     const normalizedText = String(msg.text || '').trim().toLowerCase();
     const permissionThreadId = (
       normalizedText === 'allow' || normalizedText === 'allow all' || normalizedText === 'deny'
-    ) ? this.findAwaitingPermissionThreadId(msg.workspaceId, msg.chatId, msg.platformUserId, msg.platformKey) : '';
+    ) ? this.findAwaitingPermissionThreadId(msg.workspaceId, msg.chatId, msg.platformUserId, msg.platformKey || 'weixin') : '';
     if (permissionThreadId && permissionThreadId !== threadId) {
       threadId = permissionThreadId;
     }
@@ -538,7 +539,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     });
 
     // Handle slash commands
-    const slashCommand = this.parseSlashCommand(msg.text);
+    const slashCommand = parseSlashCommand(msg.text);
     const sessionCommand = await this.executeSessionCommand({
       workspaceId: msg.workspaceId,
       currentThreadId: threadId,
@@ -898,23 +899,6 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     if (this.processedInboundMessages.has(key)) return true;
     this.processedInboundMessages.set(key, now + PROCESSED_MESSAGE_TTL_MS);
     return false;
-  }
-
-  private findAwaitingPermissionThreadId(workspaceId: string, chatId: string, platformUserId: string, platformKey = 'weixin'): string {
-    for (const [sessionKey, route] of this.threadRouting.entries()) {
-      if (route.workspaceId !== workspaceId || route.platformKey !== platformKey || route.chatId !== chatId || route.platformUserId !== platformUserId) continue;
-      const turn = this.outboundTurns.get(sessionKey);
-      if (turn?.awaitingPermission && route.threadId) return route.threadId;
-    }
-    return '';
-  }
-
-  private parseSlashCommand(text: string): { name: string; args: string[] } | null {
-    const normalized = String(text || '').trim();
-    if (!normalized.startsWith('/')) return null;
-    const [name = '', ...args] = normalized.slice(1).split(/\s+/);
-    if (!name) return null;
-    return { name: name.trim().toLowerCase(), args };
   }
 
 


### PR DESCRIPTION
## Summary

**Category: b (Code Reuse)**

Both Lark and Weixin channel gateways carried two duplicated private helpers that this PR consolidates:

1. **`parseSlashCommand()`** was duplicated privately in both subclasses, despite already existing as an exported function in `services/local-ai-core/src/acp/local-core-slash-commands.ts:43`. The shared function is imported directly and the private copies deleted (pure dead code removal).

2. **`findAwaitingPermissionThreadId()`** was duplicated in both subclasses with near-identical iteration over `this.threadRouting`. Hoisted to `BaseChannelGateway` as a `protected` method with an optional `platformKey` filter that preserves both subclass behaviors:
   - Lark call site passes 3 args (no platformKey) → filter skipped, same as before
   - Weixin call site passes `msg.platformKey || 'weixin'` → filter applies with the same default as before

Added `GatewayTurnState` interface (`{ awaitingPermission?: boolean }`) and constrained `TTurnState extends GatewayTurnState` so the base method can read `turn?.awaitingPermission` without casts. Both `LarkTurnState` and `WeixinTurnState` already declare `awaitingPermission: boolean`, which satisfies the constraint.

## Sub-agent review (1 round, all clean)

- **Code Reuse**: Confirmed both duplicates are fully removed; flagged `resolveDefaultAgentType` as a future cross-gateway dedup candidate (out of scope here).
- **Code Quality**: Ship as-is. Generic constraint, platformKey preservation (Lark no-filter / Weixin 'weixin' default), and turn-state typing all verified.
- **Efficiency**: No concerns. Both helpers run once per inbound message; net −20 lines, no new cost.

## Test plan

- [x] `pnpm test` — 369 pass / 0 fail (baseline maintained)
- [x] Lark call site preserves 3-arg behavior (no platformKey filter)
- [x] Weixin call site preserves `'weixin'` fallback when `msg.platformKey` is undefined
- [x] `GatewayTurnState` constraint satisfied by both `LarkTurnState` and `WeixinTurnState`

🤖 Generated with [Claude Code](https://claude.com/claude-code)