### PR TITLE
Drop trailing get re-fetches in automation-monitor-store create/update

### DIFF
--- a/services/local-ai-core/src/acp/store/automation-monitor-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-monitor-store.ts
@@ -94,7 +94,23 @@ export class LocalAutomationMonitorStore {
       now,
       now,
     );
-    return this.get(id)!;
+    return {
+      id,
+      workspaceId: input.workspaceId,
+      title,
+      sourceType,
+      sourceConfig: input.sourceConfig || {},
+      condition,
+      promptTemplate: input.promptTemplate,
+      platform: normalizeChannelPlatform(input.platform),
+      route: input.route,
+      executionMode: normalizeScheduledJobExecutionMode(input.executionMode, 'side-thread'),
+      enabled: input.enabled !== false,
+      cooldownMs: Math.max(0, Number(input.cooldownMs ?? 15 * 60 * 1000)),
+      concurrencyPolicy: 'skip_if_running',
+      createdAt: now,
+      updatedAt: now,
+    };
   }
 
   update(monitorId: string, input: AutomationMonitorUpdateInput): AutomationMonitor {
@@ -139,7 +155,7 @@ export class LocalAutomationMonitorStore {
       next.updatedAt,
       monitorId,
     );
-    return this.get(monitorId)!;
+    return next;
   }
 
   updateState(monitorId: string, input: {


### PR DESCRIPTION
## Summary
- `LocalAutomationMonitorStore.create` and `update` previously wrote a row then issued a second `SELECT` via `get(...)` purely to shape the return value.
- `create` now builds the `AutomationMonitor` inline from the same values just persisted; `update` returns the already-merged `next` object.
- Continues the pattern established in #44 (scheduler-store runs), #45 (automation-monitor-store runs), #46 (automation-store runs), #47 (automation-store evaluations), and #48 (scheduler-store jobs).

## Category
c) performance — eliminates 2 redundant `SELECT`s per automation-monitor create/update. Saving is small but real: callers are admin UI operations (`automations-handler.ts` POST/PATCH monitor endpoints), not per-tick hot paths.

## Review rounds
1 round. Three parallel reviewers (Code Reuse / Code Quality / Efficiency) all returned "No issues found".

Parity verified field-by-field against `toMonitor`:
- `sourceConfig`: `input.sourceConfig || {}` matches the persisted default
- `condition`: local variable already had `operator` normalized (idempotent re-normalization)
- `enabled`: `input.enabled !== false` matches the persisted `input.enabled === false ? 0 : 1`
- `cooldownMs`: `Math.max(0, Number(input.cooldownMs ?? 15*60*1000))` matches the persisted value
- `concurrencyPolicy`: `'skip_if_running'` (hardcoded in INSERT)
- Omitted optional fields (`lastState`, `lastTriggeredAt`, `lastStatus`, `lastError`) are structurally equivalent to `undefined` per the `AutomationMonitor` interface

## Test plan
- [x] `pnpm test` -> 611 pass / 0 fail / 1 skipped + 80 BDD scenarios pass (baseline preserved)
- [x] No caller of `LocalCoreAcpStore.createAutomationMonitor` / `updateAutomationMonitor` depends on post-write DB re-read semantics

Generated with Claude Code