### PR TITLE
Drop trailing get re-fetches in automation-store definitions

### DIFF
--- a/services/local-ai-core/src/acp/store/automation-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-store.ts
@@ -123,7 +123,7 @@ export class LocalAutomationStore {
       updatedAt: now,
     });
     this.insertDefinition(definition);
-    return this.get(definition.id)!;
+    return definition;
   }
 
   update(id: string, input: AutomationUpdateInput): AutomationDefinition {
@@ -152,7 +152,7 @@ export class LocalAutomationStore {
     candidate.updatedAt = new Date().toISOString();
     const definition = normalizeDefinition(candidate);
     this.writeDefinition(definition);
-    return this.get(id)!;
+    return definition;
   }
 
   updateState(id: string, input: AutomationStateUpdateInput): AutomationDefinition {
@@ -182,7 +182,7 @@ export class LocalAutomationStore {
       ? null
       : assertIsoTimestamp(nextCheckAt, 'Automation nextCheckAt');
     this.writeDefinition(definition, canonicalNextCheckAt);
-    return this.get(id)!;
+    return definition;
   }
 
   delete(id: string) {


### PR DESCRIPTION
## Summary
- `LocalAutomationStore.createWithOrigin`, `updateWithMetadata`, and `updateState` previously wrote a row then issued a second `SELECT` via `get(...)` purely to shape the return value.
- All three now return the locally-validated `definition` object directly (the canonical output of `normalizeDefinition(...)`).
- Completes the trailing re-fetch cleanup series: #44 (scheduler-store runs), #45 (automation-monitor-store runs), #46 (automation-store runs), #47 (automation-store evaluations), #48 (scheduler-store jobs), #49 (automation-monitor-store create/update).

## Category
c) performance — eliminates 3 redundant `SELECT`s per automation definition write. Biggest win on `updateState`, which is called on every automation tick / evaluation cycle / state transition (`local-core-acp-store.ts:462,472,495,507,512`).

## Review rounds
1 round. Three parallel reviewers (Code Reuse / Code Quality / Efficiency) all returned "No issues found".

Parity verified end-to-end:
- `normalizeDefinition` is idempotent — re-normalizing via `toDefinition` produces the same shape
- `updateState` correctly omits `next_check_at` from the returned object — it's a column-only scheduling concern, not part of the `AutomationDefinition` contract
- No caller mutates the returned definition; `updateState` re-reads via `requireDefinition(id)` rather than aliasing the passed reference
- All return paths already typed as `AutomationDefinition` — no new `any` casts

## Test plan
- [x] `pnpm test` -> 611 pass / 0 fail / 1 skipped + 80 BDD scenarios pass (baseline preserved)
- [x] No caller of `LocalCoreAcpStore.create/update/updateTrusted/updateState` depends on post-write DB re-read semantics

Generated with Claude Code