### PR TITLE
Drop local parseJson in automation-monitor store, reuse shared utils

### DIFF
--- a/services/local-ai-core/src/acp/store/automation-monitor-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-monitor-store.ts
@@ -18,6 +18,7 @@ import type {
   LocalAutomationMonitorRow,
   LocalAutomationMonitorRunRow,
 } from '../../router/workspace-router-types.js';
+import { parseJson } from './utils.js';
 
 export type ResolvedAutomationMonitorCreateInput = AutomationMonitorCreateInput & {
   platform: NonNullable<AutomationMonitorCreateInput['platform']>;
@@ -318,14 +319,6 @@ export class LocalAutomationMonitorStore {
     }
     if (this.get(id)) throw new Error('Unable to allocate a unique automation monitor id.');
     return id;
-  }
-}
-
-function parseJson<T>(value: string, fallback: T): T {
-  try {
-    return JSON.parse(value) as T;
-  } catch {
-    return fallback;
   }
 }
 


### PR DESCRIPTION
## Summary
- Category: **b) code reuse**
- `LocalAutomationMonitorStore` was the lone outlier under `services/local-ai-core/src/acp/store/` with a local `parseJson` copy. Every sibling store (security-store, scheduler-store, automation-store, agent-task-store, thread-store, workspace-registry-store, model-provider-store, external-store, runtime-config-store, platform-store, automation-script-store) already imports `parseJson` from `./utils.ts`. The local copy was byte-identical to the shared helper.

## Motivation
Single source of truth. The local copy added no value and risked divergence if `parseJson` ever gained stricter handling (e.g., prototype pollution guards, depth limits). Removing it brings this file in line with the established pattern and makes `./utils.ts` the canonical home for JSON parsing across all ACP stores.

## Review rounds
Round 1 (3 parallel agents): all clean.
- **Code Reuse** verified the deleted function was truly byte-identical, ran a fresh repo-wide grep (no other duplicates to clean up here), confirmed import style matches sibling stores, and found no other duplicate `utils.ts` helpers lurking in the file.
- **Code Quality** confirmed the "byte-identical" commit message accuracy, clean trailing whitespace, correct import placement. Flagged two optional caller-cleanup nits (`|| '{}'` vs ternary idiom inconsistency in the file's existing parseJson calls) — explicitly out of scope for this PR.
- **Efficiency** confirmed call-count parity per `listMonitors()`/`listRuns()` row, no bundle-size concern (CJS module cache, utils.ts is ~50 lines and already loaded by other consumers), no memoization opportunity worth pursuing.

## Test plan
- [x] `pnpm test` — 608 pass, 0 fail, 1 skipped (same as baseline)
- [x] No tests directly cover `parseJson`; behavior is byte-identical so all existing monitor-store tests (which exercise the parsing paths via row reads) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)