### PR TITLE
Collapse automation tick N+1 into a single indexed due-query

### DIFF
--- a/services/local-ai-core/src/acp/store/automation-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-store.ts
@@ -492,10 +492,11 @@ export class LocalAutomationStore {
     return row?.next_check_at ?? null;
   }
 
-  listDueAutomationIds(nowIso: string): Set<string> {
+  listDueAutomationIds(now: Date): Set<string> {
     const rows = this.db.prepare(
-      'SELECT id FROM automations WHERE next_check_at IS NOT NULL AND next_check_at <= ?',
-    ).all(nowIso) as { id: string }[];
+      `SELECT id FROM automations
+       WHERE enabled = 1 AND health = 'healthy' AND next_check_at IS NOT NULL AND next_check_at <= ?`,
+    ).all(now.toISOString()) as { id: string }[];
     return new Set(rows.map((row) => row.id));
   }
 

--- a/services/local-ai-core/src/acp/store/automation-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-store.ts
@@ -492,6 +492,19 @@ export class LocalAutomationStore {
     return row?.next_check_at ?? null;
   }
 
+  listNextCheckAtById(workspaceId?: string): Map<string, string> {
+    const rows = this.db.prepare(`
+      SELECT id, next_check_at
+      FROM automations
+      ${workspaceId ? 'WHERE workspace_id = ?' : ''}
+    `).all(...(workspaceId ? [workspaceId] : [])) as { id: string; next_check_at: string | null }[];
+    const result = new Map<string, string>();
+    for (const row of rows) {
+      if (row.next_check_at) result.set(row.id, row.next_check_at);
+    }
+    return result;
+  }
+
   private toDefinition(row: LocalAutomationRow): AutomationDefinition {
     try {
       return normalizeDefinition({

--- a/services/local-ai-core/src/acp/store/automation-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-store.ts
@@ -492,17 +492,11 @@ export class LocalAutomationStore {
     return row?.next_check_at ?? null;
   }
 
-  listNextCheckAtById(workspaceId?: string): Map<string, string> {
-    const rows = this.db.prepare(`
-      SELECT id, next_check_at
-      FROM automations
-      ${workspaceId ? 'WHERE workspace_id = ?' : ''}
-    `).all(...(workspaceId ? [workspaceId] : [])) as { id: string; next_check_at: string | null }[];
-    const result = new Map<string, string>();
-    for (const row of rows) {
-      if (row.next_check_at) result.set(row.id, row.next_check_at);
-    }
-    return result;
+  listDueAutomationIds(nowIso: string): Set<string> {
+    const rows = this.db.prepare(
+      'SELECT id FROM automations WHERE next_check_at IS NOT NULL AND next_check_at <= ?',
+    ).all(nowIso) as { id: string }[];
+    return new Set(rows.map((row) => row.id));
   }
 
   private toDefinition(row: LocalAutomationRow): AutomationDefinition {

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -434,8 +434,8 @@ export class LocalCoreAcpStore {
     return this.automations.getNextCheckAt(automationId);
   }
 
-  listAutomationNextCheckAtById(workspaceId?: string): Map<string, string> {
-    return this.automations.listNextCheckAtById(workspaceId);
+  listDueAutomationIds(nowIso: string): Set<string> {
+    return this.automations.listDueAutomationIds(nowIso);
   }
 
   createAutomation(input: AutomationCreateInput): AutomationDefinition {

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -434,8 +434,8 @@ export class LocalCoreAcpStore {
     return this.automations.getNextCheckAt(automationId);
   }
 
-  listDueAutomationIds(nowIso: string): Set<string> {
-    return this.automations.listDueAutomationIds(nowIso);
+  listDueAutomationIds(now: Date): Set<string> {
+    return this.automations.listDueAutomationIds(now);
   }
 
   createAutomation(input: AutomationCreateInput): AutomationDefinition {

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -434,6 +434,10 @@ export class LocalCoreAcpStore {
     return this.automations.getNextCheckAt(automationId);
   }
 
+  listAutomationNextCheckAtById(workspaceId?: string): Map<string, string> {
+    return this.automations.listNextCheckAtById(workspaceId);
+  }
+
   createAutomation(input: AutomationCreateInput): AutomationDefinition {
     return this.automations.create(input);
   }

--- a/services/local-ai-core/src/automation/automation-service.ts
+++ b/services/local-ai-core/src/automation/automation-service.ts
@@ -387,10 +387,12 @@ export class AutomationService {
   private async runTick(generation: number): Promise<void> {
     const now = this.now();
     const due: AutomationDefinition[] = [];
+    const nextCheckAtById = this.options.store.listAutomationNextCheckAtById();
+    const nowMs = now.getTime();
     for (const automation of this.list()) {
       if (!this.shouldPoll(automation)) continue;
-      const nextCheckAt = this.options.store.getAutomationNextCheckAt(automation.id);
-      if (nextCheckAt !== null && Date.parse(nextCheckAt) <= now.getTime()) {
+      const nextCheckAt = nextCheckAtById.get(automation.id);
+      if (nextCheckAt !== undefined && Date.parse(nextCheckAt) <= nowMs) {
         due.push(automation);
       }
     }

--- a/services/local-ai-core/src/automation/automation-service.ts
+++ b/services/local-ai-core/src/automation/automation-service.ts
@@ -387,12 +387,10 @@ export class AutomationService {
   private async runTick(generation: number): Promise<void> {
     const now = this.now();
     const due: AutomationDefinition[] = [];
-    const nextCheckAtById = this.options.store.listAutomationNextCheckAtById();
-    const nowMs = now.getTime();
+    const dueIds = this.options.store.listDueAutomationIds(now.toISOString());
     for (const automation of this.list()) {
       if (!this.shouldPoll(automation)) continue;
-      const nextCheckAt = nextCheckAtById.get(automation.id);
-      if (nextCheckAt !== undefined && Date.parse(nextCheckAt) <= nowMs) {
+      if (dueIds.has(automation.id)) {
         due.push(automation);
       }
     }

--- a/services/local-ai-core/src/automation/automation-service.ts
+++ b/services/local-ai-core/src/automation/automation-service.ts
@@ -387,7 +387,7 @@ export class AutomationService {
   private async runTick(generation: number): Promise<void> {
     const now = this.now();
     const due: AutomationDefinition[] = [];
-    const dueIds = this.options.store.listDueAutomationIds(now.toISOString());
+    const dueIds = this.options.store.listDueAutomationIds(now);
     for (const automation of this.list()) {
       if (!this.shouldPoll(automation)) continue;
       if (dueIds.has(automation.id)) {

--- a/tests/electron/automation-store.test.ts
+++ b/tests/electron/automation-store.test.ts
@@ -74,6 +74,32 @@ test('creates, reads, updates, and persists trusted automation state', () => {
   }
 });
 
+test('listNextCheckAtById returns only automations with a scheduled next check in a single query', () => {
+  const context = fixture();
+  try {
+    const withCheck = context.store.create(createInput({ title: 'With next check' }));
+    const nullCheck = context.store.create(createInput({ title: 'Without next check' }));
+    context.store.updateState(withCheck.id, { nextCheckAt: '2026-07-05T01:05:00.000Z' });
+
+    const storeMap = context.store.listNextCheckAtById();
+    assert.equal(storeMap.size, 1);
+    assert.equal(storeMap.get(withCheck.id), '2026-07-05T01:05:00.000Z');
+    assert.equal(storeMap.has(nullCheck.id), false);
+
+    const facadeMap = context.facade.listAutomationNextCheckAtById();
+    assert.equal(facadeMap.size, 1);
+    assert.equal(facadeMap.get(withCheck.id), '2026-07-05T01:05:00.000Z');
+
+    const otherWorkspace = context.store.create(createInput({ workspaceId: 'workspace-2', title: 'Other workspace' }));
+    context.store.updateState(otherWorkspace.id, { nextCheckAt: '2026-07-05T02:00:00.000Z' });
+    const scoped = context.store.listNextCheckAtById('workspace-2');
+    assert.equal(scoped.size, 1);
+    assert.equal(scoped.get(otherWorkspace.id), '2026-07-05T02:00:00.000Z');
+  } finally {
+    context.close();
+  }
+});
+
 test('reconciles queued and running action runs as interrupted after restart', () => {
   const context = fixture();
   try {

--- a/tests/electron/automation-store.test.ts
+++ b/tests/electron/automation-store.test.ts
@@ -74,27 +74,29 @@ test('creates, reads, updates, and persists trusted automation state', () => {
   }
 });
 
-test('listNextCheckAtById returns only automations with a scheduled next check in a single query', () => {
+test('listDueAutomationIds returns only automations whose next_check_at is at or before now', () => {
   const context = fixture();
   try {
-    const withCheck = context.store.create(createInput({ title: 'With next check' }));
-    const nullCheck = context.store.create(createInput({ title: 'Without next check' }));
-    context.store.updateState(withCheck.id, { nextCheckAt: '2026-07-05T01:05:00.000Z' });
+    const due = context.store.create(createInput({ title: 'Due' }));
+    const future = context.store.create(createInput({ title: 'Future' }));
+    const unset = context.store.create(createInput({ title: 'Unset' }));
+    context.store.updateState(due.id, { nextCheckAt: '2026-07-05T01:05:00.000Z' });
+    context.store.updateState(future.id, { nextCheckAt: '2026-07-05T02:00:00.000Z' });
 
-    const storeMap = context.store.listNextCheckAtById();
-    assert.equal(storeMap.size, 1);
-    assert.equal(storeMap.get(withCheck.id), '2026-07-05T01:05:00.000Z');
-    assert.equal(storeMap.has(nullCheck.id), false);
+    const atDue = context.store.listDueAutomationIds('2026-07-05T01:05:00.000Z');
+    assert.equal(atDue.size, 1);
+    assert.equal(atDue.has(due.id), true);
+    assert.equal(atDue.has(future.id), false);
+    assert.equal(atDue.has(unset.id), false);
 
-    const facadeMap = context.facade.listAutomationNextCheckAtById();
-    assert.equal(facadeMap.size, 1);
-    assert.equal(facadeMap.get(withCheck.id), '2026-07-05T01:05:00.000Z');
+    const atLater = context.store.listDueAutomationIds('2026-07-05T02:00:00.000Z');
+    assert.equal(atLater.size, 2);
+    assert.equal(atLater.has(due.id), true);
+    assert.equal(atLater.has(future.id), true);
 
-    const otherWorkspace = context.store.create(createInput({ workspaceId: 'workspace-2', title: 'Other workspace' }));
-    context.store.updateState(otherWorkspace.id, { nextCheckAt: '2026-07-05T02:00:00.000Z' });
-    const scoped = context.store.listNextCheckAtById('workspace-2');
-    assert.equal(scoped.size, 1);
-    assert.equal(scoped.get(otherWorkspace.id), '2026-07-05T02:00:00.000Z');
+    const facadeDue = context.facade.listDueAutomationIds('2026-07-05T01:05:00.000Z');
+    assert.equal(facadeDue.size, 1);
+    assert.equal(facadeDue.has(due.id), true);
   } finally {
     context.close();
   }

--- a/tests/electron/automation-store.test.ts
+++ b/tests/electron/automation-store.test.ts
@@ -80,21 +80,32 @@ test('listDueAutomationIds returns only automations whose next_check_at is at or
     const due = context.store.create(createInput({ title: 'Due' }));
     const future = context.store.create(createInput({ title: 'Future' }));
     const unset = context.store.create(createInput({ title: 'Unset' }));
+    const disabled = context.store.create(createInput({ title: 'Disabled' }));
+    const blocked = context.store.create(createInput({ title: 'Blocked' }));
     context.store.updateState(due.id, { nextCheckAt: '2026-07-05T01:05:00.000Z' });
     context.store.updateState(future.id, { nextCheckAt: '2026-07-05T02:00:00.000Z' });
+    context.store.updateState(disabled.id, { nextCheckAt: '2026-07-05T01:05:00.000Z' });
+    context.store.update(disabled.id, { enabled: false });
+    context.store.updateState(blocked.id, {
+      nextCheckAt: '2026-07-05T01:05:00.000Z',
+      health: 'blocked',
+      blockedReason: 'Provider unavailable',
+    });
 
-    const atDue = context.store.listDueAutomationIds('2026-07-05T01:05:00.000Z');
+    const atDue = context.store.listDueAutomationIds(new Date('2026-07-05T01:05:00.000Z'));
     assert.equal(atDue.size, 1);
     assert.equal(atDue.has(due.id), true);
     assert.equal(atDue.has(future.id), false);
     assert.equal(atDue.has(unset.id), false);
+    assert.equal(atDue.has(disabled.id), false);
+    assert.equal(atDue.has(blocked.id), false);
 
-    const atLater = context.store.listDueAutomationIds('2026-07-05T02:00:00.000Z');
+    const atLater = context.store.listDueAutomationIds(new Date('2026-07-05T02:00:00.000Z'));
     assert.equal(atLater.size, 2);
     assert.equal(atLater.has(due.id), true);
     assert.equal(atLater.has(future.id), true);
 
-    const facadeDue = context.facade.listDueAutomationIds('2026-07-05T01:05:00.000Z');
+    const facadeDue = context.facade.listDueAutomationIds(new Date('2026-07-05T01:05:00.000Z'));
     assert.equal(facadeDue.size, 1);
     assert.equal(facadeDue.has(due.id), true);
   } finally {


### PR DESCRIPTION
## Summary

- **Category**: c (performance optimization) — hot-path N+1 on the 30s automation scheduler tick.
- **Motivation**: `AutomationService.runTick` listed every automation and then called `getAutomationNextCheckAt(automation.id)` for each one, issuing N separate SQLite queries per tick. Replaced with a single `listDueAutomationIds(now)` query that returns only the IDs of automations whose `next_check_at` is at or before `now`, filtered by `enabled = 1 AND health = 'healthy'` so it seeks via the existing `idx_automations_enabled_next_check (enabled, next_check_at)` index. The tick loop now does an O(1) `Set.has` lookup instead of per-iteration `Date.parse`.
- **Sub-agent review**: 3 rounds with 3 parallel general-purpose agents (Code Reuse / Code Quality / Efficiency). Round 1 surfaced two real findings (push timestamp comparison into SQL; use `Date` signature and add `enabled`/`health` filters for index usage). Round 2 addressed both. Round 3: all three agents reported CLEAN with no remaining actionable findings.

## Test plan

- [x] `pnpm test` — 584 tests, 583 pass, 0 fail, 1 skipped (same skipped baseline as main)
- [x] New test `listDueAutomationIds returns only automations whose next_check_at is at or before now` covers due/future/unset/disabled/blocked cases and facade pass-through
- [x] Verified index `idx_automations_enabled_next_check (enabled, next_check_at)` exists in `services/local-ai-core/src/acp/store/schema.ts:187`
- [x] Verified `next_check_at` is canonicalized to ISO-8601 UTC via `assertIsoTimestamp` so lexicographic SQL comparison is chronologically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)