### PR TITLE
Drop trailing getRun re-fetches in automation-store runs

### DIFF
--- a/services/local-ai-core/src/acp/store/automation-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-store.ts
@@ -279,7 +279,7 @@ export class LocalAutomationStore {
       INSERT INTO automation_runs (id, automation_id, evaluation_id, status, created_at, run_json)
       VALUES (?, ?, ?, ?, ?, ?)
     `).run(run.id, run.automationId, run.evaluationId, run.status, run.createdAt, JSON.stringify(run));
-    return this.getRun(run.id)!;
+    return run;
   }
 
   updateRun(runId: string, input: AutomationRunUpdateInput): AutomationRun {
@@ -287,7 +287,7 @@ export class LocalAutomationStore {
     const run = validateRun({ ...existing, ...pickRunMutableFields(input) });
     this.db.prepare('UPDATE automation_runs SET status = ?, run_json = ? WHERE id = ?')
       .run(run.status, JSON.stringify(run), runId);
-    return this.getRun(runId)!;
+    return run;
   }
 
   listRuns(automationId: string): AutomationRun[] {


### PR DESCRIPTION
## Summary
- `LocalAutomationStore.createRun` and `updateRun` previously wrote a row then issued a second `SELECT` via `getRun(...)` purely to shape the return value.
- Both methods now return the locally-validated `run` object directly, since `validateRun(...)` already produced the canonical `AutomationRun` shape that `toRun(row)` would have reconstructed.
- Continues the pattern established in #44 (scheduler-store runs) and #45 (automation-monitor-store runs).

## Category
c) performance — eliminates 2 redundant `SELECT`s per automation-run lifecycle (1 in `createRun`, 1 in `updateRun`). Saving is real but modest: callers in `automation-service.ts` invoke these once per automation trigger (cron-driven, seconds-to-minutes cadence), not per HTTP request.

## Review rounds
1 round. Three parallel reviewers (Code Reuse / Code Quality / Efficiency) all returned "No issues found" / "No blocking issues". `validateRun` is the canonical constructor called inside `toRun`, so the returned object is structurally identical to a post-write re-fetch; the `assertDuplicatedField` consistency checks in `toRun` are correctly skipped (the indexed columns were written from the same fields).

## Test plan
- [x] `pnpm test` -> 608 pass / 0 fail / 1 skipped + 80 BDD scenarios pass (baseline preserved)
- [x] No caller of `LocalCoreAcpStore.createAutomationRun` / `updateAutomationRun` mutates the returned object
- [x] `reconcileInterruptedRuns` (the only internal `updateRun` caller) receives a fresh `AutomationRun` literal built inside `validateRun`, so no in-memory aliasing

Generated with Claude Code