### PR TITLE
Hoist duplicated session-command dispatch into BaseChannelGateway

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -66,7 +66,6 @@ import type {
 } from './types.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
-import { parseSlashCommand } from '../../acp/local-core-slash-commands.js';
 import {
   attachLarkWsDiagnostics,
   maskLarkAppId,
@@ -522,28 +521,21 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     });
     const acknowledgement = this.createTurnState(effectiveSessionKey, msg.messageId);
     await this.addAcknowledgementReaction(msg.workspaceId, msg.messageId, acknowledgement, instanceId);
-    const slashCommand = parseSlashCommand(msg.text);
-    const sessionCommand = await this.executeSessionCommand({
-      workspaceId: msg.workspaceId,
-      currentThreadId: threadId,
-      text: msg.text,
-      defaultTitle: `${msg.displayName || 'Lark'} ${new Date().toLocaleTimeString()}`,
-      defaultAgentType: slashCommand ? await this.resolveDefaultAgentType(msg.workspaceId, threadId) : '',
-      chatId: msg.chatId,
-      platformUserId: msg.platformUserId,
-      platformKey,
-      instanceId,
-    });
-    if (sessionCommand.handled) {
-      return; // { paired: true, threadId: sessionCommand.threadId || threadId };
-    }
-    const latestRun = this.options.store.getLatestRunForThread(threadId);
     if (
-      (normalizedText === 'allow' || normalizedText === 'allow all' || normalizedText === 'deny')
-      && latestRun?.status === 'awaiting_input'
+      await this.dispatchSessionCommandOrAction({
+        workspaceId: msg.workspaceId,
+        threadId,
+        text: msg.text,
+        normalizedText,
+        displayName: msg.displayName,
+        platformLabel: 'Lark',
+        chatId: msg.chatId,
+        platformUserId: msg.platformUserId,
+        platformKey,
+        instanceId,
+      })
     ) {
-      await router.sendThreadAction(threadId, msg.text);
-      return; // { paired: true, threadId };
+      return;
     }
     this.options.store.clearPlatformThreadMessageId(msg.workspaceId, msg.chatId, msg.platformUserId);
     await router.sendThreadMessage(threadId, createChannelThreadMessageInput(msg.text, msg.contentParts));

--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -511,28 +511,24 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
       threadId = permissionThreadId;
     }
     const effectiveSessionKey = this.options.getWorkspaceRouter().getThreadSessionKey(threadId);
-    this.threadRouting.set(effectiveSessionKey, {
+    const route: LarkThreadRoute = {
       workspaceId: msg.workspaceId,
       instanceId,
       platformKey,
       platformUserId: msg.platformUserId,
       chatId: msg.chatId,
       threadId,
-    });
+    };
+    this.threadRouting.set(effectiveSessionKey, route);
     const acknowledgement = this.createTurnState(effectiveSessionKey, msg.messageId);
     await this.addAcknowledgementReaction(msg.workspaceId, msg.messageId, acknowledgement, instanceId);
     if (
-      await this.dispatchSessionCommandOrAction({
-        workspaceId: msg.workspaceId,
-        threadId,
+      await this.handleSessionCommandOrAction({
+        route,
         text: msg.text,
         normalizedText,
         displayName: msg.displayName,
         platformLabel: 'Lark',
-        chatId: msg.chatId,
-        platformUserId: msg.platformUserId,
-        platformKey,
-        instanceId,
       })
     ) {
       return;

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -381,40 +381,36 @@ export abstract class BaseChannelGateway<
     return this.sessionCommandRuntime.execute(input);
   }
 
-  protected async dispatchSessionCommandOrAction(input: {
-    workspaceId: string;
-    threadId: string;
+  protected async handleSessionCommandOrAction(input: {
+    route: TThreadRoute;
     text: string;
     normalizedText: string;
     displayName?: string;
     platformLabel: string;
-    chatId: string;
-    platformUserId: string;
-    platformKey: string;
-    instanceId: string;
     contextToken?: string;
   }): Promise<boolean> {
+    const { route } = input;
     const slashCommand = parseSlashCommand(input.text);
     const sessionCommand = await this.executeSessionCommand({
-      workspaceId: input.workspaceId,
-      currentThreadId: input.threadId,
+      workspaceId: route.workspaceId,
+      currentThreadId: route.threadId,
       text: input.text,
       defaultTitle: `${input.displayName || input.platformLabel} ${new Date().toLocaleTimeString()}`,
-      defaultAgentType: slashCommand ? await this.resolveDefaultAgentType(input.workspaceId, input.threadId) : '',
-      chatId: input.chatId,
-      platformUserId: input.platformUserId,
-      platformKey: input.platformKey,
-      instanceId: input.instanceId,
+      defaultAgentType: slashCommand ? await this.resolveDefaultAgentType(route.workspaceId, route.threadId) : '',
+      chatId: route.chatId,
+      platformUserId: route.platformUserId,
+      platformKey: route.platformKey,
+      instanceId: route.instanceId,
       contextToken: input.contextToken,
     });
     if (sessionCommand.handled) return true;
-    const latestRun = this.options.store.getLatestRunForThread(input.threadId);
+    const latestRun = this.options.store.getLatestRunForThread(route.threadId);
     if (
       (input.normalizedText === 'allow' || input.normalizedText === 'allow all' || input.normalizedText === 'deny')
       && latestRun?.status === 'awaiting_input'
     ) {
       const router = this.options.getWorkspaceRouter();
-      await router.sendThreadAction(input.threadId, input.text);
+      await router.sendThreadAction(route.threadId, input.text);
       return true;
     }
     return false;

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -26,6 +26,7 @@ import { resolveChannelThreadRoute } from '../shared/thread-routing.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
 import { LocalCoreError } from '../../kernel/local-core-errors.js';
+import { parseSlashCommand } from '../../acp/local-core-slash-commands.js';
 
 export interface GatewayOptions {
   store: LocalCoreAcpStore;
@@ -378,6 +379,45 @@ export abstract class BaseChannelGateway<
 
   protected async executeSessionCommand(input: ChannelSessionCommandInput) {
     return this.sessionCommandRuntime.execute(input);
+  }
+
+  protected async dispatchSessionCommandOrAction(input: {
+    workspaceId: string;
+    threadId: string;
+    text: string;
+    normalizedText: string;
+    displayName?: string;
+    platformLabel: string;
+    chatId: string;
+    platformUserId: string;
+    platformKey: string;
+    instanceId: string;
+    contextToken?: string;
+  }): Promise<boolean> {
+    const slashCommand = parseSlashCommand(input.text);
+    const sessionCommand = await this.executeSessionCommand({
+      workspaceId: input.workspaceId,
+      currentThreadId: input.threadId,
+      text: input.text,
+      defaultTitle: `${input.displayName || input.platformLabel} ${new Date().toLocaleTimeString()}`,
+      defaultAgentType: slashCommand ? await this.resolveDefaultAgentType(input.workspaceId, input.threadId) : '',
+      chatId: input.chatId,
+      platformUserId: input.platformUserId,
+      platformKey: input.platformKey,
+      instanceId: input.instanceId,
+      contextToken: input.contextToken,
+    });
+    if (sessionCommand.handled) return true;
+    const latestRun = this.options.store.getLatestRunForThread(input.threadId);
+    if (
+      (input.normalizedText === 'allow' || input.normalizedText === 'allow all' || input.normalizedText === 'deny')
+      && latestRun?.status === 'awaiting_input'
+    ) {
+      const router = this.options.getWorkspaceRouter();
+      await router.sendThreadAction(input.threadId, input.text);
+      return true;
+    }
+    return false;
   }
 
   protected async resolveDefaultAgentType(workspaceId: string, threadId: string) {

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -510,27 +510,23 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     }
     const effectiveSessionKey = router.getThreadSessionKey(threadId);
 
-    this.threadRouting.set(effectiveSessionKey, {
+    const route: WeixinThreadRoute = {
       workspaceId: msg.workspaceId,
       instanceId,
       platformKey,
       platformUserId: msg.platformUserId,
       chatId: msg.chatId,
       threadId,
-    });
+    };
+    this.threadRouting.set(effectiveSessionKey, route);
 
     if (
-      await this.dispatchSessionCommandOrAction({
-        workspaceId: msg.workspaceId,
-        threadId,
+      await this.handleSessionCommandOrAction({
+        route,
         text: msg.text,
         normalizedText,
         displayName: msg.displayName,
         platformLabel: 'WeChat',
-        chatId: msg.chatId,
-        platformUserId: msg.platformUserId,
-        platformKey,
-        instanceId,
         contextToken: msg.contextToken,
       })
     ) {

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -31,7 +31,6 @@ import { resolveInboundChannelAuthorization } from '../shared/inbound-authorizat
 import { channelPlatformKey, extractChannelInstanceId, runtimeKey } from '../shared/channel-keys.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
-import { parseSlashCommand } from '../../acp/local-core-slash-commands.js';
 import {
   collectWeixinWorkspaceBindings,
   getWeixinBufPath,
@@ -520,30 +519,21 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
       threadId,
     });
 
-    // Handle slash commands
-    const slashCommand = parseSlashCommand(msg.text);
-    const sessionCommand = await this.executeSessionCommand({
-      workspaceId: msg.workspaceId,
-      currentThreadId: threadId,
-      text: msg.text,
-      defaultTitle: `${msg.displayName || 'WeChat'} ${new Date().toLocaleTimeString()}`,
-      defaultAgentType: slashCommand ? await this.resolveDefaultAgentType(msg.workspaceId, threadId) : '',
-      chatId: msg.chatId,
-      platformUserId: msg.platformUserId,
-      platformKey,
-      instanceId,
-      contextToken: msg.contextToken,
-    });
-    if (sessionCommand.handled) {
-      return;
-    }
-
-    const latestRun = this.options.store.getLatestRunForThread(threadId);
     if (
-      (normalizedText === 'allow' || normalizedText === 'allow all' || normalizedText === 'deny')
-      && latestRun?.status === 'awaiting_input'
+      await this.dispatchSessionCommandOrAction({
+        workspaceId: msg.workspaceId,
+        threadId,
+        text: msg.text,
+        normalizedText,
+        displayName: msg.displayName,
+        platformLabel: 'WeChat',
+        chatId: msg.chatId,
+        platformUserId: msg.platformUserId,
+        platformKey,
+        instanceId,
+        contextToken: msg.contextToken,
+      })
     ) {
-      await router.sendThreadAction(threadId, msg.text);
       return;
     }
 


### PR DESCRIPTION
## Summary

Lark and WeChat channel gateways duplicated the same ~20-line inbound-message-handling slice (`parseSlashCommand` → `executeSessionCommand` → handled check → allow/deny permission-action short-circuit). This PR extracts that slice as `handleSessionCommandOrAction` on the shared `BaseChannelGateway` both classes already extend, and removes the now-redundant `parseSlashCommand` import from both gateway files.

Each caller builds its `LarkThreadRoute` / `WeixinThreadRoute` once, passes it to both `threadRouting.set` and the helper. The helper returns `true` when the message is consumed (handled slash command or routed permission action) so each gateway can return early and otherwise proceed to its platform-specific message-id bookkeeping (`clearPlatformThreadMessageId` for Lark, `updatePlatformThreadMessageId` for WeChat).

- **Category:** code reuse / architecture
- **Eliminates clone #10** from `pnpm lint:duplicate` (14 duplicated lines, lark ↔ weixin gateways)
- Net: `+66 / −44` lines across 3 files (two gateway files shrink; one base-class helper added)

## Test plan

- [x] `pnpm test` — 611 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `node scripts/lint-duplicate.mjs` — duplicate rate 4.42% → 4.40%, clone #10 no longer in top 10
- [x] Behavior preserved: helper reproduces exact sequence (parseSlashCommand → executeSessionCommand → handled short-circuit → getLatestRunForThread → allow/all/deny+awaiting_input → sendThreadAction)

## Review rounds: 2

**Round 1** — Code Quality: APPROVE; Efficiency: APPROVE; Code Reuse: REQUEST CHANGES (rename for clarity, accept route object instead of 6 flattened fields).

**Round 2** — Applied both fixes (renamed `dispatchSessionCommandOrAction` → `handleSessionCommandOrAction`, switched to `route: TThreadRoute` parameter dropping input from 11 → 5 fields). All three reviewers APPROVE. Two further suggestions from round 1 were declined with justification: (a) folding permission-thread-id resolution into the helper would re-order Lark's `createTurnState` / `addAcknowledgementReaction` side effects that depend on the redirected `threadId`; (b) hoisting the larger 60-line authorization block was out of scope for a single daily PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)