### PR TITLE
Collapse automation startup N+1 into one batch lookup

### DIFF
--- a/services/local-ai-core/src/acp/store/automation-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-store.ts
@@ -574,6 +574,12 @@ export class LocalAutomationStore {
     return row?.next_check_at ?? null;
   }
 
+  // Single scan replaces a per-automation getNextCheckAt() call inside the startup loop.
+  listIdsMissingNextCheckAt(): Set<string> {
+    const rows = this.db.prepare('SELECT id FROM automations WHERE next_check_at IS NULL').all() as { id: string }[];
+    return new Set(rows.map((row) => row.id));
+  }
+
   listDueAutomationIds(now: Date): Set<string> {
     const rows = this.db.prepare(
       `SELECT id FROM automations

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -437,6 +437,10 @@ export class LocalCoreAcpStore {
     return this.automations.getNextCheckAt(automationId);
   }
 
+  listAutomationIdsMissingNextCheckAt(): Set<string> {
+    return this.automations.listIdsMissingNextCheckAt();
+  }
+
   listDueAutomationIds(now: Date): Set<string> {
     return this.automations.listDueAutomationIds(now);
   }

--- a/services/local-ai-core/src/automation/automation-service.ts
+++ b/services/local-ai-core/src/automation/automation-service.ts
@@ -242,10 +242,11 @@ export class AutomationService {
         this.now().toISOString(),
       );
       for (const run of recovered) this.emitRun(run);
+      const missingNextCheckAt = this.options.store.listAutomationIdsMissingNextCheckAt();
       for (const automation of this.list()) {
         if (
           this.shouldPoll(automation)
-          && this.options.store.getAutomationNextCheckAt(automation.id) === null
+          && missingNextCheckAt.has(automation.id)
           && !this.isConsumedOnce(automation)
         ) {
           this.persistInitialNextCheck(automation);

--- a/tests/electron/automation-store.test.ts
+++ b/tests/electron/automation-store.test.ts
@@ -113,6 +113,34 @@ test('listDueAutomationIds returns only automations whose next_check_at is at or
   }
 });
 
+test('listIdsMissingNextCheckAt returns only automations whose next_check_at is null', () => {
+  const context = fixture();
+  try {
+    const unsetA = context.store.create(createInput({ title: 'Unset A' }));
+    const unsetB = context.store.create(createInput({ title: 'Unset B' }));
+    const scheduled = context.store.create(createInput({ title: 'Scheduled' }));
+    context.store.updateState(scheduled.id, { nextCheckAt: '2026-07-05T02:00:00.000Z' });
+
+    const missing = context.store.listIdsMissingNextCheckAt();
+    assert.equal(missing.size, 2);
+    assert.equal(missing.has(unsetA.id), true);
+    assert.equal(missing.has(unsetB.id), true);
+    assert.equal(missing.has(scheduled.id), false);
+
+    const facadeMissing = context.facade.listAutomationIdsMissingNextCheckAt();
+    assert.equal(facadeMissing.size, 2);
+    assert.equal(facadeMissing.has(unsetA.id), true);
+
+    context.store.updateState(unsetA.id, { nextCheckAt: '2026-07-05T03:00:00.000Z' });
+    const afterUpdate = context.store.listIdsMissingNextCheckAt();
+    assert.equal(afterUpdate.size, 1);
+    assert.equal(afterUpdate.has(unsetA.id), false);
+    assert.equal(afterUpdate.has(unsetB.id), true);
+  } finally {
+    context.close();
+  }
+});
+
 test('listLatestFinishedEvaluationByOrigin returns the most recent finished evaluation per automation', () => {
   const context = fixture();
   try {


### PR DESCRIPTION
## Summary
- Category: **c) performance**
- `AutomationService.startInternal()` previously iterated `this.list()` and called `getAutomationNextCheckAt(id)` per automation — N+1 SQLite round-trips on every service start.
- Adds `LocalAutomationStore.listIdsMissingNextCheckAt()` and facade `listAutomationIdsMissingNextCheckAt()` returning the set of automation IDs where `next_check_at IS NULL` in one query. The loop now captures that Set once and does an O(1) `.has()` check per automation.
- Same pattern as #36 (`countThreadsByWorkspace`) and #37 (`fetchActiveTaskCounts` GROUP BY) — collapse per-row lookups into one bulk scan behind a typed facade.

## Motivation
Service startup is a hot path on every Local AI Core boot. With N automations, the old code issued 1 list query + N point lookups. Now it issues 1 list + 1 NULL-scan. For a typical workspace with 5-20 automations, this drops ~20 SQL round-trips to 2. The Set lookup is hash-based O(1), preserving the original per-row semantics.

## Review rounds
Round 1 (3 parallel agents): clean across Code Reuse, Code Quality, Efficiency — no changes required.

## Test plan
- [x] `pnpm test` — 600 pass, 0 fail, 1 skipped (baseline was 599 pass, +1 new test)
- [x] Added `listIdsMissingNextCheckAt returns only automations whose next_check_at is null` covering: multiple missing, one scheduled, facade passthrough, post-update invalidation
- [x] Existing automation-service startup tests pass unchanged (semantics preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)