### PR TITLE
Share thread resolution across channel schedule adapters

### DIFF
--- a/services/local-ai-core/src/scheduler/base-channel-schedule-adapter.ts
+++ b/services/local-ai-core/src/scheduler/base-channel-schedule-adapter.ts
@@ -25,7 +25,7 @@ export abstract class BaseChannelScheduleAdapter implements SchedulerExecutorRun
     });
   }
 
-  abstract get deliveryTargets(): string[];
+  abstract readonly deliveryTargets: string[];
   protected abstract readonly platformBase: string;
   protected abstract readonly supportedRouteTypes: readonly string[];
 

--- a/services/local-ai-core/src/scheduler/base-channel-schedule-adapter.ts
+++ b/services/local-ai-core/src/scheduler/base-channel-schedule-adapter.ts
@@ -1,0 +1,117 @@
+import type { ScheduledJob } from '@cc/superai-contracts';
+import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
+import type { ChannelRuntime } from '@cc/plugin-sdk';
+import type { WorkspaceRouter } from '../router/workspace-router.js';
+import type { SchedulerExecutorRuntime, ScheduledExecutionContext, ScheduledExecutionResult } from './adapters.js';
+import type { ChannelExecutionPolicyOptions } from './channel-execution-policy.js';
+import type { ScheduledExecutionPolicy } from './execution-policy.js';
+import { ScheduledConversationExecutor } from './scheduled-conversation-executor.js';
+import { platformMatches } from './scheduled-job-route.js';
+
+export type BaseChannelScheduleAdapterOptions = {
+  store: LocalCoreAcpStore;
+  getWorkspaceRouter: () => WorkspaceRouter;
+  getChannelRuntime: () => ChannelRuntime;
+  log?: (message: string) => void;
+};
+
+export abstract class BaseChannelScheduleAdapter implements SchedulerExecutorRuntime {
+  private readonly executor: ScheduledConversationExecutor;
+
+  constructor(protected readonly options: BaseChannelScheduleAdapterOptions) {
+    this.executor = new ScheduledConversationExecutor({
+      store: options.store,
+      getWorkspaceRouter: options.getWorkspaceRouter,
+    });
+  }
+
+  abstract get deliveryTargets(): string[];
+  protected abstract readonly platformBase: string;
+  protected abstract readonly supportedRouteTypes: readonly string[];
+
+  supports(job: ScheduledJob) {
+    return platformMatches(job.platform, this.platformBase) && this.supportedRouteTypes.includes(job.route.type);
+  }
+
+  async execute(context: ScheduledExecutionContext): Promise<ScheduledExecutionResult> {
+    const { job } = context;
+    const executionPolicy = this.createPolicy(
+      job,
+      {
+        store: this.options.store,
+        workspaceRouter: this.options.getWorkspaceRouter(),
+        getChannelRuntime: this.options.getChannelRuntime,
+      },
+      (nextJob) => this.resolveThread(nextJob),
+      (nextJob) => this.preferredAgentFor(nextJob),
+    );
+    const execution = await this.executor.execute(job, job.promptTemplate, executionPolicy);
+    return {
+      threadId: execution.threadId,
+      runId: execution.runId,
+      replyText: execution.replyText,
+      deliveryMode: 'bridge-stream',
+      deliveryStatus: 'succeeded',
+      lastBridgeEventAt: new Date().toISOString(),
+    };
+  }
+
+  protected abstract createPolicy(
+    job: ScheduledJob,
+    options: ChannelExecutionPolicyOptions,
+    resolveSameThread: (job: ScheduledJob) => Promise<string>,
+    preferredAgentType: (job: ScheduledJob) => string,
+  ): ScheduledExecutionPolicy;
+
+  protected async resolveThread(job: ScheduledJob) {
+    const workspaceRouter = this.options.getWorkspaceRouter();
+    const route = job.route;
+    const channelId = route.channelId;
+    const participantId = route.participantId || '';
+    const binding = this.options.store.getPlatformThreadBinding(job.workspaceId, channelId, participantId, job.platform);
+    if (binding?.thread_id && await this.threadExists(binding.thread_id)) {
+      return binding.thread_id;
+    }
+    if (route.threadId && await this.threadExists(route.threadId)) {
+      return route.threadId;
+    }
+    const thread = await workspaceRouter.createThread(
+      job.workspaceId,
+      job.description || `Scheduled ${job.platform} task`,
+    );
+    const now = new Date().toISOString();
+    this.options.store.upsertPlatformThreadBinding({
+      workspace_id: job.workspaceId,
+      platform: job.platform,
+      chat_id: channelId,
+      platform_user_id: participantId,
+      thread_id: thread.id,
+      last_platform_message_id: null,
+      created_at: now,
+      updated_at: now,
+    });
+    const authorized = this.options.store.getAuthorizedUser(job.workspaceId, participantId, job.platform);
+    if (authorized) {
+      this.options.store.updateAuthorizedUserThread(job.workspaceId, participantId, thread.id, job.platform);
+    }
+    return thread.id;
+  }
+
+  private async threadExists(threadId: string) {
+    try {
+      await this.options.getWorkspaceRouter().getThread(threadId);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  protected preferredAgentFor(job: ScheduledJob): string {
+    const route = job.route;
+    const channelId = route.channelId;
+    if (!channelId) return '';
+    const participantId = route.participantId || '';
+    const binding = this.options.store.getPlatformThreadBinding(job.workspaceId, channelId, participantId, job.platform);
+    return binding?.preferred_agent_type || '';
+  }
+}

--- a/services/local-ai-core/src/scheduler/lark-schedule-adapter.ts
+++ b/services/local-ai-core/src/scheduler/lark-schedule-adapter.ts
@@ -7,10 +7,7 @@ import { createLarkExecutionPolicy } from './lark-execution-policies.js';
 export class LarkScheduleAdapter extends BaseChannelScheduleAdapter {
   protected readonly platformBase = 'lark';
   protected readonly supportedRouteTypes = ['channel.chat', 'lark_chat'] as const;
-
-  get deliveryTargets() {
-    return ['lark'];
-  }
+  readonly deliveryTargets = ['lark'];
 
   protected createPolicy(
     job: ScheduledJob,

--- a/services/local-ai-core/src/scheduler/lark-schedule-adapter.ts
+++ b/services/local-ai-core/src/scheduler/lark-schedule-adapter.ts
@@ -1,106 +1,23 @@
 import type { ScheduledJob } from '@cc/superai-contracts';
-import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
-import type { ChannelRuntime } from '@cc/plugin-sdk';
-import type { WorkspaceRouter } from '../router/workspace-router.js';
-import type { SchedulerExecutorRuntime, ScheduledExecutionContext, ScheduledExecutionResult } from './adapters.js';
-import { ScheduledConversationExecutor } from './scheduled-conversation-executor.js';
+import type { ChannelExecutionPolicyOptions } from './channel-execution-policy.js';
+import { BaseChannelScheduleAdapter } from './base-channel-schedule-adapter.js';
+import type { ScheduledExecutionPolicy } from './execution-policy.js';
 import { createLarkExecutionPolicy } from './lark-execution-policies.js';
-import { platformMatches } from './scheduled-job-route.js';
 
-type LarkScheduleAdapterOptions = {
-  store: LocalCoreAcpStore;
-  getWorkspaceRouter: () => WorkspaceRouter;
-  getChannelRuntime: () => ChannelRuntime;
-  log?: (message: string) => void;
-};
+export class LarkScheduleAdapter extends BaseChannelScheduleAdapter {
+  protected readonly platformBase = 'lark';
+  protected readonly supportedRouteTypes = ['channel.chat', 'lark_chat'] as const;
 
-export class LarkScheduleAdapter implements SchedulerExecutorRuntime {
-  private readonly executor: ScheduledConversationExecutor;
-  readonly deliveryTargets = ['lark'];
-
-  constructor(private readonly options: LarkScheduleAdapterOptions) {
-    this.executor = new ScheduledConversationExecutor({
-      store: options.store,
-      getWorkspaceRouter: options.getWorkspaceRouter,
-    });
+  get deliveryTargets() {
+    return ['lark'];
   }
 
-  supports(job: ScheduledJob) {
-    return platformMatches(job.platform, 'lark') && (job.route.type === 'channel.chat' || job.route.type === 'lark_chat');
-  }
-
-  async execute(context: ScheduledExecutionContext): Promise<ScheduledExecutionResult> {
-    const { job } = context;
-    const executionPolicy = createLarkExecutionPolicy(
-      job,
-      {
-        store: this.options.store,
-        workspaceRouter: this.options.getWorkspaceRouter(),
-        getChannelRuntime: this.options.getChannelRuntime,
-      },
-      (nextJob) => this.resolveThread(nextJob),
-      (nextJob) => this.preferredAgentFor(nextJob),
-    );
-    const execution = await this.executor.execute(job, job.promptTemplate, executionPolicy);
-    return {
-      threadId: execution.threadId,
-      runId: execution.runId,
-      replyText: execution.replyText,
-      deliveryMode: 'bridge-stream',
-      deliveryStatus: 'succeeded',
-      lastBridgeEventAt: new Date().toISOString(),
-    };
-  }
-
-  private async resolveThread(job: ScheduledJob) {
-    const workspaceRouter = this.options.getWorkspaceRouter();
-    const route = job.route;
-    const channelId = route.channelId;
-    const participantId = route.participantId || '';
-    const binding = this.options.store.getPlatformThreadBinding(job.workspaceId, channelId, participantId, job.platform);
-    if (binding?.thread_id && await this.threadExists(binding.thread_id)) {
-      return binding.thread_id;
-    }
-    if (route.threadId && await this.threadExists(route.threadId)) {
-      return route.threadId;
-    }
-    const thread = await workspaceRouter.createThread(
-      job.workspaceId,
-      job.description || `Scheduled ${job.platform} task`,
-    );
-    const now = new Date().toISOString();
-    this.options.store.upsertPlatformThreadBinding({
-      workspace_id: job.workspaceId,
-      platform: job.platform,
-      chat_id: channelId,
-      platform_user_id: participantId,
-      thread_id: thread.id,
-      last_platform_message_id: null,
-      created_at: now,
-      updated_at: now,
-    });
-    const authorized = this.options.store.getAuthorizedUser(job.workspaceId, participantId, job.platform);
-    if (authorized) {
-      this.options.store.updateAuthorizedUserThread(job.workspaceId, participantId, thread.id, job.platform);
-    }
-    return thread.id;
-  }
-
-  private async threadExists(threadId: string) {
-    try {
-      await this.options.getWorkspaceRouter().getThread(threadId);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private preferredAgentFor(job: ScheduledJob): string {
-    const route = job.route;
-    const channelId = route.channelId;
-    if (!channelId) return '';
-    const participantId = route.participantId || '';
-    const binding = this.options.store.getPlatformThreadBinding(job.workspaceId, channelId, participantId, job.platform);
-    return binding?.preferred_agent_type || '';
+  protected createPolicy(
+    job: ScheduledJob,
+    options: ChannelExecutionPolicyOptions,
+    resolveSameThread: (job: ScheduledJob) => Promise<string>,
+    preferredAgentType: (job: ScheduledJob) => string,
+  ): ScheduledExecutionPolicy {
+    return createLarkExecutionPolicy(job, options, resolveSameThread, preferredAgentType);
   }
 }

--- a/services/local-ai-core/src/scheduler/weixin-schedule-adapter.ts
+++ b/services/local-ai-core/src/scheduler/weixin-schedule-adapter.ts
@@ -1,106 +1,23 @@
 import type { ScheduledJob } from '@cc/superai-contracts';
-import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
-import type { ChannelRuntime } from '@cc/plugin-sdk';
-import type { WorkspaceRouter } from '../router/workspace-router.js';
-import type { SchedulerExecutorRuntime, ScheduledExecutionContext, ScheduledExecutionResult } from './adapters.js';
-import { ScheduledConversationExecutor } from './scheduled-conversation-executor.js';
+import type { ChannelExecutionPolicyOptions } from './channel-execution-policy.js';
+import { BaseChannelScheduleAdapter } from './base-channel-schedule-adapter.js';
+import type { ScheduledExecutionPolicy } from './execution-policy.js';
 import { createWeixinExecutionPolicy } from './weixin-execution-policies.js';
-import { platformMatches } from './scheduled-job-route.js';
 
-type WeixinScheduleAdapterOptions = {
-  store: LocalCoreAcpStore;
-  getWorkspaceRouter: () => WorkspaceRouter;
-  getChannelRuntime: () => ChannelRuntime;
-  log?: (message: string) => void;
-};
+export class WeixinScheduleAdapter extends BaseChannelScheduleAdapter {
+  protected readonly platformBase = 'weixin';
+  protected readonly supportedRouteTypes = ['channel.chat', 'weixin_chat'] as const;
 
-export class WeixinScheduleAdapter implements SchedulerExecutorRuntime {
-  private readonly executor: ScheduledConversationExecutor;
-  readonly deliveryTargets = ['weixin'];
-
-  constructor(private readonly options: WeixinScheduleAdapterOptions) {
-    this.executor = new ScheduledConversationExecutor({
-      store: options.store,
-      getWorkspaceRouter: options.getWorkspaceRouter,
-    });
+  get deliveryTargets() {
+    return ['weixin'];
   }
 
-  supports(job: ScheduledJob) {
-    return platformMatches(job.platform, 'weixin') && (job.route.type === 'channel.chat' || job.route.type === 'weixin_chat');
-  }
-
-  async execute(context: ScheduledExecutionContext): Promise<ScheduledExecutionResult> {
-    const { job } = context;
-    const executionPolicy = createWeixinExecutionPolicy(
-      job,
-      {
-        store: this.options.store,
-        workspaceRouter: this.options.getWorkspaceRouter(),
-        getChannelRuntime: this.options.getChannelRuntime,
-      },
-      (nextJob) => this.resolveThread(nextJob),
-      (nextJob) => this.preferredAgentFor(nextJob),
-    );
-    const execution = await this.executor.execute(job, job.promptTemplate, executionPolicy);
-    return {
-      threadId: execution.threadId,
-      runId: execution.runId,
-      replyText: execution.replyText,
-      deliveryMode: 'bridge-stream',
-      deliveryStatus: 'succeeded',
-      lastBridgeEventAt: new Date().toISOString(),
-    };
-  }
-
-  private async resolveThread(job: ScheduledJob) {
-    const workspaceRouter = this.options.getWorkspaceRouter();
-    const route = job.route;
-    const channelId = route.channelId;
-    const participantId = route.participantId || '';
-    const binding = this.options.store.getPlatformThreadBinding(job.workspaceId, channelId, participantId, job.platform);
-    if (binding?.thread_id && await this.threadExists(binding.thread_id)) {
-      return binding.thread_id;
-    }
-    if (route.threadId && await this.threadExists(route.threadId)) {
-      return route.threadId;
-    }
-    const thread = await workspaceRouter.createThread(
-      job.workspaceId,
-      job.description || `Scheduled ${job.platform} task`,
-    );
-    const now = new Date().toISOString();
-    this.options.store.upsertPlatformThreadBinding({
-      workspace_id: job.workspaceId,
-      platform: 'weixin',
-      chat_id: channelId,
-      platform_user_id: participantId,
-      thread_id: thread.id,
-      last_platform_message_id: null,
-      created_at: now,
-      updated_at: now,
-    });
-    const authorized = this.options.store.getAuthorizedUser(job.workspaceId, participantId, job.platform);
-    if (authorized) {
-      this.options.store.updateAuthorizedUserThread(job.workspaceId, participantId, thread.id, job.platform);
-    }
-    return thread.id;
-  }
-
-  private async threadExists(threadId: string) {
-    try {
-      await this.options.getWorkspaceRouter().getThread(threadId);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private preferredAgentFor(job: ScheduledJob): string {
-    const route = job.route;
-    const channelId = route.channelId;
-    if (!channelId) return '';
-    const participantId = route.participantId || '';
-    const binding = this.options.store.getPlatformThreadBinding(job.workspaceId, channelId, participantId, job.platform);
-    return binding?.preferred_agent_type || '';
+  protected createPolicy(
+    job: ScheduledJob,
+    options: ChannelExecutionPolicyOptions,
+    resolveSameThread: (job: ScheduledJob) => Promise<string>,
+    preferredAgentType: (job: ScheduledJob) => string,
+  ): ScheduledExecutionPolicy {
+    return createWeixinExecutionPolicy(job, options, resolveSameThread, preferredAgentType);
   }
 }

--- a/services/local-ai-core/src/scheduler/weixin-schedule-adapter.ts
+++ b/services/local-ai-core/src/scheduler/weixin-schedule-adapter.ts
@@ -7,10 +7,7 @@ import { createWeixinExecutionPolicy } from './weixin-execution-policies.js';
 export class WeixinScheduleAdapter extends BaseChannelScheduleAdapter {
   protected readonly platformBase = 'weixin';
   protected readonly supportedRouteTypes = ['channel.chat', 'weixin_chat'] as const;
-
-  get deliveryTargets() {
-    return ['weixin'];
-  }
+  readonly deliveryTargets = ['weixin'];
 
   protected createPolicy(
     job: ScheduledJob,


### PR DESCRIPTION
## Summary
- **Category: (b) Code reuse** — `lark-schedule-adapter.ts` and `weixin-schedule-adapter.ts` were ~95% byte-identical (only `platformBase`, route type strings, and the policy factory differed).
- Hoist `supports` / `execute` / `resolveThread` / `threadExists` / `preferredAgentFor` into a new abstract `BaseChannelScheduleAdapter`. Each platform now contributes only `platformBase`, `supportedRouteTypes`, `deliveryTargets`, and a thin `createPolicy` delegating to its existing `createLarkExecutionPolicy` / `createWeixinExecutionPolicy` factory.

## Incidental bug fix
The weixin adapter previously hardcoded `platform: 'weixin'` in `upsertPlatformThreadBinding` but used `job.platform` everywhere else (lookup, authorized-user). For instance-qualified jobs like `'weixin:foo'` the stored binding was unreachable. The base uses `job.platform` consistently, matching the lark adapter's existing behavior. No tests cover this edge case; flagged here for visibility.

## Sub-agent review (3 parallel, 1 iteration)
Round 1 returned NEEDS-CHANGES from 2 of 3 agents with overlapping concerns; the actionable one was that `deliveryTargets` as an abstract getter allocated a fresh array on every read. Round 2 converted it to an abstract `readonly` field (initialized once per subclass). The other concerns were either false positives (proposed `BaseChannelScheduleAdapterOptions & ChannelExecutionPolicyOptions` would force callers to provide both eager `workspaceRouter` and lazy `getWorkspaceRouter`) or pre-existing (out of scope). Final state: all three agents effectively clean.

- **Reuse**: no pre-existing base class; `LocalScheduleAdapter` correctly left out (different semantics). Two option types intentionally separate.
- **Quality**: `deliveryTargets` now `readonly`; weixin platform bug fix called out.
- **Efficiency**: efficiency-neutral vs the original inlined version — same allocations, same call counts, executor instantiated once per adapter in ctor.

## Test plan
- [x] `pnpm test` baseline 369 pass / 0 fail
- [x] `pnpm test` after refactor + review fix 369 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)