### PR TITLE
Extract emitInboundMessageReceived helper in BaseChannelGateway

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -439,18 +439,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     const msg = input as LarkInboundMessage;
     const instanceId = msg.instanceId || 'default';
     const platformKey = msg.platformKey || channelPlatformKey('lark', instanceId);
-    this.options.eventBus.emit({
-      type: 'platform.message.received',
-      payload: {
-        platform: this.platform,
-        workspaceId: msg.workspaceId,
-        participantId: msg.platformUserId,
-        channelId: msg.chatId,
-        displayName: msg.displayName,
-        text: msg.text,
-        messageId: msg.messageId,
-      },
-    });
+    this.emitInboundMessageReceived(msg);
     const runtimeState = this.resolveRuntimeState(msg.workspaceId, instanceId).state;
     let binding: LarkWorkspaceBinding | undefined;
     try {

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -72,7 +72,7 @@ export interface GatewayTurnState {
   awaitingPermission?: boolean;
 }
 
-export interface InboundMessageEventPayload {
+export interface InboundMessageEventInput {
   workspaceId: string;
   platformUserId: string;
   chatId: string;
@@ -504,7 +504,7 @@ export abstract class BaseChannelGateway<
     return '';
   }
 
-  protected emitInboundMessageReceived(msg: InboundMessageEventPayload) {
+  protected emitInboundMessageReceived(msg: InboundMessageEventInput) {
     this.options.eventBus.emit({
       type: 'platform.message.received',
       payload: {

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -72,6 +72,15 @@ export interface GatewayTurnState {
   awaitingPermission?: boolean;
 }
 
+export interface InboundMessageEventPayload {
+  workspaceId: string;
+  platformUserId: string;
+  chatId: string;
+  displayName: string;
+  text: string;
+  messageId: string;
+}
+
 function resolveRuntimeKey(workspaceId: string, instanceId?: string): string {
   return instanceId ? `${workspaceId}::${instanceId}` : workspaceId;
 }
@@ -493,6 +502,21 @@ export abstract class BaseChannelGateway<
       }
     }
     return '';
+  }
+
+  protected emitInboundMessageReceived(msg: InboundMessageEventPayload) {
+    this.options.eventBus.emit({
+      type: 'platform.message.received',
+      payload: {
+        platform: this.platform,
+        workspaceId: msg.workspaceId,
+        participantId: msg.platformUserId,
+        channelId: msg.chatId,
+        displayName: msg.displayName,
+        text: msg.text,
+        messageId: msg.messageId,
+      },
+    });
   }
 
   // ==================== Runtime Management ====================

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -444,18 +444,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
       return;
     }
 
-    this.options.eventBus.emit({
-      type: 'platform.message.received',
-      payload: {
-        platform: this.platform,
-        workspaceId: msg.workspaceId,
-        participantId: msg.platformUserId,
-        channelId: msg.chatId,
-        displayName: msg.displayName,
-        text: msg.text,
-        messageId: msg.messageId,
-      },
-    });
+    this.emitInboundMessageReceived(msg);
 
     const binding = await this.getBinding(msg.workspaceId, instanceId);
     const authorization = resolveInboundChannelAuthorization({


### PR DESCRIPTION
## Summary
- Extracts the duplicated `platform.message.received` eventBus emit block (11 lines per gateway) between `handleInboundMessage` in `services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts` and `services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts` into a new protected `emitInboundMessageReceived(msg)` method on `BaseChannelGateway`.
- Eliminates duplicate clone #9 from the daily `pnpm lint:duplicate` report (13 lines, cross-file).
- Introduces a new exported `InboundMessageEventInput` interface in `base-channel-gateway.ts` typing the structural subset of inbound message fields the helper reads. Both `LarkInboundMessage` and `WeixinInboundMessage` satisfy this shape.

## Motivation
Daily refactor pass — **code-reuse** category. Both gateways constructed byte-identical eventBus payloads from the same msg fields. The new helper centralizes the field mapping (`platform: this.platform`, `participantId: msg.platformUserId`, `channelId: msg.chatId`, etc.) so future changes to the payload shape happen in one place.

## Design note
The new `InboundMessageEventInput` interface is intentionally a *new* type rather than reusing `DomainEventPayloadMap['platform.message.received']` from `runtime-types.ts`. The source msg uses `platformUserId`/`chatId` while the emitted payload uses `participantId`/`channelId` — different field names that require explicit mapping in the helper body. A pure reuse type would force call sites to rename fields or break the mapping.

## Review rounds
3 parallel sub-agents (Code Reuse / Code Quality / Efficiency) — round 1 results:
- **Code Reuse**: REQUEST_CHANGES (suggested reusing `Omit<DomainEventPayloadMap[...], 'platform'>`). Evaluated and rejected — the proposed type's field names (`participantId`/`channelId`) don't match the source msg's field names (`platformUserId`/`chatId`), so the suggested fix would break call sites.
- **Code Quality**: APPROVE. Flagged naming nit: `InboundMessageEventPayload` was misleading since the type represents source fields, not the actual emitted payload.
- **Efficiency**: APPROVE (zero runtime regression).

Round 2: Applied the naming nit — renamed `InboundMessageEventPayload` → `InboundMessageEventInput` to clarify it's the helper's input shape.

## Test plan
- [x] `pnpm test` — 611 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `pnpm lint:duplicate` — typescript duplicated lines dropped 1865 → 1833; the eventBus-emit clone is no longer in the top 10
- [x] Field mapping behavior verified identical to the original inline blocks