### PR TITLE
Extract applyWeixinAuthHeaders helper in weixin transport

### DIFF
--- a/services/local-ai-core/src/channel/weixin/transport.ts
+++ b/services/local-ai-core/src/channel/weixin/transport.ts
@@ -28,6 +28,13 @@ export function createIlinkHeaders(): Record<string, string> {
   };
 }
 
+export function applyWeixinAuthHeaders(headers: Record<string, string>, binding: WeixinWorkspaceBinding) {
+  if (binding.token) {
+    headers.AuthorizationType = 'ilink_bot_token';
+    headers.Authorization = `Bearer ${binding.token}`;
+  }
+}
+
 export async function weixinApiPost<T>(
   binding: WeixinWorkspaceBinding,
   endpoint: string,
@@ -50,10 +57,7 @@ export async function weixinApiPost<T>(
       'X-WECHAT-UIN': createWechatUin(),
       ...createIlinkHeaders(),
     };
-    if (binding.token) {
-      headers.AuthorizationType = 'ilink_bot_token';
-      headers.Authorization = `Bearer ${binding.token}`;
-    }
+    applyWeixinAuthHeaders(headers, binding);
     const res = await fetch(url, {
       method: 'POST',
       headers,
@@ -78,10 +82,7 @@ export async function weixinApiGet<T>(
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const headers: Record<string, string> = createIlinkHeaders();
-    if (binding.token) {
-      headers.AuthorizationType = 'ilink_bot_token';
-      headers.Authorization = `Bearer ${binding.token}`;
-    }
+    applyWeixinAuthHeaders(headers, binding);
     const res = await fetch(url, {
       method: 'GET',
       headers,


### PR DESCRIPTION
## Summary
- Extract the duplicated 3-line `ilink_bot_token` auth-header block from `weixinApiPost` and `weixinApiGet` into a single exported `applyWeixinAuthHeaders(headers, binding)` helper in `services/local-ai-core/src/channel/weixin/transport.ts`.

## Validation
- `pnpm test` — 369 pass / 0 fail (baseline preserved)
- Parallel sub-agent review (Code Reuse / Code Quality / Efficiency): all CLEAN on first pass, no iterations required
- Grep confirms `ilink_bot_token` / `AuthorizationType` appears only inside the new helper — no remaining inline copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)