### PR TITLE
Share platform runtime env builder and run polling across executors

### DIFF
--- a/services/local-ai-core/src/automation/automation-conversation-executor.ts
+++ b/services/local-ai-core/src/automation/automation-conversation-executor.ts
@@ -3,9 +3,9 @@ import type { ChannelRuntime } from '@cc/plugin-sdk';
 import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
 import type { WorkspaceRouter } from '../router/workspace-router.js';
 import { ScheduledBridgeSession } from '../scheduler/scheduled-bridge-session.js';
-import { getChannelPlatformBase, getChannelPlatformInstanceId, routeTypeForPlatform } from '../scheduler/scheduled-job-route.js';
+import { buildPlatformRuntimeEnv, getChannelPlatformBase } from '../scheduler/scheduled-job-route.js';
+import { waitForRunCompletion } from '../scheduler/run-polling.js';
 
-const TERMINAL_RUN_STATES = new Set(['completed', 'failed', 'interrupted']);
 const MONITOR_RUN_PERMISSION_MODE = 'bypassPermissions';
 
 export type AutomationConversationExecutionResult = {
@@ -52,9 +52,9 @@ export class AutomationConversationExecutor {
     try {
       const sendResult = await workspaceRouter.sendThreadMessage(threadId, prompt, {
         permissionMode: MONITOR_RUN_PERMISSION_MODE,
-        runtimeEnv: this.buildRuntimeEnv(monitor),
+        runtimeEnv: buildPlatformRuntimeEnv(monitor.platform, monitor.route),
       });
-      await this.waitForRun(sendResult.runId, timeoutMs);
+      await waitForRunCompletion(this.options.store, sendResult.runId, timeoutMs, 'Monitor');
       const thread = await workspaceRouter.getThread(threadId);
       const replyText = [...thread.messages]
         .reverse()
@@ -108,41 +108,6 @@ export class AutomationConversationExecutor {
     } catch {
       return false;
     }
-  }
-
-  private buildRuntimeEnv(monitor: AutomationMonitor) {
-    const basePlatform = getChannelPlatformBase(monitor.platform);
-    const env: Record<string, string> = {};
-    if (basePlatform && basePlatform !== 'local') {
-      env.LOCAL_AI_PLATFORM = basePlatform;
-      env.LOCAL_AI_ROUTE_TYPE = routeTypeForPlatform(monitor.platform);
-    }
-    const instanceId = monitor.route.instanceId || getChannelPlatformInstanceId(monitor.platform);
-    if (instanceId) {
-      env.LOCAL_AI_PLATFORM_INSTANCE_ID = instanceId;
-    }
-    if (monitor.route.channelId) {
-      env.LOCAL_AI_CHAT_ID = monitor.route.channelId;
-    }
-    if (monitor.route.participantId) {
-      env.LOCAL_AI_PLATFORM_USER_ID = monitor.route.participantId;
-    }
-    return env;
-  }
-
-  private async waitForRun(runId: string, timeoutMs: number) {
-    const startedAt = Date.now();
-    while (Date.now() - startedAt < timeoutMs) {
-      const run = this.options.store.getRun(runId);
-      if (run && TERMINAL_RUN_STATES.has(run.status)) {
-        if (run.status !== 'completed') {
-          throw new Error(`Monitor run finished with status ${run.status}`);
-        }
-        return run;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 300));
-    }
-    throw new Error(`Timed out waiting for monitor run ${runId}`);
   }
 
 }

--- a/services/local-ai-core/src/scheduler/run-polling.ts
+++ b/services/local-ai-core/src/scheduler/run-polling.ts
@@ -1,0 +1,20 @@
+const TERMINAL_RUN_STATES = new Set(['completed', 'failed', 'interrupted']);
+const RUN_POLL_INTERVAL_MS = 300;
+
+type RunLike = { status: string };
+type RunStore = { getRun(runId: string): RunLike | undefined | null };
+
+export async function waitForRunCompletion(store: RunStore, runId: string, timeoutMs: number, label: string) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const run = store.getRun(runId);
+    if (run && TERMINAL_RUN_STATES.has(run.status)) {
+      if (run.status !== 'completed') {
+        throw new Error(`${label} run finished with status ${run.status}`);
+      }
+      return run;
+    }
+    await new Promise((resolve) => setTimeout(resolve, RUN_POLL_INTERVAL_MS));
+  }
+  throw new Error(`Timed out waiting for ${label.toLowerCase()} run ${runId}`);
+}

--- a/services/local-ai-core/src/scheduler/scheduled-conversation-executor.ts
+++ b/services/local-ai-core/src/scheduler/scheduled-conversation-executor.ts
@@ -3,9 +3,9 @@ import type { WorkspaceRouter } from '../router/workspace-router.js';
 import type { ScheduledJob } from '@cc/superai-contracts';
 import type { ScheduledExecutionTarget } from './adapters.js';
 import type { ScheduledExecutionPolicy } from './execution-policy.js';
-import { getChannelPlatformBase, getChannelPlatformInstanceId, routeTypeForPlatform } from './scheduled-job-route.js';
+import { buildPlatformRuntimeEnv } from './scheduled-job-route.js';
+import { waitForRunCompletion } from './run-polling.js';
 
-const TERMINAL_RUN_STATES = new Set(['completed', 'failed', 'interrupted']);
 const SCHEDULED_RUN_PERMISSION_MODE = 'bypassPermissions';
 
 type ScheduledConversationExecutorOptions = {
@@ -23,9 +23,9 @@ export class ScheduledConversationExecutor {
       const workspaceRouter = this.options.getWorkspaceRouter();
       const sendResult = await workspaceRouter.sendThreadMessage(target.threadId, prompt, {
         permissionMode: SCHEDULED_RUN_PERMISSION_MODE,
-        runtimeEnv: this.buildScheduledRuntimeEnv(target),
+        runtimeEnv: buildPlatformRuntimeEnv(target.platform, target.route),
       });
-      await this.waitForRun(sendResult.runId, timeoutMs);
+      await waitForRunCompletion(this.options.store, sendResult.runId, timeoutMs, 'Scheduled');
       const thread = await workspaceRouter.getThread(target.threadId);
       const replyText = [...thread.messages]
         .reverse()
@@ -39,41 +39,5 @@ export class ScheduledConversationExecutor {
     } finally {
       await policy.afterExecute?.(target, job);
     }
-  }
-
-  private buildScheduledRuntimeEnv(target: ScheduledExecutionTarget) {
-    const route = target.route;
-    const basePlatform = getChannelPlatformBase(target.platform);
-    const env: Record<string, string> = {};
-    if (basePlatform && basePlatform !== 'local') {
-      env.LOCAL_AI_PLATFORM = basePlatform;
-      env.LOCAL_AI_ROUTE_TYPE = routeTypeForPlatform(target.platform);
-    }
-    const instanceId = route.instanceId || getChannelPlatformInstanceId(target.platform);
-    if (instanceId) {
-      env.LOCAL_AI_PLATFORM_INSTANCE_ID = instanceId;
-    }
-    if (route.channelId) {
-      env.LOCAL_AI_CHAT_ID = route.channelId;
-    }
-    if (route.participantId) {
-      env.LOCAL_AI_PLATFORM_USER_ID = route.participantId;
-    }
-    return env;
-  }
-
-  private async waitForRun(runId: string, timeoutMs: number) {
-    const startedAt = Date.now();
-    while (Date.now() - startedAt < timeoutMs) {
-      const run = this.options.store.getRun(runId);
-      if (run && TERMINAL_RUN_STATES.has(run.status)) {
-        if (run.status !== 'completed') {
-          throw new Error(`Scheduled run finished with status ${run.status}`);
-        }
-        return run;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 300));
-    }
-    throw new Error(`Timed out waiting for scheduled run ${runId}`);
   }
 }

--- a/services/local-ai-core/src/scheduler/scheduled-job-route.ts
+++ b/services/local-ai-core/src/scheduler/scheduled-job-route.ts
@@ -43,6 +43,26 @@ export function routeTypeForPlatform(platform: string) {
   return base === 'lark' || base === 'weixin' ? 'channel.chat' : base;
 }
 
+export function buildPlatformRuntimeEnv(platform: string, route: { instanceId?: string; channelId?: string; participantId?: string }) {
+  const basePlatform = getChannelPlatformBase(platform);
+  const env: Record<string, string> = {};
+  if (basePlatform && basePlatform !== 'local') {
+    env.LOCAL_AI_PLATFORM = basePlatform;
+    env.LOCAL_AI_ROUTE_TYPE = routeTypeForPlatform(platform);
+  }
+  const instanceId = route.instanceId || getChannelPlatformInstanceId(platform);
+  if (instanceId) {
+    env.LOCAL_AI_PLATFORM_INSTANCE_ID = instanceId;
+  }
+  if (route.channelId) {
+    env.LOCAL_AI_CHAT_ID = route.channelId;
+  }
+  if (route.participantId) {
+    env.LOCAL_AI_PLATFORM_USER_ID = route.participantId;
+  }
+  return env;
+}
+
 export function routeFromPlatformThreadBinding(binding: PlatformThreadBindingLike): ScheduledJobRoute {
   return {
     type: routeTypeForPlatform(binding.platform),


### PR DESCRIPTION
## Summary
- Hoist `buildPlatformRuntimeEnv` into `scheduled-job-route.ts` so scheduler and automation executors share one implementation instead of byte-identical private copies.
- Extract `waitForRunCompletion` into a new `scheduler/run-polling.ts` for the same reason — only difference between originals was the error-message prefix.

## Sub-agent review (3 parallel, all CLEAN)
- **Reuse**: no existing helper covers this; both placements are the natural home (env builder beside `getChannelPlatformBase` / `routeTypeForPlatform`; run-polling in its own single-purpose file).
- **Quality**: naming and structural `RunStore` / `RunLike` types are appropriate; `label` parameter with two call sites is fine.
- **Efficiency**: no regressions — same allocations, same 300ms poll cadence, same call counts. Pre-existing follow-ups (AbortSignal, adaptive backoff) noted but out of scope.

## Test plan
- [x] `pnpm test` baseline 369 pass / 0 fail
- [x] `pnpm test` after refactor 369 pass / 0 fail
- [x] No behavior change — error messages preserved via `label` argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)