### PR TITLE
Share extractChannelInstanceId helper across channel gateways

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -35,7 +35,7 @@ import {
   renderPendingPairingCard,
   renderPermissionCard,
 } from './cards.js';
-import { channelPlatformKey, runtimeKey } from '../shared/channel-keys.js';
+import { channelPlatformKey, extractChannelInstanceId, runtimeKey } from '../shared/channel-keys.js';
 import { collectLarkWorkspaceBindings } from './config.js';
 import {
   DEFAULT_LARK_QR_EXPIRES_IN,
@@ -176,7 +176,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     threadId: string;
     sessionKey: string;
   }) {
-    const instanceId = input.route.instanceId || getLarkInstanceId(input.platform) || 'default';
+    const instanceId = input.route.instanceId || extractChannelInstanceId(input.platform, 'lark') || 'default';
     const platformKey = channelPlatformKey('lark', instanceId);
     const route: LarkThreadRoute = {
       workspaceId: input.workspaceId,
@@ -885,7 +885,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     if (!binding || (binding.platform !== 'lark' && !binding.platform.startsWith('lark:'))) {
       return undefined;
     }
-    const bindingInstanceId = getLarkInstanceId(binding.platform) || instanceId || 'default';
+    const bindingInstanceId = extractChannelInstanceId(binding.platform, 'lark') || instanceId || 'default';
     return {
       workspaceId: binding.workspace_id,
       instanceId: bindingInstanceId,
@@ -992,9 +992,4 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     this.options.log?.(`localcore-lark bridge event produced empty render for sessionKey=${sessionKey} type=${type}`);
   }
 
-}
-
-function getLarkInstanceId(platform: string) {
-  const normalized = String(platform || '').trim();
-  return normalized.startsWith('lark:') ? normalized.slice('lark:'.length).trim() : '';
 }

--- a/services/local-ai-core/src/channel/shared/channel-keys.ts
+++ b/services/local-ai-core/src/channel/shared/channel-keys.ts
@@ -8,6 +8,12 @@ export function channelPlatformKey(platform: string, instanceId: string) {
   return instanceId === 'default' ? platform : `${platform}:${instanceId}`;
 }
 
+export function extractChannelInstanceId(platform: string, prefix: string): string {
+  const normalized = String(platform || '').trim();
+  const tag = `${prefix}:`;
+  return normalized.startsWith(tag) ? normalized.slice(tag.length).trim() : '';
+}
+
 export function runtimeKey(workspaceId: string, instanceId: string) {
   return `${workspaceId}::${instanceId}`;
 }

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -27,7 +27,7 @@ import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '.
 import { resolveChannelThreadRoute } from '../shared/thread-routing.js';
 import { BaseChannelGateway, type GatewayBinding, type GatewayRuntimeState, type GatewayThreadRoute } from '../shared/base-channel-gateway.js';
 import { resolveInboundChannelAuthorization } from '../shared/inbound-authorization.js';
-import { channelPlatformKey, runtimeKey } from '../shared/channel-keys.js';
+import { channelPlatformKey, extractChannelInstanceId, runtimeKey } from '../shared/channel-keys.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
 import { parseSlashCommand } from '../../acp/local-core-slash-commands.js';
@@ -346,7 +346,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     threadId: string;
     sessionKey: string;
   }) {
-    const instanceId = input.route.instanceId || getWeixinInstanceId(input.platform) || 'default';
+    const instanceId = input.route.instanceId || extractChannelInstanceId(input.platform, 'weixin') || 'default';
     const platformKey = channelPlatformKey('weixin', instanceId);
     const route: WeixinThreadRoute = {
       workspaceId: input.workspaceId,
@@ -886,9 +886,4 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
 
 
 
-}
-
-function getWeixinInstanceId(platform: string) {
-  const normalized = String(platform || '').trim();
-  return normalized.startsWith('weixin:') ? normalized.slice('weixin:'.length).trim() : '';
 }


### PR DESCRIPTION
## Summary
- **Category**: b) Code Reuse
- Adds `extractChannelInstanceId(platform, prefix)` to `services/local-ai-core/src/channel/shared/channel-keys.ts`.
- Deletes the byte-identical `getLarkInstanceId` (lark gateway) and `getWeixinInstanceId` (weixin gateway) helpers — 4 lines each, differing only in the platform prefix literal (`'lark:'` vs `'weixin:'`).
- Three call sites updated to use the shared helper directly.

## Motivation
The two per-gateway helpers were copy-paste with a single literal difference. The new helper sits next to its structural inverse `channelPlatformKey` (which composes `${platform}:${instanceId}`), so the file now correctly owns both directions of the platform/instanceId round-trip. Follows the same shape as PR #24 (`threadExists` consolidation).

## Sub-agent review summary
**Round 1** (3 parallel agents, all CLEAN):
- **Code Reuse**: No missed call sites; the helper's location is the correct home. Adjacent `startsWith/slice` patterns in `scheduler/job-id.ts` and `automation/monitor-id.ts` use static prefixes in different domains — leaving them untouched is correct.
- **Code Quality**: Behavior parity verified across all edge cases (empty, undefined, malformed, no-colon, empty-instance, leading/trailing whitespace). Typo risk on the `prefix` parameter is acceptable — call sites immediately pair with `channelPlatformKey('lark'|'weixin', ...)` which provides visual cross-check.
- **Efficiency**: Allocation-neutral; same operations as the originals. Call sites are not on tight hot paths.

## Validation
- `pnpm test` → 369 pass / 0 fail (baseline and after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)