### PR TITLE
Skip trailing get in workspace-registry upsert

### DIFF
--- a/services/local-ai-core/src/acp/store/workspace-registry-store.ts
+++ b/services/local-ai-core/src/acp/store/workspace-registry-store.ts
@@ -60,6 +60,9 @@ export class LocalWorkspaceRegistryStore {
       summary: 'Workspace health has not been checked.',
       issues: [],
     };
+    const git = input.git || existing?.git || { isRepo: false };
+    const metadata = input.metadata || existing?.metadata || {};
+    const createdAt = existing?.createdAt || now;
     this.db.prepare(`
       INSERT INTO workspace_registry (
         id, display_name, path, device_id, default_runtime_id, git_json, health_json, metadata_json, created_at, updated_at, last_opened_at
@@ -79,14 +82,30 @@ export class LocalWorkspaceRegistryStore {
       input.path,
       input.deviceId,
       input.defaultRuntimeId || null,
-      JSON.stringify(input.git || existing?.git || {}),
+      JSON.stringify(git),
       JSON.stringify(health),
-      JSON.stringify(input.metadata || existing?.metadata || {}),
-      existing?.createdAt || now,
+      JSON.stringify(metadata),
+      createdAt,
       now,
       existing?.lastOpenedAt || null,
     );
-    return this.get(id)!;
+    // Shape from already-fetched values; upsert doesn't touch agent_tasks, so
+    // existing.activeTaskCount/recentTaskIds remain valid snapshots.
+    return {
+      workspaceId: id,
+      displayName: input.displayName,
+      path: input.path,
+      deviceId: input.deviceId,
+      createdAt,
+      updatedAt: now,
+      lastOpenedAt: existing?.lastOpenedAt || undefined,
+      defaultRuntimeId: input.defaultRuntimeId || undefined,
+      git,
+      health,
+      activeTaskCount: existing?.activeTaskCount ?? 0,
+      recentTaskIds: existing?.recentTaskIds ?? [],
+      metadata,
+    };
   }
 
   update(workspaceId: string, input: WorkspaceRegistryUpdateInput): WorkspaceRegistryEntry {

--- a/services/local-ai-core/src/acp/store/workspace-registry-store.ts
+++ b/services/local-ai-core/src/acp/store/workspace-registry-store.ts
@@ -89,8 +89,7 @@ export class LocalWorkspaceRegistryStore {
       now,
       existing?.lastOpenedAt || null,
     );
-    // Shape from already-fetched values; upsert doesn't touch agent_tasks, so
-    // existing.activeTaskCount/recentTaskIds remain valid snapshots.
+    // Safe: upsert only touches workspace_registry; task snapshots from the leading get() stay valid.
     return {
       workspaceId: id,
       displayName: input.displayName,


### PR DESCRIPTION
## Summary
- Category: **c) performance**
- `LocalWorkspaceRegistryStore.upsert()` previously ended with `return this.get(id)!` — 3 extra SQLite queries (row SELECT + activeTaskCount + recentTaskIds) just to shape the return. Since upsert only writes to `workspace_registry` and never touches `agent_tasks`, the leading `get(id)` already has a valid snapshot of activeTaskCount/recentTaskIds. The new code shapes the return directly from already-merged values.

## Motivation
Per query plan: OLD ran **7 queries** per upsert (leading `get`=3 + INSERT/UPDATE=1 + trailing `get`=3). NEW runs **4 queries** (leading `get`=3 + write=1). That's a 43% reduction on a workspace-management call. Callers include `WorkspaceRouter.createWorkspaceRegistryEntry`, `updateWorkspaceRegistryEntry` (which calls upsert once after yesterday's PR), `persistProjectsInRegistry` (startup), and the external project sync. Not throughput-critical, but the redundant queries were pure waste.

## Behavioral delta (intentional)
The OLD code wrote `{}` to `git_json` for never-set workspaces and relied on `shapeEntry`'s `parseJson(row.git_json, { isRepo: false })` fallback to return `{ isRepo: false }`. The NEW code writes `{"isRepo":false}` directly and returns it. This aligns the on-disk representation with the in-memory shape that `list()`/`get()` already produce — net improvement, no caller-visible regression (callers always saw `{ isRepo: false }` via the fallback before).

## Review rounds
Round 1 (3 parallel agents): one nit applied, no other actionable findings.
- **Code Reuse** suggested building a synthetic row + reusing `shapeEntry`. Skipped — that path would JSON.stringify then JSON.parse the same values needlessly (we already have the parsed objects).
- **Code Quality** flagged the behavioral delta (documented above) and suggested a tighter comment. Applied the comment tightening.
- **Efficiency** confirmed 7→4 query reduction. Noted the leading `get` is required for update-merge semantics (supplies `existing.git`/`createdAt`/`lastOpenedAt`), so we can't drop it.

## Test plan
- [x] `pnpm test` — 608 pass, 0 fail, 1 skipped (same as baseline)
- [x] Existing `listWorkspaceRegistry batches active task counts...` test still passes — confirms shaping semantics are unchanged for the list/get paths
- [x] The upsert path's return shape is now identical to what `get(id)` would have returned, modulo the `git_json` on-disk alignment noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)