### PR TITLE
Extract ThreadSessionRow interfaces in workspace-thread-mappers

### DIFF
--- a/services/local-ai-core/src/thread/workspace-thread-mappers.ts
+++ b/services/local-ai-core/src/thread/workspace-thread-mappers.ts
@@ -1,11 +1,37 @@
 import type { ThreadDetail, ThreadMessage, ThreadSummary } from '@cc/superai-contracts';
 import { encodeThreadId } from './workspace-thread-id.js';
 
+export interface ThreadHistoryEntry {
+  role: string;
+  content: string;
+  kind?: string;
+  timestamp: string;
+}
+
+export interface ThreadSessionSummaryRow {
+  id: string;
+  session_key: string;
+  name: string;
+  active: boolean;
+  live: boolean;
+  created_at: string;
+  updated_at: string;
+  history_count: number;
+  last_message: { content: string } | null;
+  user_name?: string;
+  chat_name?: string;
+  agent_type: string;
+}
+
+export interface ThreadSessionDetailRow extends ThreadSessionSummaryRow {
+  history: ThreadHistoryEntry[];
+}
+
 export function normalizeMessageContent(content?: string | null) {
   return String(content || '').replace(/\n/g, ' ').trim();
 }
 
-export function toThreadMessages(history: Array<{ role: string; content: string; kind?: string; timestamp: string }>): ThreadMessage[] {
+export function toThreadMessages(history: ThreadHistoryEntry[]): ThreadMessage[] {
   return history.map((message, index) => ({
     id: `${message.timestamp || index}-${message.role}-${index}`,
     role: message.role === 'user' ? 'user' : message.role === 'assistant' ? 'assistant' : 'system',
@@ -15,23 +41,7 @@ export function toThreadMessages(history: Array<{ role: string; content: string;
   }));
 }
 
-export function toThreadSummary(
-  workspaceId: string,
-  session: {
-    id: string;
-    session_key: string;
-    name: string;
-    active: boolean;
-    live: boolean;
-    created_at: string;
-    updated_at: string;
-    history_count: number;
-    last_message: { content: string } | null;
-    user_name?: string;
-    chat_name?: string;
-    agent_type: string;
-  },
-): ThreadSummary {
+export function toThreadSummary(workspaceId: string, session: ThreadSessionSummaryRow): ThreadSummary {
   const id = encodeThreadId(workspaceId, session.id);
   return {
     id,
@@ -51,21 +61,7 @@ export function toThreadSummary(
 
 export function toThreadDetail(
   workspaceId: string,
-  session: {
-    id: string;
-    session_key: string;
-    name: string;
-    active: boolean;
-    live: boolean;
-    created_at: string;
-    updated_at: string;
-    history_count: number;
-    last_message: { content: string } | null;
-    user_name?: string;
-    chat_name?: string;
-    agent_type: string;
-    history: Array<{ role: string; content: string; kind?: string; timestamp: string }>;
-  },
+  session: ThreadSessionDetailRow,
   selectedKnowledgeBaseIds: string[] = [],
 ): ThreadDetail {
   return {


### PR DESCRIPTION
## Summary
- Extracts the duplicated inline session parameter type declarations between `toThreadSummary` and `toThreadDetail` in `services/local-ai-core/src/thread/workspace-thread-mappers.ts` into three exported interfaces.
- Eliminates duplicate clone #5 from the daily `pnpm lint:duplicate` report (15 lines, same-file).
- New exported interfaces:
  - `ThreadHistoryEntry` — the `{role, content, kind?, timestamp}` shape, previously duplicated in `toThreadMessages` and `toThreadDetail`
  - `ThreadSessionSummaryRow` — the session row shape used by `toThreadSummary`
  - `ThreadSessionDetailRow extends ThreadSessionSummaryRow` — adds the `history` field for `toThreadDetail`

## Motivation
Daily refactor pass — **code-reuse** category. The two mapper functions had near-byte-identical 12-field inline session parameter types. Extracting them to named interfaces removes the duplication and gives the rest of the codebase typed handles for the session row shape if needed.

## Review rounds
3 parallel sub-agents (Code Reuse / Code Quality / Efficiency) — all APPROVED on round 1, no requested changes.

One nit flagged non-blocking by Code Quality: `session.history || []` is now structurally redundant given `ThreadSessionDetailRow.history` is required. Left as-is — predates this PR and acts as defensible runtime defense against JS callers that bypass TypeScript.

## Test plan
- [x] `pnpm test` — 611 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `pnpm lint:duplicate` — workspace-thread-mappers clone no longer in top 10
- [x] Function bodies byte-identical to main (verified by Efficiency reviewer)