### PR TITLE
Hoist resolveDefaultAgentType to BaseChannelGateway

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -905,14 +905,6 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     };
   }
 
-  private async resolveDefaultAgentType(workspaceId: string, threadId: string) {
-    const router = this.options.getWorkspaceRouter();
-    if (typeof router.getWorkspaceDefaultAgentType === 'function') {
-      return router.getWorkspaceDefaultAgentType(workspaceId);
-    }
-    return this.options.store.getThreadRow(threadId)?.agent_type || 'codex';
-  }
-
   private async markPermissionCardActionHandled(
     workspaceId: string,
     instanceId: string,

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -380,6 +380,14 @@ export abstract class BaseChannelGateway<
     return this.sessionCommandRuntime.execute(input);
   }
 
+  protected async resolveDefaultAgentType(workspaceId: string, threadId: string) {
+    const router = this.options.getWorkspaceRouter();
+    if (typeof router.getWorkspaceDefaultAgentType === 'function') {
+      return router.getWorkspaceDefaultAgentType(workspaceId);
+    }
+    return this.options.store.getThreadRow(threadId)?.agent_type || 'codex';
+  }
+
   protected findAwaitingPermissionThreadId(
     workspaceId: string,
     chatId: string,

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -578,14 +578,6 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
 
 
 
-  private async resolveDefaultAgentType(workspaceId: string, threadId: string) {
-    const router = this.options.getWorkspaceRouter();
-    if (typeof router.getWorkspaceDefaultAgentType === 'function') {
-      return router.getWorkspaceDefaultAgentType(workspaceId);
-    }
-    return this.options.store.getThreadRow(threadId)?.agent_type || 'codex';
-  }
-
   // ==================== Private: Bindings ====================
 
 


### PR DESCRIPTION
## Summary

**Category: b (Code Reuse)**

`resolveDefaultAgentType(workspaceId, threadId)` was byte-identical in both Lark and Weixin gateways (PR #16 review flagged this as the next cleanup). Hoisted one protected method to `BaseChannelGateway` so both subclasses inherit it via `this.*`. Three call sites unchanged (lark:548, lark:870, weixin:548).

## Sub-agent review (1 round, all clean)

- **Code Reuse**: Ship as-is. Both deleted copies were byte-identical; new base method body matches. Future dedup candidates (downloadMessageImage / sendTextAsMessage) noted but out of scope — they have legitimately platform-specific shapes.
- **Code Quality**: Ship as-is. `private` → `protected` visibility is the right move; placement next to other session helpers (`executeSessionCommand`, `findAwaitingPermissionThreadId`); no unused imports; behavior preserved.
- **Efficiency**: No concerns. `getWorkspaceRouter()` returns a cached singleton; method runs once per inbound message, not in a loop.

## Test plan

- [x] `pnpm test` — 369 pass / 0 fail (baseline maintained)
- [x] Both deleted methods were byte-identical (verified via direct read)
- [x] All 3 call sites use `await this.resolveDefaultAgentType(...)` — inherited protected method works without binding changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)