### PR TITLE
Remove dead renderMonitorPrompt helper

### DIFF
--- a/services/local-ai-core/src/automation/automation-conversation-executor.ts
+++ b/services/local-ai-core/src/automation/automation-conversation-executor.ts
@@ -67,12 +67,6 @@ export class AutomationConversationExecutor {
 
 }
 
-export function renderMonitorPrompt(template: string, event: AutomationMonitorEventSnapshot, monitor: AutomationMonitor) {
-  return String(template || '').replace(/\{\{\s*([a-zA-Z0-9_.-]+)\s*\}\}/g, (_match, key: string) =>
-    String(monitorPromptVariables(event, monitor)[key] ?? '')
-  );
-}
-
 function monitorPromptVariables(
   event: AutomationMonitorEventSnapshot,
   monitor: AutomationMonitor,


### PR DESCRIPTION
## Summary
- Category: **b) code reuse / dead code**
- PR #39 (2026-07-20) routed monitor prompt rendering through the shared `renderAutomationPrompt` helper but left the original `renderMonitorPrompt` in `automation-conversation-executor.ts` as an unused duplicate. Repo-wide grep confirms zero importers across `services/`, `tests/`, `packages/`, `electron/`.
- This PR deletes the dead function (5 lines + 1 blank).

## Motivation
The dead helper was strictly worse than the live one — and leaving it in risked a future contributor reaching for it instead of the canonical path:
- No `UNSAFE_PROMPT_KEYS` prototype-pollution guard (`__proto__`/`constructor`/`prototype` would have been substituted verbatim).
- No `Object.getOwnPropertyDescriptor` own-property check (inherited properties would have leaked into the prompt).
- Called `monitorPromptVariables(event, monitor)` once per regex match — O(N) calls per template render. The live path builds the variable map once and passes it to `renderAutomationPrompt`, which then looks up keys via safe own-property access.

`monitorPromptVariables` is retained because the executor still uses it at line 63 to build the variable map passed to the shared helper.

## Review rounds
Round 1 (3 parallel agents): all clean.
- **Code Reuse** verified zero importers (fresh grep), no re-export chains touch the symbol, no implicit plugin-sdk API surface, no other dead duplicates of the template helper remain.
- **Code Quality** confirmed commit message accuracy, no orphaned imports/types, `monitorPromptVariables` still defensibly standalone, residual structure reads cleanly.
- **Efficiency** confirmed zero runtime impact (dead code), `monitorPromptVariables` is called exactly once per execute, `renderAutomationPrompt` is single-pass.

## Test plan
- [x] `pnpm test` — 608 pass, 0 fail, 1 skipped (same as baseline)
- [x] No test covered `renderMonitorPrompt` (it was unused), so no coverage regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)