### PR TITLE
Reuse formatSafeError in OpenSandbox client catch block

### DIFF
--- a/services/local-ai-core/src/sandbox/opensandbox-client.ts
+++ b/services/local-ai-core/src/sandbox/opensandbox-client.ts
@@ -1,4 +1,4 @@
-import { LocalCoreError } from '../kernel/local-core-errors.js';
+import { LocalCoreError, formatSafeError } from '../kernel/local-core-errors.js';
 
 export type OpenSandboxVolume = {
   host: string;
@@ -117,8 +117,9 @@ export class OpenSandboxClient {
         body: body === undefined ? undefined : JSON.stringify(body),
       });
     } catch (error) {
-      throw new LocalCoreError('sandbox_unavailable', `OpenSandbox request failed: ${error instanceof Error ? error.message : String(error)}`, {
-        cause: error instanceof Error ? error.message : String(error),
+      const message = formatSafeError(error);
+      throw new LocalCoreError('sandbox_unavailable', `OpenSandbox request failed: ${message}`, {
+        cause: message,
         details: { method, path, serverUrl: this.options.serverUrl },
       });
     }


### PR DESCRIPTION
## Summary

**Category: b (Code Reuse)**

`services/local-ai-core/src/sandbox/opensandbox-client.ts` formatted the same error twice in its fetch-failure catch block — once for the `LocalCoreError` message, once for the `cause` field. Both used `error instanceof Error ? error.message : String(error)`. After PR #18 introduced `formatSafeError`, this site was an obvious follow-up: compute once, reuse, and pick up `Error.cause` handling as a side benefit.

## Sub-agent review (1 round, all clean)

- **Code Reuse**: Ship as-is. `formatSafeError` is the right helper; behavior equivalent for plain Errors, improvement for Error-with-cause and non-Error objects. No other duplicate-computation patterns in the sandbox module.
- **Code Quality**: Ship as-is. Variable `message` is well-named and properly scoped to the catch block. `cause: message` (string) pattern is consistent with other `LocalCoreError` call sites in the file.
- **Efficiency**: No concerns. Cold path (only runs when fetch throws); eliminates one redundant `instanceof` check.

## Scope notes

PR #18's review flagged ~54 other `error instanceof Error ? error.message : String(error)` sites across the codebase as future dedup candidates. This PR only fixes the one site with actual duplicate computation. Bulk conversion of the other 54 sites is intentionally out of scope — they're single-use one-liners where the helper adds an import without eliminating redundancy.

## Test plan

- [x] `pnpm test` — 369 pass / 0 fail (baseline maintained)
- [x] Diff is 4 lines added, 3 removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)