### PR TITLE
Reuse shared toPublicAutomationMonitorId in monitor service

### DIFF
--- a/services/local-ai-core/src/automation/automation-monitor-service.ts
+++ b/services/local-ai-core/src/automation/automation-monitor-service.ts
@@ -18,6 +18,7 @@ import {
 import { evaluateMonitorCondition } from './condition-evaluator.js';
 import { AutomationConversationExecutor } from './automation-conversation-executor.js';
 import { AutomationMonitorRepository, type ResolvedAutomationMonitorCreateInput } from './automation-monitor-repository.js';
+import { toPublicAutomationMonitorId } from './monitor-id.js';
 
 type AutomationMonitorServiceOptions = {
   store: LocalCoreAcpStore;
@@ -316,7 +317,7 @@ export class AutomationMonitorService {
     }
     const matches = this.repository
       .list()
-      .filter((monitor) => publicMonitorId(monitor.id) === monitorId);
+      .filter((monitor) => toPublicAutomationMonitorId(monitor.id) === monitorId);
     if (matches.length === 0) {
       return '';
     }
@@ -393,7 +394,3 @@ export class AutomationMonitorService {
   }
 }
 
-function publicMonitorId(monitorId: string) {
-  const normalized = monitorId.startsWith('monitor:') ? monitorId.slice('monitor:'.length) : monitorId;
-  return normalized.includes('-') ? normalized.split('-')[0] || normalized : normalized;
-}


### PR DESCRIPTION
## Summary
- **Category**: b) Code Reuse
- Deletes the local `publicMonitorId` helper in `automation-monitor-service.ts` and routes its single call site through the existing `toPublicAutomationMonitorId` export in `monitor-id.ts`.

## Motivation
The local helper and the shared export performed the same prefix-strip + first-segment split, but with one difference: the shared helper validates a strict UUID shape before splitting, while the local one split on any hyphen. For real monitor IDs — always `monitor:${randomUUID()}` per `automation-monitor-store.ts:315` — both produce identical output, so the duplication was pure dead weight. The CLI (`lac.ts`) already used the shared export, so consolidating puts both consumers on the same path. Follows the same shape as PR #24 (`threadExists` consolidation) and PR #28 (`extractChannelInstanceId`).

## Sub-agent review summary
**Round 1** (3 parallel agents, all CLEAN):
- **Code Reuse**: No missed call sites; the scheduler equivalent (`toPublicScheduledJobId`) was already consolidated in PR #24 — symmetry confirmed.
- **Code Quality**: Behavior parity verified for all real inputs (`monitor:<uuid-v4>`). The new helper's stricter UUID guard is actually more defensive against hypothetical non-UUID inputs — no regression risk in current code since monitor IDs come exclusively from `randomUUID()`. Lookup semantics preserved for all 3 input shapes (full `monitor:uuid`, bare `uuid`, already-public `first-segment`).
- **Efficiency**: Path is admin/CLI-driven, not per-message. Single regex match against a 36-char string is sub-microsecond and noise next to the `repository.list().filter(...)` it supports. Allocation-neutral or slightly better.

## Validation
- `pnpm test` → 369 pass / 0 fail (baseline and after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)