### PR TITLE
Share bridge event helpers across lark and weixin runtime-state

### DIFF
--- a/services/local-ai-core/src/channel/lark/runtime-state.ts
+++ b/services/local-ai-core/src/channel/lark/runtime-state.ts
@@ -1,5 +1,6 @@
 import type { DesktopBridgeEvent } from '@cc/superai-contracts';
 import type { LarkOutboundRender, LarkTurnState } from './types.js';
+import { pushUniqueLine, resolveBridgeEventKind } from '../shared/bridge-event-helpers.js';
 
 export function createLarkTurnState(sessionKey: string, sourceMessageId?: string) {
   const turn: LarkTurnState = {
@@ -250,13 +251,6 @@ function isThoughtBridgeEvent(event: DesktopBridgeEvent) {
   return kind === 'thought' || kind === 'plan';
 }
 
-function resolveBridgeEventKind(event: DesktopBridgeEvent) {
-  if (event.bridgeKind) {
-    return event.bridgeKind;
-  }
-  return event.type === 'status' ? 'status' : 'assistant';
-}
-
 function renderProcessText(kind: 'thought' | 'plan', content: string) {
   const text = content.trim();
   return kind === 'plan' ? `计划\n${text}` : text;
@@ -290,15 +284,5 @@ function fencedCode(value: string, language = '') {
 }
 
 function pushUniqueLarkTurnLine(target: string[], value: string) {
-  const normalized = value.trim();
-  if (!normalized) {
-    return;
-  }
-  if (target[target.length - 1] === normalized) {
-    return;
-  }
-  target.push(normalized);
-  if (target.length > 6) {
-    target.splice(0, target.length - 6);
-  }
+  pushUniqueLine(target, value, 6);
 }

--- a/services/local-ai-core/src/channel/shared/bridge-event-helpers.ts
+++ b/services/local-ai-core/src/channel/shared/bridge-event-helpers.ts
@@ -1,0 +1,22 @@
+import type { DesktopBridgeEvent } from '@cc/superai-contracts';
+
+export function resolveBridgeEventKind(event: DesktopBridgeEvent) {
+  if (event.bridgeKind) {
+    return event.bridgeKind;
+  }
+  return event.type === 'status' ? 'status' : 'assistant';
+}
+
+export function pushUniqueLine(target: string[], value: string, maxLines: number) {
+  const normalized = value.trim();
+  if (!normalized) {
+    return;
+  }
+  if (target[target.length - 1] === normalized) {
+    return;
+  }
+  target.push(normalized);
+  if (target.length > maxLines) {
+    target.splice(0, target.length - maxLines);
+  }
+}

--- a/services/local-ai-core/src/channel/weixin/runtime-state.ts
+++ b/services/local-ai-core/src/channel/weixin/runtime-state.ts
@@ -13,10 +13,6 @@ function renderBridgeContent(event: DesktopBridgeEvent): string {
   return [name, status].filter(Boolean).join(' - ');
 }
 
-function bridgeEventKind(event: DesktopBridgeEvent) {
-  return resolveBridgeEventKind(event);
-}
-
 function pushUnique(target: string[], value: string) {
   pushUniqueLine(target, value, 8);
 }
@@ -56,7 +52,7 @@ export function getOrCreateWeixinTurnState(turns: Map<string, WeixinTurnState>, 
 
 export function consumeWeixinBridgeEvent(turn: WeixinTurnState, event: DesktopBridgeEvent) {
   const content = renderBridgeContent(event);
-  const bridgeKind = bridgeEventKind(event);
+  const bridgeKind = resolveBridgeEventKind(event);
   if (event.type === 'typing_start') {
     Object.assign(turn, {
       processing: true,
@@ -136,7 +132,7 @@ export function renderWeixinTurnText(turn: WeixinTurnState): string {
 export function isTerminalWeixinBridgeMessage(event: DesktopBridgeEvent, rendered: string): boolean {
   if (event.type === 'buttons') return true;
   if (event.type !== 'reply') return false;
-  const kind = bridgeEventKind(event);
+  const kind = resolveBridgeEventKind(event);
   if (kind === 'tool' || kind === 'thought' || kind === 'plan' || kind === 'status') return false;
   return Boolean(rendered.trim());
 }

--- a/services/local-ai-core/src/channel/weixin/runtime-state.ts
+++ b/services/local-ai-core/src/channel/weixin/runtime-state.ts
@@ -1,5 +1,6 @@
 import type { DesktopBridgeEvent } from '@cc/superai-contracts';
 import type { WeixinTurnState } from './types.js';
+import { pushUniqueLine, resolveBridgeEventKind } from '../shared/bridge-event-helpers.js';
 
 function renderBridgeContent(event: DesktopBridgeEvent): string {
   const toolCall = event.toolCall;
@@ -13,14 +14,11 @@ function renderBridgeContent(event: DesktopBridgeEvent): string {
 }
 
 function bridgeEventKind(event: DesktopBridgeEvent) {
-  return event.bridgeKind || (event.type === 'status' ? 'status' : 'assistant');
+  return resolveBridgeEventKind(event);
 }
 
 function pushUnique(target: string[], value: string) {
-  const normalized = value.trim();
-  if (!normalized || target[target.length - 1] === normalized) return;
-  target.push(normalized);
-  if (target.length > 8) target.splice(0, target.length - 8);
+  pushUniqueLine(target, value, 8);
 }
 
 function flushPendingThought(turn: WeixinTurnState) {


### PR DESCRIPTION
## Summary
- **Category: (b) Code reuse** — `services/local-ai-core/src/channel/lark/runtime-state.ts` and `services/local-ai-core/src/channel/weixin/runtime-state.ts` each carried private copies of the bridge-event-kind resolver and the dedupe-and-cap line pusher.
- Hoist both into new `services/local-ai-core/src/channel/shared/bridge-event-helpers.ts`:
  - `resolveBridgeEventKind(event)` — identical 3-line bodies across both files.
  - `pushUniqueLine(target, value, maxLines)` — same logic, only the cap differs (lark=6, weixin=8). Each module keeps a thin wrapper that pins its cap so existing call sites stay readable.

## Sub-agent review (3 parallel, 1 iteration)
Round 1 returned CLEAN from all three agents. Two of three flagged the same nit: weixin's local `bridgeEventKind(event)` wrapper was a pure pass-through (lark already imported `resolveBridgeEventKind` directly). Round 2 dropped the wrapper and updated the two weixin call sites to call the shared helper directly. Final state: all three agents effectively clean.

- **Reuse**: no pre-existing helper covers this; `bridge-event-helpers.ts` is the right home (focused 22-line module, doesn't bloat `base-channel-gateway.ts`). No other reimplementation in the tree.
- **Quality**: helper names match codebase style; `maxLines: number` parameter is appropriate for per-platform tuning; wrappers preserve meaningful per-platform constants.
- **Efficiency**: efficiency-neutral vs inlined originals — V8 inlines the monomorphic wrappers; same allocations, same array ops.

## Test plan
- [x] `pnpm test` baseline 369 pass / 0 fail
- [x] `pnpm test` after refactor + review fix 369 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)