### PR TITLE
Hoist sendFile to BaseChannelGateway

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -1,8 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { randomInt } from 'node:crypto';
 import type {
-  ChannelFileSendInput,
-  ChannelFileSendResult,
   ChannelInboundContentPart,
   ChannelOutboundMessageInput,
   ChannelOutboundMessageResult,
@@ -22,7 +20,6 @@ import type {
 } from '@cc/superai-contracts';
 import type { ChannelRuntime } from '@cc/plugin-sdk';
 import { LocalCoreError, formatSafeError, toLocalCoreErrorInfo } from '../../kernel/local-core-errors.js';
-import { buildChannelFileSendPayload } from '../../runtime/channel-service-helpers.js';
 import { createChannelThreadMessageInput } from '../shared/content.js';
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
 import { BaseChannelGateway, type GatewayBinding, type GatewayRuntimeState, type GatewayThreadRoute } from '../shared/base-channel-gateway.js';
@@ -264,21 +261,6 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     };
   }
 
-  async sendFile(workspaceId: string, input: ChannelFileSendInput): Promise<ChannelFileSendResult> {
-    const result = await this.sendOutboundMessage(workspaceId, {
-      route: {
-        type: 'channel.chat',
-        channelId: input.channelId,
-        participantId: input.participantId,
-      },
-      parts: [{
-        type: 'file',
-        path: input.path,
-        fileName: input.fileName,
-      }],
-    });
-    return buildChannelFileSendPayload('lark', workspaceId, input, result);
-  }
 
   async onBridgeEvent(event: DesktopBridgeEvent) {
     if (!event.sessionKey) {

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -22,6 +22,7 @@ import type { WorkspaceRouter } from '../../router/workspace-router.js';
 import type { LocalPlatformUserRow } from '../../router/workspace-router-types.js';
 import type { EventBus } from '@cc/plugin-sdk';
 import { createChannelThreadMessageInput } from '../shared/content.js';
+import { buildChannelFileSendPayload } from '../../runtime/channel-service-helpers.js';
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
 import { resolveChannelThreadRoute } from '../shared/thread-routing.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
@@ -181,8 +182,22 @@ export abstract class BaseChannelGateway<
   /** Send an outbound message through the platform. */
   abstract sendOutboundMessage(workspaceId: string, input: ChannelOutboundMessageInput): Promise<ChannelOutboundMessageResult>;
 
-  /** Send a file through the platform. */
-  abstract sendFile(workspaceId: string, input: ChannelFileSendInput): Promise<ChannelFileSendResult>;
+  /** Send a file through the platform via the standard file-part payload. */
+  async sendFile(workspaceId: string, input: ChannelFileSendInput): Promise<ChannelFileSendResult> {
+    const result = await this.sendOutboundMessage(workspaceId, {
+      route: {
+        type: 'channel.chat',
+        channelId: input.channelId,
+        participantId: input.participantId,
+      },
+      parts: [{
+        type: 'file',
+        path: input.path,
+        fileName: input.fileName,
+      }],
+    });
+    return buildChannelFileSendPayload(this.platform, workspaceId, input, result);
+  }
 
   /** Handle a bridge event from the ACP runtime. */
   abstract onBridgeEvent(event: DesktopBridgeEvent): Promise<void>;

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -4,8 +4,6 @@ import { EventEmitter } from 'node:events';
 import { randomInt, randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type {
-  ChannelFileSendInput,
-  ChannelFileSendResult,
   ChannelOutboundMessageInput,
   ChannelOutboundMessagePart,
   ChannelOutboundMessageResult,
@@ -20,7 +18,6 @@ import type {
 } from '@cc/superai-contracts';
 import type { ChannelRuntime } from '@cc/plugin-sdk';
 import { LocalCoreError, formatSafeError, toLocalCoreErrorInfo } from '../../kernel/local-core-errors.js';
-import { buildChannelFileSendPayload } from '../../runtime/channel-service-helpers.js';
 import { createChannelThreadMessageInput } from '../shared/content.js';
 import { prepareChannelFile, type PreparedChannelFile } from '../shared/file-utils.js';
 import { FileSystemInboundAttachmentStore, resolveInboundAttachmentUri } from '../shared/inbound-attachment-store.js';
@@ -417,21 +414,6 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     };
   }
 
-  async sendFile(workspaceId: string, input: ChannelFileSendInput): Promise<ChannelFileSendResult> {
-    const result = await this.sendOutboundMessage(workspaceId, {
-      route: {
-        type: 'channel.chat',
-        channelId: input.channelId,
-        participantId: input.participantId,
-      },
-      parts: [{
-        type: 'file',
-        path: input.path,
-        fileName: input.fileName,
-      }],
-    });
-    return buildChannelFileSendPayload('weixin', workspaceId, input, result);
-  }
 
   // ==================== Inbound Message Handling ====================
 

--- a/services/local-ai-core/src/runtime/channel-service-helpers.ts
+++ b/services/local-ai-core/src/runtime/channel-service-helpers.ts
@@ -1,7 +1,7 @@
 import type { ChannelFileSendInput, ChannelFileSendResult, ChannelOutboundMessageResult } from '@cc/superai-contracts';
 
 export function buildChannelFileSendPayload(
-  platform: 'lark' | 'weixin',
+  platform: string,
   workspaceId: string,
   input: ChannelFileSendInput,
   result: ChannelOutboundMessageResult,


### PR DESCRIPTION
## Summary
- Removes the duplicated `sendFile` method body between the lark and weixin gateway subclasses (15 lines each, byte-identical except for the platform string passed to `buildChannelFileSendPayload`).
- Hoists a concrete `sendFile` implementation onto `BaseChannelGateway` that uses `this.platform` and `this.sendOutboundMessage`. Drops the `abstract sendFile` declaration and both subclass implementations.
- Loosens `buildChannelFileSendPayload`'s `platform` parameter from `'lark' | 'weixin'` to `string` — `ChannelFileSendResult.platform` is already typed as `string` in contracts, and `this.platform` is typed as `string` on the base class.
- Drops the now-unused `ChannelFileSendInput`, `ChannelFileSendResult`, and `buildChannelFileSendPayload` imports from both gateway files.

## Motivation
Daily refactor pass — **code-reuse** category. Both gateways built the same file-part payload (single `{ type: 'file', path, fileName }` part wrapped in a `channel.chat` route) and forwarded the result to the same helper. The hoist eliminates the largest remaining cross-gateway clone (#1 in the daily `pnpm lint:duplicate` report, 19 lines).

## Design notes
- The helper stays in `services/local-ai-core/src/runtime/channel-service-helpers.ts`. Code Reuse reviewer noted a mild layering mismatch (helper lives in `runtime/` but is now only consumed by `channel/`), but relocation is out of scope for this PR.
- `sendFile` is intentionally a regular `async` method (not `final`) — subclasses can still override if a future platform needs different file-sending semantics. The abstract `sendOutboundMessage` remains the primary per-platform extension point.

## Review rounds
3 parallel sub-agents (Code Reuse / Code Quality / Efficiency) — all APPROVED on round 1, no requested changes.

## Test plan
- [x] `pnpm test` — 618 pass / 0 fail / 1 skipped, 80 BDD scenarios pass
- [x] `pnpm lint:duplicate` — typescript duplicated lines dropped 1816 → 1799; the sendFile clone is no longer in the top 10
- [x] Behavior parity verified: same payload shape (route type, channelId, participantId, parts structure), same helper call, same return type