### PR TITLE
Hoist inbound thread-resolution slice into BaseChannelGateway

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -25,7 +25,6 @@ import { LocalCoreError, formatSafeError, toLocalCoreErrorInfo } from '../../ker
 import { buildChannelFileSendPayload } from '../../runtime/channel-service-helpers.js';
 import { createChannelThreadMessageInput } from '../shared/content.js';
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
-import { resolveChannelThreadRoute } from '../shared/thread-routing.js';
 import { BaseChannelGateway, type GatewayBinding, type GatewayRuntimeState, type GatewayThreadRoute } from '../shared/base-channel-gateway.js';
 import { resolveInboundChannelAuthorization } from '../shared/inbound-authorization.js';
 import {
@@ -490,27 +489,16 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     }
     const authorized = authorization.authorized;
     const router = this.options.getWorkspaceRouter();
-    let { threadId } = await resolveChannelThreadRoute({
-      store: this.options.store,
-      router,
+    const { threadId, normalizedText, effectiveSessionKey } = await this.resolveInboundThreadAndSession({
       workspaceId: msg.workspaceId,
       platformKey,
-      chatId: msg.chatId,
       platformUserId: msg.platformUserId,
+      chatId: msg.chatId,
       displayName: msg.displayName,
-      fallbackTitlePrefix: 'Lark',
+      text: msg.text,
       authorized,
+      fallbackTitlePrefix: 'Lark',
     });
-    const normalizedText = String(msg.text || '').trim().toLowerCase();
-    const permissionThreadId = (
-      normalizedText === 'allow' || normalizedText === 'allow all' || normalizedText === 'deny'
-    )
-      ? this.findAwaitingPermissionThreadId(msg.workspaceId, msg.chatId, msg.platformUserId)
-      : '';
-    if (permissionThreadId && permissionThreadId !== threadId) {
-      threadId = permissionThreadId;
-    }
-    const effectiveSessionKey = this.options.getWorkspaceRouter().getThreadSessionKey(threadId);
     const route: LarkThreadRoute = {
       workspaceId: msg.workspaceId,
       instanceId,

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -19,6 +19,7 @@ import type {
 import type { ChannelRuntime } from '@cc/plugin-sdk';
 import type { LocalCoreAcpStore } from '../../acp/local-core-acp-store.js';
 import type { WorkspaceRouter } from '../../router/workspace-router.js';
+import type { LocalPlatformUserRow } from '../../router/workspace-router-types.js';
 import type { EventBus } from '@cc/plugin-sdk';
 import { createChannelThreadMessageInput } from '../shared/content.js';
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
@@ -379,6 +380,51 @@ export abstract class BaseChannelGateway<
 
   protected async executeSessionCommand(input: ChannelSessionCommandInput) {
     return this.sessionCommandRuntime.execute(input);
+  }
+
+  protected async resolveInboundThreadAndSession(input: {
+    workspaceId: string;
+    platformKey: string;
+    platformUserId: string;
+    chatId: string;
+    displayName: string;
+    text?: string;
+    authorized: Pick<LocalPlatformUserRow, 'chat_id' | 'thread_id'>;
+    fallbackTitlePrefix: string;
+    permissionLookupPlatformKey?: string;
+  }): Promise<{
+    threadId: string;
+    normalizedText: string;
+    effectiveSessionKey: string;
+  }> {
+    const router = this.options.getWorkspaceRouter();
+    let { threadId } = await resolveChannelThreadRoute({
+      store: this.options.store,
+      router,
+      workspaceId: input.workspaceId,
+      platformKey: input.platformKey,
+      chatId: input.chatId,
+      platformUserId: input.platformUserId,
+      displayName: input.displayName,
+      fallbackTitlePrefix: input.fallbackTitlePrefix,
+      authorized: input.authorized,
+    });
+    const normalizedText = String(input.text || '').trim().toLowerCase();
+    const permissionThreadId = (
+      normalizedText === 'allow' || normalizedText === 'allow all' || normalizedText === 'deny'
+    )
+      ? this.findAwaitingPermissionThreadId(
+          input.workspaceId,
+          input.chatId,
+          input.platformUserId,
+          input.permissionLookupPlatformKey,
+        )
+      : '';
+    if (permissionThreadId && permissionThreadId !== threadId) {
+      threadId = permissionThreadId;
+    }
+    const effectiveSessionKey = router.getThreadSessionKey(threadId);
+    return { threadId, normalizedText, effectiveSessionKey };
   }
 
   protected async handleSessionCommandOrAction(input: {

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -25,7 +25,6 @@ import { createChannelThreadMessageInput } from '../shared/content.js';
 import { prepareChannelFile, type PreparedChannelFile } from '../shared/file-utils.js';
 import { FileSystemInboundAttachmentStore, resolveInboundAttachmentUri } from '../shared/inbound-attachment-store.js';
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
-import { resolveChannelThreadRoute } from '../shared/thread-routing.js';
 import { BaseChannelGateway, type GatewayBinding, type GatewayRuntimeState, type GatewayThreadRoute } from '../shared/base-channel-gateway.js';
 import { resolveInboundChannelAuthorization } from '../shared/inbound-authorization.js';
 import { channelPlatformKey, extractChannelInstanceId, runtimeKey } from '../shared/channel-keys.js';
@@ -489,26 +488,17 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     const authorized = authorization.authorized;
 
     const router = this.options.getWorkspaceRouter();
-    let { threadId } = await resolveChannelThreadRoute({
-      store: this.options.store,
-      router,
+    const { threadId, normalizedText, effectiveSessionKey } = await this.resolveInboundThreadAndSession({
       workspaceId: msg.workspaceId,
       platformKey,
-      chatId: msg.chatId,
       platformUserId: msg.platformUserId,
+      chatId: msg.chatId,
       displayName: msg.displayName,
-      fallbackTitlePrefix: 'WeChat',
+      text: msg.text,
       authorized,
+      fallbackTitlePrefix: 'WeChat',
+      permissionLookupPlatformKey: msg.platformKey || 'weixin',
     });
-
-    const normalizedText = String(msg.text || '').trim().toLowerCase();
-    const permissionThreadId = (
-      normalizedText === 'allow' || normalizedText === 'allow all' || normalizedText === 'deny'
-    ) ? this.findAwaitingPermissionThreadId(msg.workspaceId, msg.chatId, msg.platformUserId, msg.platformKey || 'weixin') : '';
-    if (permissionThreadId && permissionThreadId !== threadId) {
-      threadId = permissionThreadId;
-    }
-    const effectiveSessionKey = router.getThreadSessionKey(threadId);
 
     const route: WeixinThreadRoute = {
       workspaceId: msg.workspaceId,


### PR DESCRIPTION
## Summary

Follow-up to #51, continuing the inbound-message-handling dedup between Lark and WeChat gateways. The slice immediately upstream of `handleSessionCommandOrAction` — `resolveChannelThreadRoute` + permission-thread redirect + `effectiveSessionKey` derivation — was byte-for-byte identical between the two gateways except for two deltas: `fallbackTitlePrefix` (`'Lark'` vs `'WeChat'`) and the `platformKey` passed to `findAwaitingPermissionThreadId` (Lark omits; WeChat passes `msg.platformKey || 'weixin'`).

Extracted as `resolveInboundThreadAndSession` on the shared `BaseChannelGateway`, returning `{ threadId, normalizedText, effectiveSessionKey }`. Each caller keeps its platform-specific route-object construction (the route carries `instanceId` and the gateway's `TThreadRoute` subtype, which is a gateway-local concern). Removes the now-unused `resolveChannelThreadRoute` import from both gateway files.

- **Category:** code reuse / architecture
- Net: `+55 / −31` lines across 3 files
- Completes the two-step inbound-handler dedup started in #51

## Test plan

- [x] `pnpm test` — 611 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `pnpm typecheck` — clean (initial attempt had wrong types for `authorized` and `displayName`; fixed by matching `ResolveChannelThreadRouteInput` exactly)
- [x] Behavior preserved: helper reproduces the exact sequence (resolveChannelThreadRoute → normalizedText → conditional findAwaitingPermissionThreadId → swap threadId → getThreadSessionKey)

## Review rounds: 1

All three reviewers signed off in round 1 with no change requests:
- **Code Reuse:** APPROVE — correct layer, right boundary (route construction stays in caller), input shape accurate and minimal; other candidates (resolveInboundChannelAuthorization, pending branch, route literal) correctly left alone as platform-specific.
- **Code Quality:** APPROVE — behavior parity preserved, `authorized: Pick<LocalPlatformUserRow, 'chat_id' | 'thread_id'>` matches `ResolveChannelThreadRouteInput` exactly, `displayName: string` matches msg types, router double-call idempotent.
- **Efficiency:** APPROVE — no meaningful regression (9-field object allocation negligible at chat-message rate; `getWorkspaceRouter()` is a cheap closure dereference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)