### PR TITLE
Collapse listWorkspaces N+1 thread counts into one GROUP BY query

### DIFF
--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -142,6 +142,10 @@ export class LocalCoreAcpStore {
     return this.threads.count(workspaceId);
   }
 
+  countThreadsByWorkspace(workspaceIds: ReadonlyArray<string>): Map<string, number> {
+    return this.threads.countByWorkspace(workspaceIds);
+  }
+
   createThread(workspaceId: string, title: string, agentType = LOCALCORE_ACP_AGENT_TYPE, agentMode = 'default'): ThreadDetail {
     return this.threads.create(workspaceId, title, agentType, agentMode);
   }

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -138,10 +138,6 @@ export class LocalCoreAcpStore {
     return this.threads.listSummaries(workspaceId);
   }
 
-  countThreads(workspaceId: string) {
-    return this.threads.count(workspaceId);
-  }
-
   countThreadsByWorkspace(workspaceIds: ReadonlyArray<string>): Map<string, number> {
     return this.threads.countByWorkspace(workspaceIds);
   }

--- a/services/local-ai-core/src/acp/store/thread-store.ts
+++ b/services/local-ai-core/src/acp/store/thread-store.ts
@@ -42,11 +42,6 @@ export class LocalThreadStore {
     }));
   }
 
-  count(workspaceId: string) {
-    const row = this.db.prepare('SELECT COUNT(*) AS total FROM threads WHERE workspace_id = ?').get(workspaceId) as { total: number } | undefined;
-    return Number(row?.total || 0);
-  }
-
   countByWorkspace(workspaceIds: ReadonlyArray<string>): Map<string, number> {
     const result = new Map<string, number>();
     if (workspaceIds.length === 0) return result;

--- a/services/local-ai-core/src/acp/store/thread-store.ts
+++ b/services/local-ai-core/src/acp/store/thread-store.ts
@@ -47,6 +47,25 @@ export class LocalThreadStore {
     return Number(row?.total || 0);
   }
 
+  countByWorkspace(workspaceIds: ReadonlyArray<string>): Map<string, number> {
+    const result = new Map<string, number>();
+    if (workspaceIds.length === 0) return result;
+    const placeholders = workspaceIds.map(() => '?').join(', ');
+    const rows = this.db.prepare(`
+      SELECT workspace_id, COUNT(*) AS total
+      FROM threads
+      WHERE workspace_id IN (${placeholders})
+      GROUP BY workspace_id
+    `).all(...workspaceIds) as Array<{ workspace_id: string; total: number }>;
+    for (const id of workspaceIds) {
+      result.set(id, 0);
+    }
+    for (const row of rows) {
+      result.set(row.workspace_id, Number(row.total || 0));
+    }
+    return result;
+  }
+
   create(workspaceId: string, title: string, agentType = LOCALCORE_ACP_AGENT_TYPE, agentMode = 'default'): ThreadDetail {
     const sessionId = randomUUID();
     const threadId = encodeThreadId(workspaceId, sessionId);

--- a/services/local-ai-core/src/router/workspace-router.ts
+++ b/services/local-ai-core/src/router/workspace-router.ts
@@ -122,20 +122,26 @@ export class WorkspaceRouter {
     const localProjects = await this.listLocalCoreProjects();
     const workspaceMap = new Map<string, WorkspaceSummary>();
     const configState = await this.options.readRuntimeConfig();
+    const workspaceIds: string[] = [];
     for (const project of localProjects) {
       const route = this.resolveProjectRoute(configState, project);
       if (!route) {
         continue;
       }
       const workspaceId = projectWorkspaceId(project);
+      workspaceIds.push(workspaceId);
       workspaceMap.set(workspaceId, {
         id: workspaceId,
         name: project.name,
         agentType: route.agentType,
         platforms: normalizePlatformTypes(project),
-        sessionsCount: this.store.countThreads(workspaceId),
+        sessionsCount: 0,
         heartbeatEnabled: false,
       });
+    }
+    const threadCounts = this.store.countThreadsByWorkspace(workspaceIds);
+    for (const [workspaceId, summary] of workspaceMap) {
+      summary.sessionsCount = threadCounts.get(workspaceId) ?? 0;
     }
     return [...workspaceMap.values()].sort((a, b) => a.name.localeCompare(b.name));
   }

--- a/tests/electron/workspace-task-store.test.ts
+++ b/tests/electron/workspace-task-store.test.ts
@@ -72,6 +72,30 @@ test('runtime project migration makes workspace registry authoritative and prese
   }
 });
 
+test('countThreadsByWorkspace batches thread counts across workspaces in one query', () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'thread-count-batch-'));
+  try {
+    const store = new LocalCoreAcpStore(userDataPath);
+    store.createThread('workspace-a', 'A1');
+    store.createThread('workspace-a', 'A2');
+    store.createThread('workspace-b', 'B1');
+    // workspace-c has no threads; workspace-d is not in the input set at all.
+
+    const counts = store.countThreadsByWorkspace(['workspace-a', 'workspace-b', 'workspace-c']);
+    assert.equal(counts.get('workspace-a'), 2);
+    assert.equal(counts.get('workspace-b'), 1);
+    assert.equal(counts.get('workspace-c'), 0);
+    assert.equal(counts.has('workspace-d'), false);
+
+    const empty = store.countThreadsByWorkspace([]);
+    assert.equal(empty.size, 0);
+
+    store.close();
+  } finally {
+    rmSync(userDataPath, { recursive: true, force: true });
+  }
+});
+
 test('model providers persist independently from workspace config', () => {
   const userDataPath = mkdtempSync(join(tmpdir(), 'model-provider-store-'));
   try {


### PR DESCRIPTION
## Summary

Performance optimization (category **c**). `WorkspaceRouter.listWorkspaces()` was firing one `SELECT COUNT(*) FROM threads WHERE workspace_id = ?` per workspace — classic N+1. This PR replaces it with one batched `SELECT workspace_id, COUNT(*) FROM threads WHERE workspace_id IN (...) GROUP BY workspace_id` driven off the existing `idx_threads_workspace_updated` index.

### What changed
- `services/local-ai-core/src/acp/store/thread-store.ts`: replaced `count(workspaceId)` with `countByWorkspace(workspaceIds: ReadonlyArray<string>): Map<string, number>` — single `IN (...)` + `GROUP BY` query, pre-seeds the Map with 0 for every requested id so callers always get a count.
- `services/local-ai-core/src/acp/store/local-core-acp-store.ts`: matching facade `countThreadsByWorkspace(...)`; removed the now-dead `countThreads(workspaceId)` facade.
- `services/local-ai-core/src/router/workspace-router.ts:121`: rewrote `listWorkspaces()` to call the batch method once and assign counts to the already-built summary objects.
- `tests/electron/workspace-task-store.test.ts`: new test covering empty input, multi-workspace counts, zero-threads branch, and absent-id behavior.

### Motivation
`listWorkspaces()` is on the workspace-list HTTP hot path. After this change its latency no longer scales linearly in workspace count.

### Test plan
- [x] `pnpm test` — 599 tests, 598 pass, 0 fail, 1 skipped (baseline before: same pass count without the new test)
- [x] New test exercises the empty-input short-circuit, the no-threads default-to-0, the multi-workspace path, and the absent-id contract

### Sub-agent review
3 rounds (general-purpose agents, parallel), each round covering Code Reuse / Code Quality / Efficiency.

- **Round 1**: 2/3 CLEAN. Code Quality: CLEAN (verified Map mutation, edge cases, test coverage). Code Reuse: CLEAN (no helper extraction warranted — only 1 call site). Efficiency: 1 finding — the singular `countThreads()` facade and `LocalThreadStore.count()` had zero remaining callers and were dead code.
- **Round 1 iteration**: deleted both singular methods per the project's "delete unused code completely" guidance.
- **Round 2**: 3/3 CLEAN. Confirmed query is index-backed (`idx_threads_workspace_updated`), no remaining N+1 in `listWorkspaces()` or its callees, parameter count is realistic for the workspace-list endpoint, Map mutation is correct, test coverage is comprehensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)