### PR TITLE
Reuse SchedulerHandlers type in acp-backend

### DIFF
--- a/services/local-ai-core/src/acp/local-core-acp-backend.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-backend.ts
@@ -1,9 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import type { DesktopBridgeEvent, ScheduledJobRoute, ThreadDetail, ThreadSummary } from '@cc/superai-contracts';
+import type { DesktopBridgeEvent, ThreadDetail, ThreadSummary } from '@cc/superai-contracts';
 import {
   LOCALCORE_ACP_AGENT_TYPE,
 } from '@cc/superai-contracts';
-import type { ScheduledJob } from '@cc/superai-contracts';
 import { LocalCoreAcpStore } from './local-core-acp-store.js';
 import type { EventBus } from '@cc/plugin-sdk';
 import type {
@@ -13,7 +12,7 @@ import type {
 import { LocalCoreAcpTransport } from './local-core-acp-transport.js';
 import { LocalCoreAcpTurnCoordinator } from './local-core-acp-turn-coordinator.js';
 import { LocalCoreAcpSessionCoordinator } from './local-core-acp-session-coordinator.js';
-import { LocalCoreAcpResponseProcessor } from './local-core-acp-response-processor.js';
+import { LocalCoreAcpResponseProcessor, type SchedulerHandlers } from './local-core-acp-response-processor.js';
 import type { ThreadMessageInput } from './local-core-acp-content.js';
 import { normalizeThreadMessageInput } from './local-core-acp-content.js';
 import { classifyCommandRisk } from '../security/command-risk.js';
@@ -37,19 +36,7 @@ type LocalCoreAcpBackendOptions = {
   localCoreBase?: string;
   emitBridge: (event: DesktopBridgeEvent) => void;
   eventBus: EventBus;
-  scheduler: {
-    createJob: (input: {
-      workspaceId: string;
-      platform: string;
-      route: ScheduledJobRoute;
-      name: string;
-      schedule: string;
-      scheduleDescription: string;
-      message: string;
-    }) => Promise<ScheduledJob>;
-    listJobsForThread: (threadId: string) => Promise<ScheduledJob[]>;
-    deleteJob: (jobId: string) => Promise<void>;
-  };
+  scheduler: SchedulerHandlers;
   getAgentTypes?: () => string[];
   log?: (message: string) => void;
 };

--- a/services/local-ai-core/src/acp/local-core-acp-response-processor.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-response-processor.ts
@@ -3,7 +3,7 @@ import { detectCronCommands, stripCronCommands, type CronCommand } from '../sche
 import { toPublicScheduledJobId } from '../scheduler/job-id.js';
 import { withoutThreadRoute } from '../scheduler/scheduled-job-route.js';
 
-type SchedulerHandlers = {
+export type SchedulerHandlers = {
   createJob: (input: {
     workspaceId: string;
     platform: string;


### PR DESCRIPTION
## Summary
- Removes the duplicated 13-line `SchedulerHandlers` type signature between `services/local-ai-core/src/acp/local-core-acp-backend.ts` (where it was inline inside `LocalCoreAcpBackendOptions`) and `services/local-ai-core/src/acp/local-core-acp-response-processor.ts` (where it was already declared as a local `type SchedulerHandlers`).
- Exports `SchedulerHandlers` from response-processor and imports it (type-only) into backend.
- Drops now-unused `ScheduledJob` / `ScheduledJobRoute` imports from backend.

## Motivation
Daily refactor pass — **code-reuse** category. Two files in the same `acp/` module declared the same scheduler-handler contract twice. Centralizing on the existing named type means future signature changes happen in one place.

The reused type lives in `response-processor.ts` (not a neutral types file) because the shape is ACP-internal — it's not a cross-process contract that belongs in `packages/contracts/`. Both consumers are in the same directory.

## Review rounds
3 parallel sub-agents (Code Reuse / Code Quality / Efficiency) — all APPROVED on round 1, no requested changes.

Code Reuse reviewer noted a structurally overlapping third clone in `services/local-ai-core/src/router/workspace-router.ts:57-69` (uses `ScheduledJob['route']` instead of `ScheduledJobRoute`, different scoping) — explicitly flagged as out of scope per the "1-2 issues per PR" guideline.

## Test plan
- [x] `pnpm test` — 611 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `pnpm lint:duplicate` — typescript duplicated lines dropped 1833 → 1821; the SchedulerHandlers clone is no longer in the top 10
- [x] Verified `ScheduledJob` / `ScheduledJobRoute` have zero remaining references in backend (confirmed by Code Reuse reviewer)