### PR TITLE
Extract collectPlatformOptions helper for channel configs

### DIFF
--- a/services/local-ai-core/src/channel/lark/config.ts
+++ b/services/local-ai-core/src/channel/lark/config.ts
@@ -1,47 +1,34 @@
 import type { DesktopConnectConfig } from '@cc/superai-contracts';
-import { normalizeDesktopPlatformType } from '@cc/superai-contracts';
-import { channelPlatformKey, normalizeChannelInstanceId } from '../shared/channel-keys.js';
+import { collectPlatformOptions } from '../shared/collect-platform-options.js';
 import type { LarkWorkspaceBinding } from './types.js';
 
 export function collectLarkWorkspaceBindings(
   config: DesktopConnectConfig | null | undefined,
   options: { defaultCardActionsEnabled: boolean },
 ): LarkWorkspaceBinding[] {
-  const projects = Array.isArray(config?.projects) ? config!.projects! : [];
-  return projects.flatMap((project) => {
-    const platforms = Array.isArray(project.platforms) ? project.platforms : [];
-    return platforms
-      .map((platform) => ({
-        platformType: normalizeDesktopPlatformType(platform?.type),
-        options: platform?.options && typeof platform.options === 'object'
-          ? platform.options as Record<string, unknown>
-          : {},
-      }))
-      .filter((platform) => platform.platformType === 'lark')
-      .map((platform, index) => {
-        const instanceId = normalizeChannelInstanceId(platform.options.instance_id || platform.options.id, index === 0 ? 'default' : `lark-${index + 1}`);
-        return {
-          workspaceId: project.name,
-          instanceId,
-          displayName: String(platform.options.name || platform.options.display_name || `Lark ${index + 1}`).trim(),
-          platformKey: channelPlatformKey('lark', instanceId),
-          appId: String(platform.options.app_id || '').trim(),
-          appSecret: String(platform.options.app_secret || '').trim(),
-          encryptKey: String(platform.options.encrypt_key || '').trim(),
-          verificationToken: String(platform.options.verification_token || '').trim(),
-          autoApprove: String(platform.options.auto_approve || '').trim().toLowerCase() === 'true'
-            || platform.options.auto_approve === true,
-          cardActionsEnabled: String(platform.options.card_actions || platform.options.enable_card_actions || '').trim().toLowerCase() === 'true'
-            || platform.options.card_actions === true
-            || platform.options.enable_card_actions === true
-            || options.defaultCardActionsEnabled,
-          groupReplyAll: String(platform.options.group_reply_all || '').trim().toLowerCase() === 'true'
-            || platform.options.group_reply_all === true,
-          downloadsDir: String(platform.options.downloads_dir || '').trim(),
-          brand: String(platform.options.brand || platform.options.lark_brand || '').trim().toLowerCase() === 'lark' ? 'lark' : 'feishu',
-          enabled: Boolean(String(platform.options.app_id || '').trim() && String(platform.options.app_secret || '').trim()),
-          project,
-        };
-      });
+  return collectPlatformOptions(config, 'lark').map((entry) => {
+    const { project, options: platformOptions, instanceId, workspaceId, platformKey, displayName } = entry;
+    return {
+      workspaceId,
+      instanceId,
+      displayName,
+      platformKey,
+      appId: String(platformOptions.app_id || '').trim(),
+      appSecret: String(platformOptions.app_secret || '').trim(),
+      encryptKey: String(platformOptions.encrypt_key || '').trim(),
+      verificationToken: String(platformOptions.verification_token || '').trim(),
+      autoApprove: String(platformOptions.auto_approve || '').trim().toLowerCase() === 'true'
+        || platformOptions.auto_approve === true,
+      cardActionsEnabled: String(platformOptions.card_actions || platformOptions.enable_card_actions || '').trim().toLowerCase() === 'true'
+        || platformOptions.card_actions === true
+        || platformOptions.enable_card_actions === true
+        || options.defaultCardActionsEnabled,
+      groupReplyAll: String(platformOptions.group_reply_all || '').trim().toLowerCase() === 'true'
+        || platformOptions.group_reply_all === true,
+      downloadsDir: String(platformOptions.downloads_dir || '').trim(),
+      brand: String(platformOptions.brand || platformOptions.lark_brand || '').trim().toLowerCase() === 'lark' ? 'lark' : 'feishu',
+      enabled: Boolean(String(platformOptions.app_id || '').trim() && String(platformOptions.app_secret || '').trim()),
+      project,
+    };
   });
 }

--- a/services/local-ai-core/src/channel/shared/collect-platform-options.ts
+++ b/services/local-ai-core/src/channel/shared/collect-platform-options.ts
@@ -1,0 +1,47 @@
+import type { DesktopConnectConfig, DesktopProjectConfig } from '@cc/superai-contracts';
+import { normalizeDesktopPlatformType } from '@cc/superai-contracts';
+import { channelPlatformKey, normalizeChannelInstanceId } from './channel-keys.js';
+
+const PLATFORM_LABELS: Record<'lark' | 'weixin', string> = {
+  lark: 'Lark',
+  weixin: 'WeChat',
+};
+
+export type PreparedPlatformOption = {
+  project: DesktopProjectConfig;
+  options: Record<string, unknown>;
+  instanceId: string;
+  workspaceId: string;
+  platformKey: string;
+  displayName: string;
+};
+
+export function collectPlatformOptions(
+  config: DesktopConnectConfig | null | undefined,
+  platformType: 'lark' | 'weixin',
+): PreparedPlatformOption[] {
+  const projects = Array.isArray(config?.projects) ? config!.projects! : [];
+  return projects.flatMap((project) => {
+    const platforms = Array.isArray(project.platforms) ? project.platforms : [];
+    return platforms
+      .map((platform) => ({
+        platformType: normalizeDesktopPlatformType(platform?.type),
+        options: platform?.options ?? {},
+      }))
+      .filter((p) => p.platformType === platformType)
+      .map((p, index) => {
+        const instanceId = normalizeChannelInstanceId(
+          p.options.instance_id || p.options.id,
+          index === 0 ? 'default' : `${platformType}-${index + 1}`,
+        );
+        return {
+          project,
+          options: p.options,
+          instanceId,
+          workspaceId: project.name,
+          platformKey: channelPlatformKey(platformType, instanceId),
+          displayName: String(p.options.name || p.options.display_name || `${PLATFORM_LABELS[platformType]} ${index + 1}`).trim(),
+        };
+      });
+  });
+}

--- a/services/local-ai-core/src/channel/weixin/config.ts
+++ b/services/local-ai-core/src/channel/weixin/config.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { DesktopConnectConfig } from '@cc/superai-contracts';
-import { normalizeDesktopPlatformType } from '@cc/superai-contracts';
-import { channelPlatformKey, normalizeChannelInstanceId } from '../shared/channel-keys.js';
+import { collectPlatformOptions } from '../shared/collect-platform-options.js';
 import type { WeixinCredentials, WeixinWorkspaceBinding } from './types.js';
 
 export const DEFAULT_BASE_URL = 'https://ilinkai.weixin.qq.com';
@@ -68,43 +67,31 @@ export function saveWeixinBuf(binding: WeixinWorkspaceBinding, buf: string): voi
 }
 
 export function collectWeixinWorkspaceBindings(config: DesktopConnectConfig | null | undefined): WeixinWorkspaceBinding[] {
-  const projects = Array.isArray(config?.projects) ? config!.projects! : [];
-  return projects.flatMap((project) => {
-    const platforms = Array.isArray(project.platforms) ? project.platforms : [];
-    return platforms
-      .map((platform) => ({
-        platformType: normalizeDesktopPlatformType(platform?.type),
-        options: platform?.options && typeof platform.options === 'object'
-          ? platform.options as Record<string, unknown>
-          : {},
-      }))
-      .filter((p) => p.platformType === 'weixin')
-      .map((p, index) => {
-        const instanceId = normalizeChannelInstanceId(p.options.instance_id || p.options.id, index === 0 ? 'default' : `weixin-${index + 1}`);
-        const stateDir = String(p.options.state_dir || getDefaultWeixinStateDir()).trim();
-        const credentials = loadWeixinCredentials(project.name, stateDir, instanceId);
-        const configuredToken = String(p.options.token || '').trim();
-        const configuredBaseUrl = String(p.options.base_url || '').trim();
-        const accountId = String(p.options.account_id || credentials?.botId || 'qr-login').trim();
-        return {
-          workspaceId: project.name,
-          instanceId,
-          displayName: String(p.options.name || p.options.display_name || `WeChat ${index + 1}`).trim(),
-          platformKey: channelPlatformKey('weixin', instanceId),
-          token: configuredToken || credentials?.token || '',
-          accountId,
-          baseUrl: configuredBaseUrl || credentials?.baseUrl || DEFAULT_BASE_URL,
-          cdnBaseUrl: String(p.options.cdn_base_url || DEFAULT_CDN_BASE_URL).trim(),
-          allowFrom: String(p.options.allow_from || '*').trim(),
-          routeTag: String(p.options.route_tag || '').trim(),
-          longPollTimeoutMs: Number(p.options.long_poll_timeout_ms || LONG_POLL_TIMEOUT_MS) || LONG_POLL_TIMEOUT_MS,
-          stateDir,
-          proxy: String(p.options.proxy || '').trim(),
-          proxyUsername: String(p.options.proxy_username || '').trim(),
-          proxyPassword: String(p.options.proxy_password || '').trim(),
-          enabled: true,
-          project,
-        };
-      });
+  return collectPlatformOptions(config, 'weixin').map((entry) => {
+    const { project, options: p, instanceId, workspaceId, platformKey, displayName } = entry;
+    const stateDir = String(p.state_dir || getDefaultWeixinStateDir()).trim();
+    const credentials = loadWeixinCredentials(project.name, stateDir, instanceId);
+    const configuredToken = String(p.token || '').trim();
+    const configuredBaseUrl = String(p.base_url || '').trim();
+    const accountId = String(p.account_id || credentials?.botId || 'qr-login').trim();
+    return {
+      workspaceId,
+      instanceId,
+      displayName,
+      platformKey,
+      token: configuredToken || credentials?.token || '',
+      accountId,
+      baseUrl: configuredBaseUrl || credentials?.baseUrl || DEFAULT_BASE_URL,
+      cdnBaseUrl: String(p.cdn_base_url || DEFAULT_CDN_BASE_URL).trim(),
+      allowFrom: String(p.allow_from || '*').trim(),
+      routeTag: String(p.route_tag || '').trim(),
+      longPollTimeoutMs: Number(p.long_poll_timeout_ms || LONG_POLL_TIMEOUT_MS) || LONG_POLL_TIMEOUT_MS,
+      stateDir,
+      proxy: String(p.proxy || '').trim(),
+      proxyUsername: String(p.proxy_username || '').trim(),
+      proxyPassword: String(p.proxy_password || '').trim(),
+      enabled: true,
+      project,
+    };
   });
 }


### PR DESCRIPTION
## Summary
- Hoists the cross-file scaffolding (config walk → platform normalize → filter → instanceId/displayName/platformKey computation) duplicated at the start of `collectLarkWorkspaceBindings` and `collectWeixinWorkspaceBindings` into a shared `collectPlatformOptions(config, platformType)` helper at `services/local-ai-core/src/channel/shared/collect-platform-options.ts`. Eliminates clone #10 from `pnpm lint:duplicate` (12 lines, cross-file).
- Continues the daily refactor series (#54, #55, #56, #57, #58, #61) targeting top duplicate-code clones.

## Behavior preservation
- `instanceId`, `displayName`, and `platformKey` are now computed inside the helper using the **per-project post-filter `index`** — exactly matching the original semantics where the final `.map` lived inside the `flatMap` callback. (Round 1 had a regression where `displayName` fell back to the outer flattened index, diverging numbering across projects; round 2 fixed this by lifting `displayName`/`workspaceId`/`platformKey` into the helper.)
- All lark-specific fields (`appId`, `appSecret`, `encryptKey`, `verificationToken`, `autoApprove`, `cardActionsEnabled`, `groupReplyAll`, `downloadsDir`, `brand`, `enabled`) and weixin-specific fields (`stateDir`, `credentials`, `token`, `accountId`, `baseUrl`, `cdnBaseUrl`, `allowFrom`, `routeTag`, `longPollTimeoutMs`, `proxy*`, `enabled`) compute identically to `main`.
- `platform?.options ?? {}` replaces the prior `typeof === 'object'` ternary + cast — strictly equivalent since `DesktopPlatformConfig.options` is already typed `Record<string, unknown> | undefined`.

## Review rounds
- **Round 1**: 3 parallel agents (Code Reuse / Code Quality / Efficiency). Code Reuse suggested lifting shared fields; Code Quality flagged unnecessary cast + naming; **Efficiency caught a real `displayName` index regression**.
- **Round 2**: applied all three rounds of feedback in one pass (lift shared fields → fixes the index regression; drop cast; align with `?? {}`). Re-review: **APPROVE**.

## Validation
- `pnpm test`: 619 tests, **618 pass / 0 fail / 1 skipped**; Cucumber BDD 80 scenarios passed.

## Category
`chore` · `refactor` · `dedup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)