### PR TITLE
Drop trailing getJob re-fetches in scheduler-store jobs

### DIFF
--- a/services/local-ai-core/src/acp/store/scheduler-store.ts
+++ b/services/local-ai-core/src/acp/store/scheduler-store.ts
@@ -84,7 +84,22 @@ export class LocalSchedulerStore {
       now,
       now,
     );
-    return this.getJob(id)!;
+    return {
+      id,
+      workspaceId: input.workspaceId,
+      platform: normalizeChannelPlatform(input.platform),
+      route: input.route,
+      executionMode: normalizeScheduledJobExecutionMode(input.executionMode),
+      triggerType: normalizeScheduledJobTriggerType(input.triggerType),
+      cronExpr: input.cronExpr || undefined,
+      runAt: input.runAt || undefined,
+      promptTemplate: input.promptTemplate,
+      description: input.description || '',
+      enabled: input.enabled !== false,
+      concurrencyPolicy: 'skip_if_running',
+      createdAt: now,
+      updatedAt: now,
+    };
   }
 
   updateJob(jobId: string, input: ScheduledJobUpdateInput): ScheduledJob {
@@ -122,7 +137,7 @@ export class LocalSchedulerStore {
       next.updatedAt,
       jobId,
     );
-    return this.getJob(jobId)!;
+    return next;
   }
 
   deleteJob(jobId: string) {


### PR DESCRIPTION
## Summary
- `LocalSchedulerStore.createJob` and `updateJob` previously wrote a row then issued a second `SELECT` via `getJob(...)` purely to shape the return value.
- `createJob` now builds the `ScheduledJob` inline from the same values just persisted; `updateJob` returns the already-merged `next` object.
- Continues the pattern established in #44 (scheduler-store runs), #45 (automation-monitor-store runs), #46 (automation-store runs), and #47 (automation-store evaluations). PR #44's reviewer specifically flagged these two sites as "trivial to also inline if scope allows".

## Category
c) performance — eliminates 2 redundant `SELECT`s per scheduled-job create/update. Saving is small but real: callers are user-driven admin edits via `scheduler-handler.ts` (POST/PATCH job endpoints), not per-tick hot paths.

## Review rounds
1 round. Three parallel reviewers (Code Reuse / Code Quality / Efficiency) all returned "No issues found".

Parity verified field-by-field against `toScheduledJob`:
- `description`: `input.description || ''` matches the persisted default
- `enabled`: `input.enabled !== false` matches the persisted `input.enabled === false ? 0 : 1`
- `concurrencyPolicy`: `'skip_if_running'` (hardcoded in INSERT)
- Omitted optional fields (`lastRunAt`, `lastStatus`, `lastError`) are structurally equivalent to `undefined` per the `ScheduledJob` interface

## Test plan
- [x] `pnpm test` -> 608 pass / 0 fail / 1 skipped + 80 BDD scenarios pass (baseline preserved)
- [x] No caller of `LocalCoreAcpStore.createScheduledJob` / `updateScheduledJob` depends on post-write DB re-read semantics

Generated with Claude Code