### PR TITLE
Drop trailing getRun re-fetches in automation-monitor-store runs

### DIFF
--- a/services/local-ai-core/src/acp/store/automation-monitor-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-monitor-store.ts
@@ -216,7 +216,22 @@ export class LocalAutomationMonitorStore {
       lastStatus: normalizedStatus,
       lastError: input.error || '',
     });
-    return this.getRun(id)!;
+    return {
+      id,
+      monitorId,
+      status: normalizedStatus,
+      triggeredAt,
+      startedAt: input.startedAt || undefined,
+      finishedAt: input.finishedAt || undefined,
+      error: input.error || undefined,
+      eventSnapshot: input.eventSnapshot || undefined,
+      threadId: input.threadId || undefined,
+      runId: input.runId || undefined,
+      deliveryMode: input.deliveryMode || undefined,
+      deliveryStatus: input.deliveryStatus || undefined,
+      deliveryError: input.deliveryError || undefined,
+      lastBridgeEventAt: input.lastBridgeEventAt || undefined,
+    };
   }
 
   getRun(runId: string): AutomationMonitorRun | undefined {
@@ -262,7 +277,7 @@ export class LocalAutomationMonitorStore {
         lastError: next.error || '',
       });
     }
-    return this.getRun(runId)!;
+    return next;
   }
 
   private toMonitor(row: LocalAutomationMonitorRow): AutomationMonitor {


### PR DESCRIPTION
## Summary
- `LocalAutomationMonitorStore.createRun` and `updateRun` previously wrote a row then issued a second `SELECT` via `getRun(...)` purely to shape the return value.
- `createRun` now builds the `AutomationMonitorRun` inline from values already in scope; `updateRun` returns the already-merged `next` object.
- All optional string fields preserve the existing `|| undefined` empty-string coercion, matching the prior observable shape.

## Category
c) performance — eliminates 2 redundant `SELECT`s per automation-monitor-run lifecycle (1 in `createRun`, 1 in `updateRun`). Continues the pattern established in #44 (scheduler-store runs).

## Review rounds
1 round. Three parallel reviewers (Code Reuse / Code Quality / Efficiency) all returned "No issues found". Field-by-field parity vs `toRun` confirmed for every field including `eventSnapshot`.

## Test plan
- [x] `pnpm test` -> 608 pass / 0 fail / 1 skipped (baseline preserved)
- [x] No caller of `LocalCoreAcpStore.createAutomationMonitorRun` / `updateAutomationMonitorRun` depends on post-write DB re-read semantics (call sites route through `automation-monitor-repository.ts`)

Generated with Claude Code