### PR TITLE
Reuse getLatestAssistantFinalContent in automation executor

### DIFF
--- a/services/local-ai-core/src/automation/automation-action-executor.ts
+++ b/services/local-ai-core/src/automation/automation-action-executor.ts
@@ -6,7 +6,7 @@ import { BACKGROUND_AGENT_EXECUTION_TIMEOUT_MS } from '../agents/shared/executio
 import { ScheduledBridgeSession } from '../scheduler/scheduled-bridge-session.js';
 import { buildPlatformRuntimeEnv, getChannelPlatformBase } from '../scheduler/scheduled-job-route.js';
 import { waitForRunCompletion } from '../scheduler/run-polling.js';
-import { threadExists } from '../scheduler/thread-resolution.js';
+import { getLatestAssistantFinalContent, threadExists } from '../scheduler/thread-resolution.js';
 
 const AUTOMATION_RUN_PERMISSION_MODE = 'bypassPermissions';
 const UNSAFE_PROMPT_KEYS = new Set(['__proto__', 'constructor', 'prototype', 'toString']);
@@ -78,10 +78,7 @@ export class AutomationActionExecutor {
         interruptRun: (runId) => workspaceRouter.interruptRun(runId),
       });
       const thread = await workspaceRouter.getThread(threadId);
-      const replyText = [...thread.messages]
-        .reverse()
-        .find((message) => message.role === 'assistant' && message.kind === 'final')
-        ?.content;
+      const replyText = getLatestAssistantFinalContent(thread);
       return {
         threadId,
         acpRunId: sendResult.runId,


### PR DESCRIPTION
## Summary
- Category: **b) code reuse**
- v0.1.67 extracted the "find latest assistant final message" loop into `scheduler/thread-resolution.ts:getLatestAssistantFinalContent` and migrated `scheduled-conversation-executor.ts` onto it, but `automation-action-executor.ts` was left with the original inline duplication.
- This PR swaps `[...thread.messages].reverse().find((m) => m.role === 'assistant' && m.kind === 'final')?.content` for a call to the shared helper. Single source of truth, zero-copy reverse iteration.

## Motivation
v0.1.67 created the helper specifically so the two background-execution paths (scheduler + automation) would share one definition of "latest assistant final content". The scheduler side was migrated; the automation side was missed. Same invariant, same thread shape, same call context (`await workspaceRouter.getThread(...)` → extract reply text) — pure oversight. Also drops a `[...arr].reverse()` allocation per automation fire (minor, but free).

## Review rounds
Round 1 (3 parallel agents): clean across Code Reuse, Code Quality, Efficiency — no changes required.
- Code Reuse confirmed no other duplicating call sites worth migrating (one similar pattern in `local-core-acp-turn-coordinator.ts` has different semantics; one in `scripts/e2e-compose.mjs` is a non-TS test script).
- Code Quality confirmed strict behavioral equivalence — old `[...arr].reverse().find()` and new backward-index loop both return `undefined` when no match exists.
- Efficiency flagged a meaningful but out-of-scope follow-up: `workspaceRouter.getThread(threadId)` fetches the entire thread just to read the last final assistant message. A leaner router endpoint pushing the scan into storage would be the larger win — deferred to a future daily.

## Test plan
- [x] `pnpm test` — 608 pass, 0 fail, 1 skipped (same as baseline)
- [x] No test directly covers the `replyText` extraction on the automation path, but the swap is behavior-preserving and existing executor tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)