### PR TITLE
Consolidate error formatting into shared formatSafeError

### DIFF
--- a/services/local-ai-core/src/channel/weixin/inbound-poller.ts
+++ b/services/local-ai-core/src/channel/weixin/inbound-poller.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import type { ChannelInboundContentPart } from '@cc/superai-contracts';
-import { LocalCoreError, toLocalCoreErrorInfo } from '../../kernel/local-core-errors.js';
+import { LocalCoreError, formatSafeError, toLocalCoreErrorInfo } from '../../kernel/local-core-errors.js';
 import { loadWeixinBuf, saveWeixinBuf } from './config.js';
 import {
   FILE_ITEM_TYPE,
@@ -9,7 +9,7 @@ import {
   TEXT_ITEM_TYPE,
   VOICE_ITEM_TYPE,
 } from './transport.js';
-import { formatWeixinError, waitForWeixinRetry } from './text-utils.js';
+import { waitForWeixinRetry } from './text-utils.js';
 import { createWeixinAttachmentContentPart, type WeixinDownloadedMedia } from './inbound-media.js';
 import type { WeixinRawItem, WeixinRuntimeState, WeixinWorkspaceBinding } from './types.js';
 
@@ -138,7 +138,7 @@ export async function runWeixinInboundPoller(input: {
               try {
                 return await input.downloadMediaItem(item, msgId, index, uploadsDir, binding);
               } catch (error) {
-                input.log?.(`localcore-weixin attachment download failed (${conversationId}#${index}): ${formatWeixinError(error)}`);
+                input.log?.(`localcore-weixin attachment download failed (${conversationId}#${index}): ${formatSafeError(error)}`);
                 return null;
               }
             }));
@@ -186,8 +186,8 @@ export async function runWeixinInboundPoller(input: {
         input.notifyRuntimeStateChanged();
       }
       logPollError(
-        formatWeixinError(error),
-        `localcore-weixin getUpdates error for ${binding.workspaceId} (${consecutiveFailures}): ${formatWeixinError(error)}`,
+        formatSafeError(error),
+        `localcore-weixin getUpdates error for ${binding.workspaceId} (${consecutiveFailures}): ${formatSafeError(error)}`,
       );
       await waitForWeixinRetry(retryDelayMs, signal);
     }

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -19,7 +19,7 @@ import type {
   LocalCorePairingRequest,
 } from '@cc/superai-contracts';
 import type { ChannelRuntime } from '@cc/plugin-sdk';
-import { LocalCoreError, toLocalCoreErrorInfo } from '../../kernel/local-core-errors.js';
+import { LocalCoreError, formatSafeError, toLocalCoreErrorInfo } from '../../kernel/local-core-errors.js';
 import { createChannelThreadMessageInput } from '../shared/content.js';
 import { prepareChannelFile, type PreparedChannelFile } from '../shared/file-utils.js';
 import { FileSystemInboundAttachmentStore, resolveInboundAttachmentUri } from '../shared/inbound-attachment-store.js';
@@ -65,7 +65,6 @@ import {
   renderWeixinTurnText,
 } from './runtime-state.js';
 import {
-  formatWeixinError,
   splitTextByUtf8Bytes,
   stripWeixinHtml,
   truncateTextByUtf8Bytes,
@@ -335,7 +334,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
           turn.lastSentText = rendered;
           this.options.log?.(`localcore-weixin sent message for sessionKey=${sessionKey} type=${event.type} sent=${turn.sentCount}/${binding.last_platform_message_id ? WEIXIN_CONTEXT_SEND_LIMIT : 'unlimited'}`);
         } catch (error) {
-          this.options.log?.(`localcore-weixin send failed for sessionKey=${sessionKey}: ${formatWeixinError(error)}`);
+          this.options.log?.(`localcore-weixin send failed for sessionKey=${sessionKey}: ${formatSafeError(error)}`);
         }
       })
       .finally(() => {

--- a/services/local-ai-core/src/channel/weixin/text-utils.ts
+++ b/services/local-ai-core/src/channel/weixin/text-utils.ts
@@ -14,14 +14,6 @@ export function stripWeixinHtml(html: string): string {
     .replace(/&nbsp;/g, ' ');
 }
 
-export function formatWeixinError(error: unknown): string {
-  if (error instanceof Error) {
-    const cause = (error as Error & { cause?: unknown }).cause;
-    return cause !== undefined ? `${error.message}: ${String(cause)}` : error.message;
-  }
-  return String(error);
-}
-
 export function waitForWeixinRetry(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(resolve, ms);

--- a/services/local-ai-core/src/cli/lac.ts
+++ b/services/local-ai-core/src/cli/lac.ts
@@ -13,6 +13,7 @@ import { toPublicScheduledJobId } from '../scheduler/job-id.js';
 import { getChannelPlatformBase, getChannelPlatformInstanceId, scheduledJobMatchesCliContext } from '../scheduler/scheduled-job-route.js';
 import { toPublicAutomationMonitorId } from '../automation/monitor-id.js';
 import { parseDurationMs, parseMonitorCondition } from './monitor-cli-parsers.js';
+import { formatSafeError } from '../kernel/local-core-errors.js';
 
 type JsonEnvelope<T> = {
   ok: boolean;
@@ -96,7 +97,7 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv = process.en
         return 2;
     }
   } catch (error) {
-    io.stderr.write(`${formatError(error)}\n`);
+    io.stderr.write(`${formatSafeError(error)}\n`);
     return 1;
   }
 }
@@ -375,7 +376,7 @@ async function request<T>(baseUrl: string, method: string, path: string, body?: 
       body: body ? JSON.stringify(body) : undefined,
     });
   } catch (error) {
-    throw new Error(`Local AI Core is unavailable at ${baseUrl}: ${formatError(error)}`);
+    throw new Error(`Local AI Core is unavailable at ${baseUrl}: ${formatSafeError(error)}`);
   }
   const payload = await response.json() as JsonEnvelope<T>;
   if (!response.ok || !payload.ok) {
@@ -586,10 +587,6 @@ function monitorMatchesCliContext(monitor: AutomationMonitor, context: CliContex
     createdAt: monitor.createdAt,
     updatedAt: monitor.updatedAt,
   }, context);
-}
-
-function formatError(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
 }
 
 void (async () => {

--- a/services/local-ai-core/src/kernel/local-core-errors.ts
+++ b/services/local-ai-core/src/kernel/local-core-errors.ts
@@ -187,6 +187,14 @@ export function formatLogError(info: LocalCoreErrorInfo) {
   return `${info.code}: ${message}${suffix}`;
 }
 
+export function formatSafeError(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = (error as Error & { cause?: unknown }).cause;
+    return cause !== undefined ? `${error.message}: ${cause instanceof Error ? cause.message : coerceErrorMessage(cause)}` : error.message;
+  }
+  return coerceErrorMessage(error);
+}
+
 export function errorInfoToHttpBody(info: LocalCoreErrorInfo) {
   return {
     ok: false,


### PR DESCRIPTION
## Summary

**Category: b (Code Reuse)**

The Weixin channel carried `formatWeixinError` (Error + `Error.cause` aware) and the CLI carried a private `formatError` that ignored `cause`. Both did the same job — convert `unknown` to a single-line string. Moved one shared `formatSafeError` helper to `services/local-ai-core/src/kernel/local-core-errors.ts`.

Two side effects:
- CLI error messages now include `Error.cause` (diagnostic upgrade — previously swallowed)
- Weixin error output uses `cause.message` for Error causes instead of `String(cause)` (drops the redundant `Error: ` prefix)

## Sub-agent review (1 round, all clean)

- **Code Reuse**: Ship as-is. All callers updated, no leftover `formatWeixinError` or local `formatError`. Flagged ~42 other `error instanceof Error ? error.message : String(error)` patterns across the codebase as future dedup candidates — explicitly out of scope for this PR.
- **Code Quality**: Ship as-is. The format difference from `formatLogError` (`cause=X` suffix vs `: X` inline) is intentional — different consumers (structured log vs user-facing). Type cast on `Error.cause` is safe.
- **Efficiency**: No concerns. All 6 call sites are in catch blocks; both modules already imported from `kernel/local-core-errors.js`.

## Test plan

- [x] `pnpm test` — 369 pass / 0 fail (baseline maintained)
- [x] No `formatWeixinError` references remain in `services/local-ai-core/src/`
- [x] No local `formatError` in `cli/lac.ts`
- [x] All 6 call sites updated to use `formatSafeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)