### PR TITLE
Share threadExists helper across scheduler adapters and automation executor

### DIFF
--- a/services/local-ai-core/src/automation/automation-conversation-executor.ts
+++ b/services/local-ai-core/src/automation/automation-conversation-executor.ts
@@ -5,6 +5,7 @@ import type { WorkspaceRouter } from '../router/workspace-router.js';
 import { ScheduledBridgeSession } from '../scheduler/scheduled-bridge-session.js';
 import { buildPlatformRuntimeEnv, getChannelPlatformBase } from '../scheduler/scheduled-job-route.js';
 import { waitForRunCompletion } from '../scheduler/run-polling.js';
+import { threadExists } from '../scheduler/thread-resolution.js';
 
 const MONITOR_RUN_PERMISSION_MODE = 'bypassPermissions';
 
@@ -82,10 +83,10 @@ export class AutomationConversationExecutor {
         monitor.route.participantId || '',
         monitor.platform,
       );
-      if (binding?.thread_id && await this.threadExists(binding.thread_id)) {
+      if (binding?.thread_id && await threadExists(workspaceRouter, binding.thread_id)) {
         return binding.thread_id;
       }
-      if (monitor.route.threadId && await this.threadExists(monitor.route.threadId)) {
+      if (monitor.route.threadId && await threadExists(workspaceRouter, monitor.route.threadId)) {
         return monitor.route.threadId;
       }
     }
@@ -99,15 +100,6 @@ export class AutomationConversationExecutor {
     }
     const created = await workspaceRouter.createThread(monitor.workspaceId, title);
     return created.id;
-  }
-
-  private async threadExists(threadId: string) {
-    try {
-      await this.options.getWorkspaceRouter().getThread(threadId);
-      return true;
-    } catch {
-      return false;
-    }
   }
 
 }

--- a/services/local-ai-core/src/scheduler/base-channel-schedule-adapter.ts
+++ b/services/local-ai-core/src/scheduler/base-channel-schedule-adapter.ts
@@ -7,6 +7,7 @@ import type { ChannelExecutionPolicyOptions } from './channel-execution-policy.j
 import type { ScheduledExecutionPolicy } from './execution-policy.js';
 import { ScheduledConversationExecutor } from './scheduled-conversation-executor.js';
 import { platformMatches } from './scheduled-job-route.js';
+import { threadExists } from './thread-resolution.js';
 
 export type BaseChannelScheduleAdapterOptions = {
   store: LocalCoreAcpStore;
@@ -69,10 +70,10 @@ export abstract class BaseChannelScheduleAdapter implements SchedulerExecutorRun
     const channelId = route.channelId;
     const participantId = route.participantId || '';
     const binding = this.options.store.getPlatformThreadBinding(job.workspaceId, channelId, participantId, job.platform);
-    if (binding?.thread_id && await this.threadExists(binding.thread_id)) {
+    if (binding?.thread_id && await threadExists(workspaceRouter, binding.thread_id)) {
       return binding.thread_id;
     }
-    if (route.threadId && await this.threadExists(route.threadId)) {
+    if (route.threadId && await threadExists(workspaceRouter, route.threadId)) {
       return route.threadId;
     }
     const thread = await workspaceRouter.createThread(
@@ -95,15 +96,6 @@ export abstract class BaseChannelScheduleAdapter implements SchedulerExecutorRun
       this.options.store.updateAuthorizedUserThread(job.workspaceId, participantId, thread.id, job.platform);
     }
     return thread.id;
-  }
-
-  private async threadExists(threadId: string) {
-    try {
-      await this.options.getWorkspaceRouter().getThread(threadId);
-      return true;
-    } catch {
-      return false;
-    }
   }
 
   protected preferredAgentFor(job: ScheduledJob): string {

--- a/services/local-ai-core/src/scheduler/local-schedule-adapter.ts
+++ b/services/local-ai-core/src/scheduler/local-schedule-adapter.ts
@@ -4,6 +4,7 @@ import type { WorkspaceRouter } from '../router/workspace-router.js';
 import type { SchedulerExecutorRuntime, ScheduledExecutionContext, ScheduledExecutionResult } from './adapters.js';
 import type { ScheduledExecutionPolicy } from './execution-policy.js';
 import { ScheduledConversationExecutor } from './scheduled-conversation-executor.js';
+import { threadExists } from './thread-resolution.js';
 
 type LocalScheduleAdapterOptions = {
   store: LocalCoreAcpStore;
@@ -51,7 +52,7 @@ export class LocalScheduleAdapter implements SchedulerExecutorRuntime {
 
   private async resolveThread(job: ScheduledJob) {
     const workspaceRouter = this.options.getWorkspaceRouter();
-    if (job.route.threadId && await this.threadExists(job.route.threadId)) {
+    if (job.route.threadId && await threadExists(workspaceRouter, job.route.threadId)) {
       return job.route.threadId;
     }
     const title = `[Scheduled] ${job.description || job.id}`;
@@ -62,15 +63,6 @@ export class LocalScheduleAdapter implements SchedulerExecutorRuntime {
     }
     const created = await workspaceRouter.createThread(job.workspaceId, title);
     return created.id;
-  }
-
-  private async threadExists(threadId: string) {
-    try {
-      await this.options.getWorkspaceRouter().getThread(threadId);
-      return true;
-    } catch {
-      return false;
-    }
   }
 
 }

--- a/services/local-ai-core/src/scheduler/thread-resolution.ts
+++ b/services/local-ai-core/src/scheduler/thread-resolution.ts
@@ -1,0 +1,10 @@
+import type { WorkspaceRouter } from '../router/workspace-router.js';
+
+export async function threadExists(router: WorkspaceRouter, threadId: string): Promise<boolean> {
+  try {
+    await router.getThread(threadId);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- **Category: (b) Code reuse** — `LocalScheduleAdapter`, `BaseChannelScheduleAdapter`, and `AutomationConversationExecutor` each carried a private byte-identical `threadExists(threadId): Promise<boolean>` helper.
- Extracted into a single `threadExists(router, threadId)` function in new `services/local-ai-core/src/scheduler/thread-resolution.ts`. All three callers now share one definition.

## Sub-agent review (3 parallel, 1 round — all CLEAN)
Round 1 returned CLEAN from all three agents. The Reuse agent flagged a third byte-identical copy in `automation-conversation-executor.ts` (the original PR only covered the two scheduler adapters). Round 2 folded the automation executor into the shared helper. Final state: all three agents effectively clean.

- **Reuse**: no pre-existing helper; `thread-resolution.ts` is the right home (free function, type-only WorkspaceRouter import). Title-scan unification between `LocalScheduleAdapter` and `SideThreadChannelExecutionPolicy` correctly deferred — single title vs reusable-title-set + targetAgent have semantically different shapes.
- **Quality**: free function beats method-on-router (avoids coupling `WorkspaceRouter` to "does this thread exist" semantics); explicit `router` parameter is cleaner than capturing `this.options.getWorkspaceRouter()`; broad `catch {}` matches original semantics.
- **Efficiency**: behavior-preserving; minor positive — `resolveThread` now captures `workspaceRouter` once instead of calling `getWorkspaceRouter()` repeatedly.

## Test plan
- [x] `pnpm test` baseline 369 pass / 0 fail
- [x] `pnpm test` after both rounds 369 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)