### PR TITLE
Extract getLatestAssistantFinalContent helper

### DIFF
--- a/services/local-ai-core/src/automation/automation-conversation-executor.ts
+++ b/services/local-ai-core/src/automation/automation-conversation-executor.ts
@@ -5,7 +5,7 @@ import type { WorkspaceRouter } from '../router/workspace-router.js';
 import { ScheduledBridgeSession } from '../scheduler/scheduled-bridge-session.js';
 import { buildPlatformRuntimeEnv, getChannelPlatformBase } from '../scheduler/scheduled-job-route.js';
 import { waitForRunCompletion } from '../scheduler/run-polling.js';
-import { threadExists } from '../scheduler/thread-resolution.js';
+import { getLatestAssistantFinalContent, threadExists } from '../scheduler/thread-resolution.js';
 
 const MONITOR_RUN_PERMISSION_MODE = 'bypassPermissions';
 
@@ -57,10 +57,7 @@ export class AutomationConversationExecutor {
       });
       await waitForRunCompletion(this.options.store, sendResult.runId, timeoutMs, 'Monitor');
       const thread = await workspaceRouter.getThread(threadId);
-      const replyText = [...thread.messages]
-        .reverse()
-        .find((message) => message.role === 'assistant' && message.kind === 'final')
-        ?.content;
+      const replyText = getLatestAssistantFinalContent(thread);
       return {
         threadId,
         runId: sendResult.runId,

--- a/services/local-ai-core/src/scheduler/scheduled-conversation-executor.ts
+++ b/services/local-ai-core/src/scheduler/scheduled-conversation-executor.ts
@@ -5,6 +5,7 @@ import type { ScheduledExecutionTarget } from './adapters.js';
 import type { ScheduledExecutionPolicy } from './execution-policy.js';
 import { buildPlatformRuntimeEnv } from './scheduled-job-route.js';
 import { waitForRunCompletion } from './run-polling.js';
+import { getLatestAssistantFinalContent } from './thread-resolution.js';
 
 const SCHEDULED_RUN_PERMISSION_MODE = 'bypassPermissions';
 
@@ -27,10 +28,7 @@ export class ScheduledConversationExecutor {
       });
       await waitForRunCompletion(this.options.store, sendResult.runId, timeoutMs, 'Scheduled');
       const thread = await workspaceRouter.getThread(target.threadId);
-      const replyText = [...thread.messages]
-        .reverse()
-        .find((message) => message.role === 'assistant' && message.kind === 'final')
-        ?.content;
+      const replyText = getLatestAssistantFinalContent(thread);
       return {
         threadId: target.threadId,
         runId: sendResult.runId,

--- a/services/local-ai-core/src/scheduler/thread-resolution.ts
+++ b/services/local-ai-core/src/scheduler/thread-resolution.ts
@@ -1,3 +1,4 @@
+import type { ThreadDetail } from '@cc/superai-contracts';
 import type { WorkspaceRouter } from '../router/workspace-router.js';
 
 export async function threadExists(router: WorkspaceRouter, threadId: string): Promise<boolean> {
@@ -7,4 +8,14 @@ export async function threadExists(router: WorkspaceRouter, threadId: string): P
   } catch {
     return false;
   }
+}
+
+export function getLatestAssistantFinalContent(thread: ThreadDetail): string | undefined {
+  for (let i = thread.messages.length - 1; i >= 0; i -= 1) {
+    const message = thread.messages[i];
+    if (message && message.role === 'assistant' && message.kind === 'final') {
+      return message.content;
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Category: **(b) Code Reuse**
- Extract the duplicated 4-line "extract last assistant final message" block from `ScheduledConversationExecutor` and `AutomationConversationExecutor` into a single exported `getLatestAssistantFinalContent(thread)` helper in `services/local-ai-core/src/scheduler/thread-resolution.ts` (where `threadExists` already lived and where the automation executor already imported from).
- Behavior-preserving: backward iteration with the same predicate `role === 'assistant' && kind === 'final'`. Drops the `[...arr].reverse()` allocation/copy.

## Motivation
Two adjacent executors (~40 lines apart in concept) had byte-identical inline logic for "what was the assistant's final reply?". Easy to drift apart; one home for the predicate makes future intent changes (e.g. new message kind, different filter) a single-edit update.

## Sub-agent review
3 parallel reviews dispatched (Code Reuse / Code Quality / Efficiency):
- **Code Reuse**: CLEAN. Flagged adjacent spots in `acp-turn-coordinator.ts` and `acp-backend.ts` with similar predicates but different semantics (one omits the `kind === 'final'` filter; one collects all matches), correctly out of scope.
- **Code Quality**: CLEAN. Iteration order matches `[...].reverse().find(...)`. `kind` is optional in `ThreadMessage` and correctly narrowed by `=== 'final'`. `message &&` guard is harmless defense under current tsconfig.
- **Efficiency**: CLEAN. Both call sites are one-shot per job execution (post `waitForRunCompletion`), so allocation/function-call overhead is immeasurable. Array-copy elimination is marginal but free.

Rounds: 1 (no iteration needed).

## Validation
- `pnpm test` — 369 pass / 0 fail (baseline preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)