### PR TITLE
Fix runtime-config-store recovery overwriting stripped projects

### DIFF
--- a/services/local-ai-core/src/acp/store/runtime-config-store.ts
+++ b/services/local-ai-core/src/acp/store/runtime-config-store.ts
@@ -71,7 +71,13 @@ export class LocalRuntimeConfigStore {
           warnings: ['Recovered projects from disk after SQLite config lost them.', ...legacy.warnings],
         });
       }
-      // Fall through to the standard legacy path (which also handles the no-row case below).
+      if (legacy && 'error' in legacy) {
+        return this.errorState(legacy.path, legacy.error);
+      }
+      // Row exists but projects were intentionally stripped (workspace-registry is
+      // authoritative). Return the row as-is rather than fabricating an empty
+      // projects list, which would mask the registry as the source of truth.
+      return this.toState(row, config, []);
     }
 
     const legacy = this.readLegacyConfig();

--- a/tests/electron/plugin-kernel.test.ts
+++ b/tests/electron/plugin-kernel.test.ts
@@ -809,8 +809,10 @@ test('LocalCoreController accepts injected bootstrap dependencies', async () => 
     status: 'signed',
   });
   await controller.saveRuntimeConfig({ projects: [] } as any);
-  assert.equal(channelRefreshes, 1);
-  assert.equal(weixinRefreshes, 1);
+  // init() and saveRuntimeConfig() each refresh bindings once; the channel-gateway
+  // startup fix in local-core-controller.init() intentionally added the first call.
+  assert.equal(channelRefreshes, 2);
+  assert.equal(weixinRefreshes, 2);
   await controller.close();
   assert.equal(stopped, true);
 });


### PR DESCRIPTION
## Summary

Bug fix — **category: bug fix** (test regressions on main). Two baseline failures introduced by upstream commit 2dfa47a (\"Fix channel gateways not starting after process restart\"):

- `not ok 348 - LocalCoreController accepts injected bootstrap dependencies`
- `not ok 412 - runtime project migration makes workspace registry authoritative and preserves identity across rename`

### Root causes

1. `local-core-controller.init()` now intentionally calls `channelService.refreshBindings()` to fix channel-gateway startup. The plugin-kernel test was not updated — `init() + saveRuntimeConfig()` now produce 2 refreshes per channel, not 1.

2. `LocalRuntimeConfigStore.read()` added a recovery that fires whenever SQLite has no projects (`!Array.isArray(config.projects) || config.projects.length === 0`). Under the workspace-registry architecture, the controller intentionally strips projects via `withoutRuntimeProjects` before saving, so every row read in steady state trips the recovery. When no legacy `config.toml` existed to recover from, the code fell through to `this.save({ projects: [] })`, fabricating an empty list and overwriting the intentionally-stripped row — defeating the registry as the source of truth.

### Changes

- `services/local-ai-core/src/acp/store/runtime-config-store.ts:read()` — when a row exists but projects were stripped and no legacy toml is available to recover from, return the row as-is (`this.toState(row, config, [])`) rather than fabricating `[]`. Also explicitly surface legacy parse errors via `errorState` instead of dropping them.
- `tests/electron/plugin-kernel.test.ts:812-813` — `channelRefreshes` / `weixinRefreshes` expectation bumped from 1 to 2 with a comment explaining the init() refresh.

### Test plan

- [x] `pnpm test` — 598 tests, 597 pass, 0 fail, 1 skipped (baseline before: 2 fail)
- [x] Both target tests now pass: `LocalCoreController accepts injected bootstrap dependencies` and `runtime project migration makes workspace registry authoritative and preserves identity across rename`

### Sub-agent review

3 agents in parallel (Code Reuse / Code Quality / Efficiency), 2 rounds.

- **Round 1**: 2/3 CLEAN. Code Quality confirmed discriminated-union narrowings are sound and no callers break. Code Reuse confirmed no actionable duplication. Efficiency flagged that `readLegacyConfig()` still does filesystem I/O on every hot-path read when projects are stripped.
- **Round 1 iteration decision**: did not address the efficiency finding in this PR. The deeper fix requires either mtime-based caching of the legacy probe or restructuring the recovery trigger (both expand scope beyond a baseline bug-fix). The partial fix in this PR already eliminates the per-read SQLite UPDATE that the old `save({ projects: [] })` path was performing.
- **Round 2**: 3/3 CLEAN. Confirmed partial improvement is genuine (write-on-every-read eliminated), deferral is sound, no new efficiency regressions, no broken callers (`Array.isArray(...)` / optional chaining guard all call sites).

### Remaining concern (deferred)

The legacy probe still runs `existsSync` + (if a file exists) `readFileSync` + `TOML.parse` + `migrateDesktopConnectConfig` whenever the row has no projects. In the steady state (workspace-registry authoritative), this is wasted work on the hot path. Additionally, if a user has BOTH a stripped row AND a legacy `config.toml` on disk, the recovery would still overwrite the row with the legacy's projects — but this is a behavior-vs-design question that needs its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)