### PR TITLE
Drop trailing getEvaluation re-fetches in automation-store evaluations

### DIFF
--- a/services/local-ai-core/src/acp/store/automation-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-store.ts
@@ -198,7 +198,7 @@ export class LocalAutomationStore {
       startedAt: input.startedAt,
     });
     this.insertEvaluation(evaluation);
-    return this.getEvaluation(evaluation.id)!;
+    return evaluation;
   }
 
   finishEvaluation(evaluationId: string, input: AutomationEvaluationFinishInput): AutomationEvaluation {
@@ -219,7 +219,7 @@ export class LocalAutomationStore {
       SET status = ?, finished_at = ?, evaluation_json = ?
       WHERE id = ?
     `).run(evaluation.status, evaluation.finishedAt, JSON.stringify(evaluation), evaluationId);
-    return this.getEvaluation(evaluationId)!;
+    return evaluation;
   }
 
   listEvaluations(automationId: string): AutomationEvaluation[] {


### PR DESCRIPTION
## Summary
- `LocalAutomationStore.createEvaluation` and `finishEvaluation` previously wrote a row then issued a second `SELECT` via `getEvaluation(...)` purely to shape the return value.
- Both methods now return the locally-validated `evaluation` object directly, since `validateEvaluation(...)` already produces the canonical `AutomationEvaluation` shape that `toEvaluation(row)` would have reconstructed.
- Continues the pattern established in #44 (scheduler-store runs), #45 (automation-monitor-store runs), and #46 (automation-store runs).

## Category
c) performance — eliminates 2 redundant `SELECT`s per automation-evaluation cycle (1 in `createEvaluation`, 1 in `finishEvaluation`). Saving is real but modest: callers in `automation-service.ts` invoke this pair once per due automation per cron tick.

## Review rounds
1 round. Three parallel reviewers (Code Reuse / Code Quality / Efficiency) all returned "No issues found".

Parity verified end-to-end:
- `validateEvaluation` is the canonical constructor called inside `toEvaluation`, so the returned object is structurally identical to a post-write re-fetch.
- The `assertDuplicatedField` consistency checks in `toEvaluation` are correctly skipped. For `createEvaluation`, all indexed columns are written from the same `evaluation` object. For `finishEvaluation`, the untouched indexed columns (`automation_id`, `activation_kind`, `script_version_id`, `started_at`) come from `existing`, which was loaded via `getEvaluation` → `toEvaluation` (already consistency-checked), then copied into the new `evaluation` via `validateEvaluation` — so consistency is preserved.

## Test plan
- [x] `pnpm test` -> 608 pass / 0 fail / 1 skipped + 80 BDD scenarios pass (baseline preserved)
- [x] No caller of `LocalCoreAcpStore.createEvaluation` / `finishEvaluation` mutates the returned object
- [x] `automation-service.ts` treats the returned evaluation as read-only

Generated with Claude Code