### PR TITLE
Extract resolveContractEnum helper for status normalize functions

### DIFF
--- a/packages/contracts/src/local-core.ts
+++ b/packages/contracts/src/local-core.ts
@@ -5,6 +5,7 @@ import {
   ChannelRoute,
   normalizeContractEnumValue,
   normalizeScheduledJobExecutionMode,
+  resolveContractEnum,
   ScheduledJobExecutionMode,
   ScheduledJobRoute,
 } from './scheduler.js';
@@ -119,26 +120,13 @@ export interface CommandRiskClassification {
 export type ApprovalRequestStatus = 'pending' | 'approved' | 'rejected' | 'cancelled' | 'expired';
 
 export function normalizeApprovalRequestStatus(value: unknown, fallback: ApprovalRequestStatus = 'pending'): ApprovalRequestStatus {
-  const normalized = normalizeContractEnumValue(value || fallback).replace(/-/g, '_');
-  if (
-    normalized === 'pending' ||
-    normalized === 'approved' ||
-    normalized === 'rejected' ||
-    normalized === 'cancelled' ||
-    normalized === 'expired'
-  ) {
-    return normalized;
-  }
-  if (normalized === 'approve') {
-    return 'approved';
-  }
-  if (normalized === 'reject') {
-    return 'rejected';
-  }
-  if (normalized === 'canceled') {
-    return 'cancelled';
-  }
-  throw new Error('Approval request status must be pending, approved, rejected, cancelled, or expired.');
+  return resolveContractEnum({
+    value,
+    fallback,
+    valid: ['pending', 'approved', 'rejected', 'cancelled', 'expired'],
+    aliases: { approve: 'approved', reject: 'rejected', canceled: 'cancelled' },
+    errorMessage: 'Approval request status must be pending, approved, rejected, cancelled, or expired.',
+  });
 }
 
 export type ApprovalRequestKind =
@@ -348,22 +336,13 @@ export type AgentTaskStatus =
   | 'cancelled';
 
 export function normalizeAgentTaskStatus(value: unknown, fallback: AgentTaskStatus = 'created'): AgentTaskStatus {
-  const normalized = normalizeContractEnumValue(value || fallback).replace(/-/g, '_');
-  if (
-    normalized === 'created' ||
-    normalized === 'queued' ||
-    normalized === 'running' ||
-    normalized === 'waiting_for_user' ||
-    normalized === 'completed' ||
-    normalized === 'failed' ||
-    normalized === 'cancelled'
-  ) {
-    return normalized;
-  }
-  if (normalized === 'canceled') {
-    return 'cancelled';
-  }
-  throw new Error('Agent task status must be created, queued, running, waiting_for_user, completed, failed, or cancelled.');
+  return resolveContractEnum({
+    value,
+    fallback,
+    valid: ['created', 'queued', 'running', 'waiting_for_user', 'completed', 'failed', 'cancelled'],
+    aliases: { canceled: 'cancelled' },
+    errorMessage: 'Agent task status must be created, queued, running, waiting_for_user, completed, failed, or cancelled.',
+  });
 }
 
 export type AgentTaskTimelineItemType =
@@ -707,21 +686,13 @@ export function normalizeChannelPlatform(value: unknown) {
 }
 
 export function normalizeRunStatus(value: unknown, fallback: RunSummary['status'] = 'queued'): RunSummary['status'] {
-  const normalized = normalizeContractEnumValue(value || fallback).replace(/-/g, '_');
-  if (
-    normalized === 'queued' ||
-    normalized === 'running' ||
-    normalized === 'awaiting_input' ||
-    normalized === 'completed' ||
-    normalized === 'failed' ||
-    normalized === 'interrupted'
-  ) {
-    return normalized;
-  }
-  if (normalized === 'cancelled' || normalized === 'canceled') {
-    return 'interrupted';
-  }
-  throw new Error('Run status must be queued, running, awaiting_input, completed, failed, or interrupted.');
+  return resolveContractEnum({
+    value,
+    fallback,
+    valid: ['queued', 'running', 'awaiting_input', 'completed', 'failed', 'interrupted'],
+    aliases: { cancelled: 'interrupted', canceled: 'interrupted' },
+    errorMessage: 'Run status must be queued, running, awaiting_input, completed, failed, or interrupted.',
+  });
 }
 
 export interface ScheduledJobExecutionTarget {
@@ -772,23 +743,19 @@ export interface ScheduledJobRun {
 }
 
 export function normalizeScheduledJobRunStatus(value: unknown, fallback: ScheduledJobRun['status'] = 'queued'): ScheduledJobRun['status'] {
-  const normalized = normalizeContractEnumValue(value || fallback).replace(/-/g, '_');
-  if (
-    normalized === 'queued' ||
-    normalized === 'running' ||
-    normalized === 'succeeded' ||
-    normalized === 'failed' ||
-    normalized === 'skipped'
-  ) {
-    return normalized;
-  }
-  if (normalized === 'complete' || normalized === 'completed' || normalized === 'success') {
-    return 'succeeded';
-  }
-  if (normalized === 'cancelled' || normalized === 'canceled') {
-    return 'skipped';
-  }
-  throw new Error('Scheduled job run status must be queued, running, succeeded, failed, or skipped.');
+  return resolveContractEnum({
+    value,
+    fallback,
+    valid: ['queued', 'running', 'succeeded', 'failed', 'skipped'],
+    aliases: {
+      complete: 'succeeded',
+      completed: 'succeeded',
+      success: 'succeeded',
+      cancelled: 'skipped',
+      canceled: 'skipped',
+    },
+    errorMessage: 'Scheduled job run status must be queued, running, succeeded, failed, or skipped.',
+  });
 }
 
 export interface ScheduledJobCreateInput {
@@ -902,20 +869,13 @@ export interface AutomationMonitorUpdateInput {
 }
 
 export function normalizeAutomationMonitorStatus(value: unknown, fallback: AutomationMonitorStatus = 'queued'): AutomationMonitorStatus {
-  const normalized = normalizeContractEnumValue(value || fallback).replace(/-/g, '_');
-  if (
-    normalized === 'queued' ||
-    normalized === 'running' ||
-    normalized === 'succeeded' ||
-    normalized === 'failed' ||
-    normalized === 'skipped'
-  ) {
-    return normalized;
-  }
-  if (normalized === 'complete' || normalized === 'completed' || normalized === 'success') {
-    return 'succeeded';
-  }
-  throw new Error('Automation monitor status must be queued, running, succeeded, failed, or skipped.');
+  return resolveContractEnum({
+    value,
+    fallback,
+    valid: ['queued', 'running', 'succeeded', 'failed', 'skipped'],
+    aliases: { complete: 'succeeded', completed: 'succeeded', success: 'succeeded' },
+    errorMessage: 'Automation monitor status must be queued, running, succeeded, failed, or skipped.',
+  });
 }
 
 export function normalizeAutomationMonitorConditionOperator(value: unknown): AutomationMonitorConditionOperator {

--- a/packages/contracts/src/scheduler.ts
+++ b/packages/contracts/src/scheduler.ts
@@ -17,6 +17,22 @@ export function normalizeContractEnumValue(value: unknown) {
   return String(value || '').trim().toLowerCase().replace(/[\s_]+/g, '-');
 }
 
+export function resolveContractEnum<T extends string>(input: {
+  value: unknown;
+  fallback: T;
+  valid: readonly T[];
+  aliases?: Record<string, T>;
+  errorMessage: string;
+}): T {
+  const normalized = normalizeContractEnumValue(input.value || input.fallback).replace(/-/g, '_');
+  const direct = input.valid.find((candidate) => candidate === normalized);
+  if (direct) return direct;
+  if (input.aliases && normalized in input.aliases) {
+    return input.aliases[normalized];
+  }
+  throw new Error(input.errorMessage);
+}
+
 export function normalizeScheduledJobExecutionMode(value: unknown, fallback: ScheduledJobExecutionMode = 'same-thread'): ScheduledJobExecutionMode {
   const normalized = normalizeContractEnumValue(value || fallback);
   if (normalized === 'same-thread' || normalized === 'side-thread') {


### PR DESCRIPTION
## Summary

Five `normalize*Status` functions in `packages/contracts/src/local-core.ts` followed the exact same shape: `normalizeContractEnumValue(value || fallback).replace(/-/g, '_')` → check valid-values list → check alias blocks → throw. The duplication showed up as clones #5 and #7 in the duplicate-code report (15 and 14 lines, same-file in local-core.ts).

Extracted `resolveContractEnum<T extends string>` in `scheduler.ts` (next to the existing `normalizeContractEnumValue` it builds on). Each call site is now a single config object: `{ value, fallback, valid, aliases?, errorMessage }`. The helper uses `Array.find` for the direct-match check (returns `T` directly, no unsafe cast), then checks the aliases record, then throws.

Functions refactored:
- `normalizeApprovalRequestStatus` — aliases: approve→approved, reject→rejected, canceled→cancelled
- `normalizeAgentTaskStatus` — alias: canceled→cancelled
- `normalizeRunStatus` — aliases: cancelled/canceled→interrupted
- `normalizeScheduledJobRunStatus` — aliases: complete/completed/success→succeeded, cancelled/canceled→skipped
- `normalizeAutomationMonitorStatus` — aliases: complete/completed/success→succeeded

- **Category:** code reuse / code quality
- Net: `+58 / −82` lines across 2 files; duplicate rate 4.39% → 4.33%, clones #5 and #7 eliminated from top 10

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 611 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `node scripts/lint-duplicate.mjs` — contracts/local-core.ts no longer in top duplicated blocks
- [x] Behavior preserved: verified valid-values, aliases, error messages, and fallback defaults match originals exactly for all 5 functions

## Review rounds: 1

All three reviewers signed off in round 1 with no change requests:
- **Code Reuse:** APPROVE — sound helper design, correct placement, correct scope boundary (3 similar functions excluded for diverging patterns).
- **Code Quality:** APPROVE — all 5 functions verified for parity, type-safe via generic constraint + `find`-based narrowing, no drift.
- **Efficiency:** APPROVE — no meaningful regression; per-call config allocation negligible on these paths.

Two non-blocking nits were noted (hoist config to module constants; add comment on alias key convention) — both explicitly marked as polish, not required.

## Out of scope (follow-up candidates)

Three similar functions deliberately excluded:
- `normalizeScheduledJobTriggerType` / `normalizeScheduledJobExecutionMode` — use hyphenated values (`same-thread`), would need a `keepHyphens` flag.
- `normalizeChannelContentPartType` — no fallback, no aliases.
- `normalizeAutomationMonitorConditionOperator` — different base normalization, operator tokens (`>=`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)