### PR TITLE
Reuse isWeixinApiError in inbound poller

### DIFF
--- a/services/local-ai-core/src/channel/weixin/inbound-poller.ts
+++ b/services/local-ai-core/src/channel/weixin/inbound-poller.ts
@@ -6,6 +6,7 @@ import {
   FILE_ITEM_TYPE,
   getWeixinUpdates,
   IMAGE_ITEM_TYPE,
+  isWeixinApiError,
   TEXT_ITEM_TYPE,
   VOICE_ITEM_TYPE,
 } from './transport.js';
@@ -64,8 +65,7 @@ export async function runWeixinInboundPoller(input: {
   while (!signal.aborted) {
     try {
       const resp = await getWeixinUpdates(binding, buf, signal);
-      const isApiError = (resp.ret !== undefined && resp.ret !== 0) || (resp.errcode !== undefined && resp.errcode !== 0);
-      if (isApiError) {
+      if (isWeixinApiError(resp)) {
         consecutiveFailures += 1;
         const state = input.getRuntimeState();
         const retryDelayMs = computeRetryDelay(consecutiveFailures);

--- a/services/local-ai-core/src/channel/weixin/transport.ts
+++ b/services/local-ai-core/src/channel/weixin/transport.ts
@@ -226,6 +226,6 @@ export async function uploadEncryptedBufferToWeixinCdn(
   return encryptedQueryParam;
 }
 
-export function isWeixinApiError(resp: SendMessageResp | GetUploadUrlResp): boolean {
+export function isWeixinApiError(resp: { ret?: number; errcode?: number }): boolean {
   return (resp.ret !== undefined && resp.ret !== 0) || (resp.errcode !== undefined && resp.errcode !== 0);
 }


### PR DESCRIPTION
## Summary
- **Category**: b) Code Reuse
- Broadens the parameter type of `isWeixinApiError` from the union `SendMessageResp | GetUploadUrlResp` to the minimal structural shape `{ ret?: number; errcode?: number }` so callers can pass any of the three WeChat response types sharing that prefix.
- Imports and calls `isWeixinApiError(resp)` in `inbound-poller.ts:67` instead of inlining the same boolean expression on a `GetUpdatesResp` value.

## Motivation
The three WeChat API response types (`GetUpdatesResp`, `SendMessageResp`, `GetUploadUrlResp` in `weixin/types.ts:127-147`) all share the structural prefix `{ ret?: number; errcode?: number; errmsg?: string }`. The original union type on `isWeixinApiError` was artificially narrow — it covered only two of the three shapes that share the error semantics, forcing the inbound poller to inline the identical predicate. Structural typing is the natural fit here.

## Sub-agent review summary
**Round 1** (3 parallel agents, all CLEAN):
- **Code Reuse**: All 4 existing call sites in `local-core-weixin-gateway.ts` (3 calls + import) and the new poller site are structurally compatible. No other inlined copies of the predicate remain. The 2 QR-code sites at gateway:211/228 use a slightly different semantics against `QrCodeStatusResp` (which lacks `ret`), so they correctly stay inline — flagged as pre-existing, not introduced by this diff.
- **Code Quality**: Type safety preserved (TS structural typing — all callers still type-check). Behavior parity byte-identical. Imports correctly alphabetized; `SendMessageResp`/`GetUploadUrlResp` still imported in `transport.ts` and used elsewhere in that file. No dead code.
- **Efficiency**: Hot-path-replacing inline with a 1-line function call — V8 inlines monomorphic small functions, JIT output effectively identical. Poller blocks on a ~30s HTTP long-poll plus retry backoff; the helper is irrelevant noise.

## Validation
- `pnpm test` → 369 pass / 0 fail (baseline and after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)