### PR TITLE
Extract buildWorkspacePlatformWhere helper in platform-store

### DIFF
--- a/services/local-ai-core/src/acp/store/platform-store.ts
+++ b/services/local-ai-core/src/acp/store/platform-store.ts
@@ -9,6 +9,21 @@ import type {
   LocalPlatformUserRow,
 } from './acp-store-types.js';
 
+function buildWorkspacePlatformWhere(workspaceId?: string, platform?: string): { where: string; params: string[] } {
+  const params: string[] = [];
+  const predicates: string[] = [];
+  if (workspaceId) {
+    predicates.push('workspace_id = ?');
+    params.push(workspaceId);
+  }
+  if (platform) {
+    predicates.push('platform = ?');
+    params.push(platform);
+  }
+  const where = predicates.length > 0 ? `WHERE ${predicates.join(' AND ')}` : '';
+  return { where, params };
+}
+
 export class LocalPlatformStore {
   constructor(private readonly db: DatabaseSync) {}
 
@@ -75,17 +90,7 @@ export class LocalPlatformStore {
   }
 
   listAuthorizedUsers(workspaceId?: string, platform?: string): LocalCoreAuthorizedUser[] {
-    const params: string[] = [];
-    const predicates: string[] = [];
-    if (workspaceId) {
-      predicates.push('workspace_id = ?');
-      params.push(workspaceId);
-    }
-    if (platform) {
-      predicates.push('platform = ?');
-      params.push(platform);
-    }
-    const where = predicates.length > 0 ? `WHERE ${predicates.join(' AND ')}` : '';
+    const { where, params } = buildWorkspacePlatformWhere(workspaceId, platform);
     const query = `
         SELECT id, workspace_id, platform, platform_user_id, chat_id, display_name, thread_id, authorized_at
         FROM platform_users
@@ -216,17 +221,7 @@ export class LocalPlatformStore {
   }
 
   listPairingRequests(workspaceId?: string, platform?: string): LocalCorePairingRequest[] {
-    const params: string[] = [];
-    const predicates: string[] = [];
-    if (workspaceId) {
-      predicates.push('workspace_id = ?');
-      params.push(workspaceId);
-    }
-    if (platform) {
-      predicates.push('platform = ?');
-      params.push(platform);
-    }
-    const where = predicates.length > 0 ? `WHERE ${predicates.join(' AND ')}` : '';
+    const { where, params } = buildWorkspacePlatformWhere(workspaceId, platform);
     const query = `
         SELECT code, workspace_id, platform, platform_user_id, chat_id, display_name, requested_at, expires_at, status
         FROM platform_pairings


### PR DESCRIPTION
## Summary
- Extracts the duplicated workspace+platform WHERE-clause construction between `listAuthorizedUsers` and `listPairingRequests` in `services/local-ai-core/src/acp/store/platform-store.ts` into a single module-level helper `buildWorkspacePlatformWhere(workspaceId?, platform?)` returning `{ where, params }`.
- Eliminates duplicate clone #10 from the daily `pnpm lint:duplicate` report (13 lines, same-file).
- No behavior change — predicate order, parameter order, and the "no WHERE when both filters absent" branch are preserved exactly.

## Motivation
Daily refactor pass — code-reuse category. The two methods had byte-for-byte identical WHERE-construction blocks. Both query different tables (`platform_users` vs `platform_pairings`) but build the exact same filter shape, so the helper is a clean shared extraction without forcing broader scope.

Other stores (`security-store.ts`, `agent-task-store.ts`) use different field sets and are deliberately left out of scope.

## Review rounds
3 parallel sub-agents (Code Reuse / Code Quality / Efficiency) — all APPROVED on round 1, no requested changes.

## Test plan
- [x] `pnpm test` — 611 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `pnpm lint:duplicate` — platform-store clone no longer in top 10
- [x] Manual verification of all 4 input combinations (both filters / workspace-only / platform-only / neither) produces byte-identical SQL to the original