### PR TITLE
Drop double write in updateWorkspaceRegistryEntry

### DIFF
--- a/services/local-ai-core/src/router/workspace-router.ts
+++ b/services/local-ai-core/src/router/workspace-router.ts
@@ -168,16 +168,20 @@ export class WorkspaceRouter {
   }
 
   async updateWorkspaceRegistryEntry(workspaceId: string, input: WorkspaceRegistryUpdateInput): Promise<WorkspaceRegistryEntry> {
-    const next = this.store.updateWorkspaceRegistryEntry(workspaceId, input);
+    const existing = this.store.getWorkspaceRegistryEntry(workspaceId);
+    if (!existing) {
+      throw new Error(`Workspace not found: ${workspaceId}`);
+    }
+    const path = input.path || existing.path;
     return this.store.upsertWorkspaceRegistryEntry({
-      workspaceId: next.workspaceId,
-      displayName: next.displayName,
-      path: next.path,
-      deviceId: next.deviceId,
-      defaultRuntimeId: next.defaultRuntimeId,
-      git: detectGitSummary(next.path),
-      health: workspaceHealth(next.path),
-      metadata: next.metadata,
+      workspaceId,
+      displayName: input.displayName || existing.displayName,
+      path,
+      deviceId: existing.deviceId,
+      defaultRuntimeId: input.defaultRuntimeId === null ? undefined : input.defaultRuntimeId || existing.defaultRuntimeId,
+      git: detectGitSummary(path),
+      health: workspaceHealth(path),
+      metadata: input.metadata || existing.metadata,
     });
   }
 


### PR DESCRIPTION
## Summary
- Category: **c) performance**
- `WorkspaceRouter.updateWorkspaceRegistryEntry` called `store.updateWorkspaceRegistryEntry()` (which internally does `get` + `upsert`, preserving stale `git_json`/`health_json`) and then `store.upsertWorkspaceRegistryEntry()` again on the result (writing AGAIN with fresh `git`/`health` from `detectGitSummary`/`workspaceHealth`). The second upsert overwrote the first's git/health, making the first INSERT/UPDATE pure write-amplification.
- The new code does one `get` (throw on missing) + one `upsert` with the merged fields. Same observable behavior, fewer queries, fewer filesystem shell-outs.

## Motivation
Per the store layout, `store.get` does 3 SQLite queries (row SELECT + active-task count + recent-task IDs); `store.upsert` does ~7 (internal get + write + trailing get). The OLD path ran `store.update` (= get + upsert = ~10) plus another `store.upsert` (~7) = **17 queries per PATCH**. The NEW path runs `get` (3) + `upsert` (7) = **10 queries per PATCH**, a ~41% reduction. More importantly, the OLD path also issued two `INSERT ... ON CONFLICT DO UPDATE` writes to `workspace_registry` per single PATCH — the first was guaranteed to be overwritten by the second.

## Review rounds
Round 1 (3 parallel agents): no actionable findings.
- **Code Reuse** flagged the field merge as similar to `store.update`'s merge, but the data sources intentionally differ (store preserves stale `git`/`health`; router recomputes from `path`). Pushing `detectGitSummary`/`workspaceHealth` into the store would mix storage and filesystem layers — wrong direction. Skipped as false positive.
- **Code Quality** confirmed strict behavioral equivalence for all input shapes (empty-string fields, null vs undefined defaultRuntimeId, missing metadata). All nits self-dismissed.
- **Efficiency** confirmed 17→10 query reduction; flagged out-of-scope nit (the trailing `this.get(id)!` inside `store.upsert` re-runs 3 queries just to shape the return — could be built from the merged input. Defer to a future daily; affects both OLD and NEW paths equally).

## Test plan
- [x] `pnpm test` — 608 pass, 0 fail, 1 skipped (same as baseline)
- [x] No direct test covers `updateWorkspaceRegistryEntry`, but the change is a pure refactor with verified behavioral equivalence — existing workspace-task-store and runtime config migration tests exercise adjacent code paths and still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)