### PR TITLE
Extract buildAgentCapabilityFields helper for agent plugin factories

### DIFF
--- a/services/local-ai-core/src/agents/index.ts
+++ b/services/local-ai-core/src/agents/index.ts
@@ -1,4 +1,5 @@
 import type { RuntimePlugin } from '@cc/plugin-sdk';
+import { buildAgentCapabilityFields } from './shared/agent-plugin.js';
 
 export {
   getAgentRuntimeDefinitions,
@@ -8,23 +9,7 @@ export {
 } from './registry.js';
 
 export function createBuiltinStaticAgentCapabilityPlugin(agentType: string, displayName = agentType): RuntimePlugin {
-  return {
-    manifest: {
-      id: `builtin.agent-${agentType}`,
-      kind: 'agent',
-      version: '0.1.0',
-      provides: [`agent:${agentType}`],
-    },
-    capabilities: {
-      agents: [
-        {
-          id: `agent.${agentType}`,
-          agentType,
-          displayName,
-        },
-      ],
-    },
-  };
+  return buildAgentCapabilityFields(agentType, displayName);
 }
 
 export { createBuiltinCodexAgentPlugin } from './codex/index.js';

--- a/services/local-ai-core/src/agents/shared/agent-plugin.ts
+++ b/services/local-ai-core/src/agents/shared/agent-plugin.ts
@@ -1,5 +1,5 @@
 import type { DesktopProjectConfig, RuntimeConfigState } from '@cc/superai-contracts';
-import type { AgentPlugin, AgentRuntime, AgentRuntimeRoute, PluginContext } from '@cc/plugin-sdk';
+import type { AgentCapability, AgentPlugin, AgentRuntime, AgentRuntimeRoute, PluginContext, PluginManifest } from '@cc/plugin-sdk';
 import { LOCALCORE_ACP_AGENT_TYPE } from '@cc/superai-contracts';
 import { toLocalCoreProjectConfig } from '../../router/workspace-route-config.js';
 import type { AgentRuntimeDefinition } from './definition.js';
@@ -32,8 +32,8 @@ function createRuntime(agentType: string, match: (normalizedAgentType: string) =
 }
 
 export function buildAgentCapabilityFields(agentType: string, displayName = agentType, pluginId = `builtin.agent-${agentType}`): {
-  manifest: { id: string; kind: 'agent'; version: string; provides: string[] };
-  capabilities: { agents: Array<{ id: string; agentType: string; displayName: string }> };
+  manifest: PluginManifest & { kind: 'agent' };
+  capabilities: { agents: AgentCapability[] };
 } {
   return {
     manifest: {

--- a/services/local-ai-core/src/agents/shared/agent-plugin.ts
+++ b/services/local-ai-core/src/agents/shared/agent-plugin.ts
@@ -31,17 +31,10 @@ function createRuntime(agentType: string, match: (normalizedAgentType: string) =
   };
 }
 
-export function createBuiltinAgentPlugin(options: {
-  pluginId?: string;
-  agentType?: string;
-  definition?: AgentRuntimeDefinition;
-  match: (normalizedAgentType: string) => boolean;
-  displayName?: string;
-}): AgentPlugin {
-  const agentType = options.definition?.agentType || options.agentType || '';
-  const displayName = options.definition?.displayName || options.displayName || agentType;
-  const pluginId = options.pluginId || `builtin.agent-${agentType}`;
-  let runtime: AgentRuntime | null = null;
+export function buildAgentCapabilityFields(agentType: string, displayName = agentType, pluginId = `builtin.agent-${agentType}`): {
+  manifest: { id: string; kind: 'agent'; version: string; provides: string[] };
+  capabilities: { agents: Array<{ id: string; agentType: string; displayName: string }> };
+} {
   return {
     manifest: {
       id: pluginId,
@@ -58,6 +51,22 @@ export function createBuiltinAgentPlugin(options: {
         },
       ],
     },
+  };
+}
+
+export function createBuiltinAgentPlugin(options: {
+  pluginId?: string;
+  agentType?: string;
+  definition?: AgentRuntimeDefinition;
+  match: (normalizedAgentType: string) => boolean;
+  displayName?: string;
+}): AgentPlugin {
+  const agentType = options.definition?.agentType || options.agentType || '';
+  const displayName = options.definition?.displayName || options.displayName || agentType;
+  const pluginId = options.pluginId || `builtin.agent-${agentType}`;
+  let runtime: AgentRuntime | null = null;
+  return {
+    ...buildAgentCapabilityFields(agentType, displayName, pluginId),
     createRuntime(_ctx: PluginContext) {
       if (!runtime) {
         runtime = createRuntime(agentType, options.match, displayName);


### PR DESCRIPTION
## Summary
- Removes the duplicated 14-line `manifest + capabilities` object literal between `createBuiltinStaticAgentCapabilityPlugin` (in `services/local-ai-core/src/agents/index.ts`) and `createBuiltinAgentPlugin` (in `services/local-ai-core/src/agents/shared/agent-plugin.ts`).
- Extracts a new exported `buildAgentCapabilityFields(agentType, displayName, pluginId)` helper in `agent-plugin.ts`.
- The static capability factory now returns the helper output directly; the full plugin factory spreads the helper output and adds `createRuntime`.

## Motivation
Daily refactor pass — **code-reuse** category. Both factories declared byte-identical `{ manifest: { id, kind: 'agent', version, provides }, capabilities: { agents: [...] } }` literals. Centralizing on a single helper means future shape changes (e.g., adding a new capability field) happen in one place.

The helper lives in `agent-plugin.ts` (not a neutral types file) because the shape is an internal builder concern, not a cross-process contract that belongs in `packages/contracts/`. It's co-located with `createBuiltinAgentPlugin`, its primary user.

## Review rounds
3 parallel sub-agents (Code Reuse / Code Quality / Efficiency) — round 1 results:
- **Code Reuse**: APPROVE. Confirmed no missed existing helper and no other constructors of the same shape.
- **Code Quality**: APPROVE with non-blocking nit — the verbose inline return type `{ manifest: { id: string; kind: 'agent'; ... } }` duplicated shape info already in `PluginManifest` and `AgentCapability` from `@cc/plugin-sdk`.
- **Efficiency**: APPROVE (cold path at registration; negligible shallow-spread cost).

Round 2: Applied the type nit — return type now uses `PluginManifest & { kind: 'agent' }` and `AgentCapability[]` from `@cc/plugin-sdk`, keeping the `kind` narrowing while reusing existing contract types.

## Test plan
- [x] `pnpm test` — 611 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `pnpm lint:duplicate` — typescript duplicated lines dropped 1821 → 1808; the manifest-capabilities clone is no longer in the top 10
- [x] Behavior parity verified: default `displayName = agentType`, default `pluginId = \`builtin.agent-${agentType}\``, spread doesn't shadow `createRuntime`