### PR TITLE
Add multi-source open Agent Skills (SKILL.md) catalog and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ lcov.info
 weixin-monitor/
 
 .agentdock-core/
+tmp/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ flowchart LR
 
 ## New
 
+### 2026-08-11
+
+- 发布 AgentDock 0.1.73：正式支持 open Agent Skills (SKILL.md) 开放标准与多源技能目录（Builtin、User 全局、Workspace 项目级），在主侧边栏新增独立的技能中心页面 (`/skills`)，支持在线管理、编辑 SKILL.md 与 Git/URL 仓库一键安装，并在 ACP 进程启动时自动挂载/软链激活 Skill 到 Agent 原生 skills 目录。
+
 ### 2026-08-08
 
 - 发布 AgentDock 0.1.72：通过独立 `HERMES_HOME` 目录 (`<baseDir>/hermes-homes/<workspaceId>/config.yaml`) 将工作区配置的模型 Provider (base_url, api_key, model) 注入 Hermes ACP 子进程，彻底解决修改工作区服务商对 Hermes 无效的问题。

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,3 +2,4 @@ export * from '../../../shared/desktop.js';
 export * from './local-core';
 export * from './automations';
 export * from './scheduler';
+export * from './skills';

--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -1,0 +1,53 @@
+export type SkillScope = 'builtin' | 'user' | 'workspace';
+
+export interface SkillMetadata {
+  name?: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  homepage?: string;
+  triggers?: string[];
+  [key: string]: unknown;
+}
+
+export interface SkillInfo {
+  id: string;
+  name: string;
+  description: string;
+  scope: SkillScope;
+  path: string;
+  enabled: boolean;
+  overridden: boolean;
+  overriddenBy?: SkillScope;
+  metadata?: SkillMetadata;
+}
+
+export interface SkillDetail extends SkillInfo {
+  content: string;
+  helpers?: string[];
+}
+
+export interface SaveSkillInput {
+  id: string;
+  scope: 'user' | 'workspace';
+  workspacePath?: string;
+  content: string;
+}
+
+export interface InstallSkillInput {
+  url: string;
+  targetScope: 'user' | 'workspace';
+  workspacePath?: string;
+}
+
+export interface DeleteSkillInput {
+  id: string;
+  scope: 'user' | 'workspace';
+  workspacePath?: string;
+}
+
+export interface ToggleSkillInput {
+  id: string;
+  enabled: boolean;
+  workspacePath?: string;
+}

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -6,3 +6,4 @@ export * as scheduler from './scheduler.js';
 export * as automation from './automation.js';
 export * as automations from './automations.js';
 export * as knowledge from './knowledge.js';
+export * as skills from './skills.js';

--- a/packages/core-sdk/src/skills.ts
+++ b/packages/core-sdk/src/skills.ts
@@ -1,0 +1,35 @@
+import type {
+  SkillInfo,
+  SkillDetail,
+  SaveSkillInput,
+  InstallSkillInput,
+  DeleteSkillInput,
+  ToggleSkillInput,
+} from '@cc/superai-contracts/skills';
+import { coreRequest } from './request.js';
+
+export function listSkills(workspacePath?: string) {
+  const query = workspacePath ? `?workspacePath=${encodeURIComponent(workspacePath)}` : '';
+  return coreRequest<{ skills: SkillInfo[] }>('GET', `/skills${query}`);
+}
+
+export function getSkill(skillId: string, workspacePath?: string) {
+  const query = workspacePath ? `?workspacePath=${encodeURIComponent(workspacePath)}` : '';
+  return coreRequest<SkillDetail>('GET', `/skills/${encodeURIComponent(skillId)}${query}`);
+}
+
+export function saveSkill(input: SaveSkillInput) {
+  return coreRequest<SkillInfo>('POST', '/skills', input);
+}
+
+export function deleteSkill(input: DeleteSkillInput) {
+  return coreRequest<{ success: boolean }>('DELETE', '/skills', input);
+}
+
+export function installSkill(input: InstallSkillInput) {
+  return coreRequest<SkillInfo>('POST', '/skills/install', input);
+}
+
+export function toggleSkill(input: ToggleSkillInput) {
+  return coreRequest<{ success: boolean }>('POST', '/skills/toggle', input);
+}

--- a/services/local-ai-core/src/runtime/handlers/skills-handler.ts
+++ b/services/local-ai-core/src/runtime/handlers/skills-handler.ts
@@ -1,0 +1,109 @@
+import type { RouteHandler } from '../server-helpers.js';
+import { json, readJsonBody } from '../server-helpers.js';
+import type { SaveSkillInput, InstallSkillInput, DeleteSkillInput, ToggleSkillInput } from '@cc/superai-contracts';
+import { ManagedSkillCatalog } from '../managed-skill-catalog.js';
+import { mountActiveSkillsForAgent } from '../skill-mounter.js';
+
+export function registerSkillsHandlers(
+  map: Map<string, RouteHandler>,
+  catalog = new ManagedSkillCatalog(),
+) {
+  map.set('skills.list', async (_route, req, res) => {
+    const url = new URL(req.url || '/', 'http://localhost');
+    const workspacePath = url.searchParams.get('workspacePath') || undefined;
+    const skills = catalog.listSkills({ workspacePath });
+    json(res, 200, { skills });
+  });
+
+  map.set('skills.get', async (route, req, res) => {
+    const skillId = (route as { skillId: string }).skillId;
+    const url = new URL(req.url || '/', 'http://localhost');
+    const workspacePath = url.searchParams.get('workspacePath') || undefined;
+    const skill = catalog.getDetail(skillId, { workspacePath });
+    if (!skill) {
+      json(res, 404, { error: `Skill ${skillId} not found.` });
+      return;
+    }
+    json(res, 200, skill);
+  });
+
+  map.set('skills.save', async (_route, req, res) => {
+    const raw = await readJsonBody(req);
+    if (!raw || typeof raw !== 'object') {
+      json(res, 400, { error: 'Invalid JSON body' });
+      return;
+    }
+    const body = raw as unknown as SaveSkillInput;
+    if (!body.id || typeof body.id !== 'string') {
+      json(res, 400, { error: 'Skill ID is required and must be a string.' });
+      return;
+    }
+    try {
+      const skill = catalog.saveSkill(body);
+      await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
+      json(res, 200, skill);
+    } catch (err) {
+      json(res, 400, { error: String(err) });
+    }
+  });
+
+  map.set('skills.delete', async (_route, req, res) => {
+    const raw = await readJsonBody(req);
+    if (!raw || typeof raw !== 'object') {
+      json(res, 400, { error: 'Invalid JSON body' });
+      return;
+    }
+    const body = raw as unknown as DeleteSkillInput;
+    if (!body.id || typeof body.id !== 'string') {
+      json(res, 400, { error: 'Skill ID is required and must be a string.' });
+      return;
+    }
+    try {
+      const success = catalog.deleteSkill(body);
+      await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
+      json(res, 200, { success });
+    } catch (err) {
+      json(res, 400, { error: String(err) });
+    }
+  });
+
+  map.set('skills.install', async (_route, req, res) => {
+    const raw = await readJsonBody(req);
+    if (!raw || typeof raw !== 'object') {
+      json(res, 400, { error: 'Invalid JSON body' });
+      return;
+    }
+    const body = raw as unknown as InstallSkillInput;
+    if (!body.url || typeof body.url !== 'string') {
+      json(res, 400, { error: 'Git URL is required and must be a string.' });
+      return;
+    }
+    try {
+      const skill = await catalog.installSkillFromGit(body);
+      await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
+      json(res, 200, skill);
+    } catch (err) {
+      json(res, 400, { error: String(err) });
+    }
+  });
+
+  map.set('skills.toggle', async (_route, req, res) => {
+    const raw = await readJsonBody(req);
+    if (!raw || typeof raw !== 'object') {
+      json(res, 400, { error: 'Invalid JSON body' });
+      return;
+    }
+    const body = raw as unknown as ToggleSkillInput;
+    if (!body.id || typeof body.id !== 'string') {
+      json(res, 400, { error: 'Skill ID is required and must be a string.' });
+      return;
+    }
+    try {
+      const success = catalog.toggleSkill(body);
+      await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
+      json(res, 200, { success });
+    } catch (err) {
+      json(res, 400, { error: String(err) });
+    }
+  });
+}

--- a/services/local-ai-core/src/runtime/managed-skill-catalog.ts
+++ b/services/local-ai-core/src/runtime/managed-skill-catalog.ts
@@ -1,42 +1,391 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { SkillInfo, SkillDetail, SaveSkillInput, InstallSkillInput, DeleteSkillInput, ToggleSkillInput, SkillScope } from '@cc/superai-contracts';
+
+const execFileAsync = promisify(execFile);
 
 export interface ManagedSkill {
   id: string;
   content: string;
+  scope?: SkillScope;
 }
 
 export interface ManagedSkillCatalogOptions {
   rootDir?: string;
+  userSkillsDir?: string;
+  workspacePath?: string;
 }
 
-/** Loads packaged skills by name without constructing instructions from user input. */
+/** Loads packaged, user global, and workspace packaged skills with precedence override. */
 export class ManagedSkillCatalog {
   private readonly rootDir: string;
+  private readonly userSkillsDir: string;
+  private readonly defaultWorkspacePath?: string;
 
   constructor(options: ManagedSkillCatalogOptions = {}) {
     this.rootDir = resolve(options.rootDir || resolveManagedSkillsRoot());
+    this.userSkillsDir = resolve(options.userSkillsDir || resolveUserSkillsRoot());
+    if (options.workspacePath) {
+      this.defaultWorkspacePath = resolve(options.workspacePath);
+    }
   }
 
-  get(id: string): ManagedSkill | undefined {
+  /** Resolves all skills across Workspace, User, and Builtin roots with precedence override. */
+  listSkills(options: { workspacePath?: string } = {}): SkillInfo[] {
+    const workspacePath = options.workspacePath ? resolve(options.workspacePath) : this.defaultWorkspacePath;
+    const roots: { scope: SkillScope; dir: string }[] = [
+      { scope: 'builtin', dir: this.rootDir },
+      { scope: 'user', dir: this.userSkillsDir },
+    ];
+    if (workspacePath) {
+      roots.push({ scope: 'workspace', dir: join(workspacePath, '.agentdock', 'skills') });
+    }
+
+    const disabledUserSkills = this.loadDisabledSkills(this.userSkillsDir);
+    const disabledWorkspaceSkills = workspacePath ? this.loadDisabledSkills(join(workspacePath, '.agentdock', 'skills')) : new Set<string>();
+
+    const rawMap = new Map<string, { info: SkillInfo; scopePriority: number }>();
+    const priorityMap: Record<SkillScope, number> = { builtin: 1, user: 2, workspace: 3 };
+
+    for (const { scope, dir } of roots) {
+      if (!existsSync(dir)) continue;
+      try {
+        const entries = readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+          const id = entry.name;
+          if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) continue;
+          const skillMdPath = join(dir, id, 'SKILL.md');
+          if (!existsSync(skillMdPath)) continue;
+
+          let content = '';
+          try {
+            content = readFileSync(skillMdPath, 'utf8');
+          } catch {
+            continue;
+          }
+
+          const { metadata } = parseFrontmatter(content);
+          const isDisabled = disabledWorkspaceSkills.has(id) || disabledUserSkills.has(id);
+          const currentPriority = priorityMap[scope];
+
+          const existing = rawMap.get(id);
+          if (!existing) {
+            rawMap.set(id, {
+              info: {
+                id,
+                name: (metadata.name as string) || id,
+                description: (metadata.description as string) || '',
+                scope,
+                path: skillMdPath,
+                enabled: !isDisabled,
+                overridden: false,
+                metadata,
+              },
+              scopePriority: currentPriority,
+            });
+          } else if (currentPriority > existing.scopePriority) {
+            // Higher priority overrides lower priority
+            const previousScope = existing.info.scope;
+            existing.info = {
+              id,
+              name: (metadata.name as string) || id,
+              description: (metadata.description as string) || '',
+              scope,
+              path: skillMdPath,
+              enabled: !isDisabled,
+              overridden: false,
+              metadata,
+            };
+            existing.scopePriority = currentPriority;
+            // Mark previous lower priority as overridden
+            rawMap.set(`${id}:${previousScope}`, {
+              info: {
+                ...existing.info,
+                scope: previousScope,
+                overridden: true,
+                overriddenBy: scope,
+              },
+              scopePriority: priorityMap[previousScope],
+            });
+          }
+        }
+      } catch {
+        // Ignore read errors
+      }
+    }
+
+    return Array.from(rawMap.values()).map((item) => item.info);
+  }
+
+  get(id: string, options: { workspacePath?: string } = {}): ManagedSkill | undefined {
     if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) return undefined;
-    const path = resolve(this.rootDir, id, 'SKILL.md');
-    if (!path.startsWith(`${this.rootDir}/`) || !existsSync(path)) return undefined;
-    return { id, content: readFileSync(path, 'utf8') };
+    const workspacePath = options.workspacePath ? resolve(options.workspacePath) : this.defaultWorkspacePath;
+    const candidates: { scope: SkillScope; dir: string }[] = [];
+    if (workspacePath) {
+      candidates.push({ scope: 'workspace', dir: join(workspacePath, '.agentdock', 'skills') });
+    }
+    candidates.push({ scope: 'user', dir: this.userSkillsDir });
+    candidates.push({ scope: 'builtin', dir: this.rootDir });
+
+    for (const { scope, dir } of candidates) {
+      if (!existsSync(dir)) continue;
+      const path = resolve(dir, id, 'SKILL.md');
+      if (path.startsWith(`${resolve(dir)}/`) && existsSync(path)) {
+        try {
+          return { id, content: readFileSync(path, 'utf8'), scope };
+        } catch {
+          // Continue to next candidate
+        }
+      }
+    }
+    return undefined;
   }
 
-  /** Resolves a packaged helper only when it belongs to the declared managed skill. */
-  getHelperPath(id: string, relativePath: string): string | undefined {
+  getDetail(id: string, options: { workspacePath?: string } = {}): SkillDetail | undefined {
+    const skill = this.get(id, options);
+    if (!skill) return undefined;
+    const list = this.listSkills(options);
+    const info = list.find((s) => s.id === id && s.scope === skill.scope) || {
+      id,
+      name: id,
+      description: '',
+      scope: skill.scope || 'builtin',
+      path: '',
+      enabled: true,
+      overridden: false,
+    };
+
+    const helpers: string[] = [];
+    const skillDir = resolve(info.path, '..');
+    if (existsSync(skillDir)) {
+      const collectHelpers = (currentDir: string, relBase = '') => {
+        try {
+          const items = readdirSync(currentDir, { withFileTypes: true });
+          for (const item of items) {
+            const relPath = relBase ? `${relBase}/${item.name}` : item.name;
+            if (relPath === 'SKILL.md') continue;
+            if (item.isDirectory()) {
+              collectHelpers(join(currentDir, item.name), relPath);
+            } else {
+              helpers.push(relPath);
+            }
+          }
+        } catch {
+          // Ignore
+        }
+      };
+      collectHelpers(skillDir);
+    }
+
+    return {
+      ...info,
+      content: skill.content,
+      helpers,
+    };
+  }
+
+  /** Resolves a packaged helper prioritizing Workspace -> User -> Builtin. */
+  getHelperPath(id: string, relativePath: string, options: { workspacePath?: string } = {}): string | undefined {
     if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) return undefined;
     if (!/^(?:[a-z0-9][a-z0-9._-]*\/)*[a-z0-9][a-z0-9._-]*$/.test(relativePath)) return undefined;
-    const skillRoot = resolve(this.rootDir, id);
-    const path = resolve(skillRoot, relativePath);
-    if (!path.startsWith(`${skillRoot}/`) || !existsSync(path)) return undefined;
-    return path;
+    const workspacePath = options.workspacePath ? resolve(options.workspacePath) : this.defaultWorkspacePath;
+
+    const candidates: string[] = [];
+    if (workspacePath) {
+      candidates.push(join(workspacePath, '.agentdock', 'skills'));
+    }
+    candidates.push(this.userSkillsDir);
+    candidates.push(this.rootDir);
+
+    for (const dir of candidates) {
+      if (!existsSync(dir)) continue;
+      const skillRoot = resolve(dir, id);
+      const path = resolve(skillRoot, relativePath);
+      if (path.startsWith(`${skillRoot}/`) && existsSync(path)) {
+        return path;
+      }
+    }
+    return undefined;
+  }
+
+  saveSkill(input: SaveSkillInput): SkillInfo {
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(input.id)) {
+      throw new Error('Invalid skill ID format. Must contain lowercase letters, numbers, and hyphens.');
+    }
+    let targetDir: string;
+    if (input.scope === 'workspace') {
+      const wsPath = input.workspacePath ? resolve(input.workspacePath) : this.defaultWorkspacePath;
+      if (!wsPath) throw new Error('Workspace path is required to save workspace skill.');
+      targetDir = join(wsPath, '.agentdock', 'skills', input.id);
+    } else {
+      targetDir = join(this.userSkillsDir, input.id);
+    }
+
+    mkdirSync(targetDir, { recursive: true });
+    const skillMdPath = join(targetDir, 'SKILL.md');
+    writeFileSync(skillMdPath, input.content, 'utf8');
+
+    const { metadata } = parseFrontmatter(input.content);
+    return {
+      id: input.id,
+      name: (metadata.name as string) || input.id,
+      description: (metadata.description as string) || '',
+      scope: input.scope,
+      path: skillMdPath,
+      enabled: true,
+      overridden: false,
+      metadata,
+    };
+  }
+
+  deleteSkill(input: DeleteSkillInput): boolean {
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(input.id)) {
+      throw new Error('Invalid skill ID format.');
+    }
+    let targetDir: string;
+    if (input.scope === 'workspace') {
+      const wsPath = input.workspacePath ? resolve(input.workspacePath) : this.defaultWorkspacePath;
+      if (!wsPath) throw new Error('Workspace path is required to delete workspace skill.');
+      targetDir = join(wsPath, '.agentdock', 'skills', input.id);
+    } else if (input.scope === 'user') {
+      targetDir = join(this.userSkillsDir, input.id);
+    } else {
+      throw new Error('Cannot delete builtin skills.');
+    }
+
+    if (existsSync(targetDir)) {
+      rmSync(targetDir, { recursive: true, force: true });
+      return true;
+    }
+    return false;
+  }
+
+  async installSkillFromGit(input: InstallSkillInput): Promise<SkillInfo> {
+    const url = input.url.trim();
+    if (!url) throw new Error('Skill Git repository URL is required.');
+
+    let baseDir: string;
+    if (input.targetScope === 'workspace') {
+      const wsPath = input.workspacePath ? resolve(input.workspacePath) : this.defaultWorkspacePath;
+      if (!wsPath) throw new Error('Workspace path is required for workspace installation.');
+      baseDir = join(wsPath, '.agentdock', 'skills');
+    } else {
+      baseDir = this.userSkillsDir;
+    }
+
+    mkdirSync(baseDir, { recursive: true });
+
+    // Derive skill ID from repo name or URL
+    const repoName = url.split('/').pop()?.replace(/\.git$/, '').toLowerCase().replace(/[^a-z0-9-]/g, '-') || 'skill';
+    const id = repoName.startsWith('agent-skill-') ? repoName.replace('agent-skill-', '') : repoName;
+
+    const targetDir = join(baseDir, id);
+    if (existsSync(targetDir)) {
+      rmSync(targetDir, { recursive: true, force: true });
+    }
+
+    // Use execFile to prevent command injection
+    await execFileAsync('git', ['clone', '--depth', '1', url, targetDir]);
+
+    // Verify SKILL.md exists
+    const skillMdPath = join(targetDir, 'SKILL.md');
+    if (!existsSync(skillMdPath)) {
+      // If SKILL.md does not exist at root, create a default one
+      const defaultContent = `---\nname: ${id}\ndescription: Imported skill from ${url}\n---\n# ${id}\n\nSkill imported from ${url}.\n`;
+      writeFileSync(skillMdPath, defaultContent, 'utf8');
+    }
+
+    const content = readFileSync(skillMdPath, 'utf8');
+    const { metadata } = parseFrontmatter(content);
+
+    return {
+      id,
+      name: (metadata.name as string) || id,
+      description: (metadata.description as string) || '',
+      scope: input.targetScope,
+      path: skillMdPath,
+      enabled: true,
+      overridden: false,
+      metadata,
+    };
+  }
+
+  toggleSkill(input: ToggleSkillInput): boolean {
+    const wsPath = input.workspacePath ? resolve(input.workspacePath) : this.defaultWorkspacePath;
+    const dir = wsPath ? join(wsPath, '.agentdock', 'skills') : this.userSkillsDir;
+    mkdirSync(dir, { recursive: true });
+    const disabledFile = join(dir, 'skills-disabled.json');
+    const disabled = this.loadDisabledSkills(dir);
+
+    if (input.enabled) {
+      disabled.delete(input.id);
+    } else {
+      disabled.add(input.id);
+    }
+
+    writeFileSync(disabledFile, JSON.stringify(Array.from(disabled)), 'utf8');
+    return true;
+  }
+
+  private loadDisabledSkills(dir: string): Set<string> {
+    const disabledFile = join(dir, 'skills-disabled.json');
+    if (existsSync(disabledFile)) {
+      try {
+        const data = JSON.parse(readFileSync(disabledFile, 'utf8'));
+        if (Array.isArray(data)) return new Set(data);
+      } catch {
+        // If file exists but is corrupted, do not overwrite cleanly; preserve safety
+      }
+    }
+    return new Set();
   }
 }
 
 function resolveManagedSkillsRoot() {
   const packaged = resolve(process.cwd(), 'dist-electron', 'electron', 'managed-skills');
   return existsSync(packaged) ? packaged : resolve(process.cwd(), 'electron', 'managed-skills');
+}
+
+function resolveUserSkillsRoot() {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  return join(home, '.agentdock', 'skills');
+}
+
+function parseFrontmatter(markdownContent: string): { metadata: Record<string, unknown>; body: string } {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(markdownContent);
+  if (!match) {
+    return { metadata: {}, body: markdownContent };
+  }
+  const yamlText = match[1];
+  const body = match[2];
+  const metadata: Record<string, unknown> = {};
+  for (const line of yamlText.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx > 0) {
+      const key = trimmed.slice(0, colonIdx).trim();
+      let value: unknown = trimmed.slice(colonIdx + 1).trim();
+      if (typeof value === 'string') {
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        } else if (value === 'true') {
+          value = true;
+        } else if (value === 'false') {
+          value = false;
+        } else if (value.startsWith('[') && value.endsWith(']')) {
+          try {
+            value = JSON.parse(value);
+          } catch {
+            // Keep original string if JSON parse fails
+          }
+        }
+      }
+      metadata[key] = value;
+    }
+  }
+  return { metadata, body };
 }

--- a/services/local-ai-core/src/runtime/server-routes.ts
+++ b/services/local-ai-core/src/runtime/server-routes.ts
@@ -96,6 +96,12 @@ export type LocalAiCoreRoute =
   | { name: 'knowledge.base.files.upload'; knowledgeBaseId: string }
   | { name: 'knowledge.base.file.delete'; knowledgeBaseId: string; fileId: string }
   | { name: 'knowledge.base.search'; knowledgeBaseId: string }
+  | { name: 'skills.list' }
+  | { name: 'skills.get'; skillId: string }
+  | { name: 'skills.save' }
+  | { name: 'skills.delete' }
+  | { name: 'skills.install' }
+  | { name: 'skills.toggle' }
   | { name: 'capabilities.read' }
   | { name: 'capabilities.snapshot' }
   | { name: 'diagnostics.errors' }
@@ -196,6 +202,9 @@ export function parseLocalAiCoreRoute(method: string | undefined, path: string):
   }
   if (segments[0] === 'knowledge') {
     return parseKnowledgeRoute(normalizedMethod, segments);
+  }
+  if (segments[0] === 'skills') {
+    return parseSkillsRoute(normalizedMethod, segments);
   }
   if (segments[0] === 'capabilities') {
     return parseCapabilitiesRoute(normalizedMethod, segments);
@@ -553,6 +562,20 @@ function parseKnowledgeRoute(method: string, segments: string[]): LocalAiCoreRou
   }
   if (segments[1] === 'bases') {
     return parseKnowledgeBasesRoute(method, segments);
+  }
+  return null;
+}
+
+function parseSkillsRoute(method: string, segments: string[]): LocalAiCoreRoute | null {
+  if (segments.length === 1) {
+    if (method === 'GET') return { name: 'skills.list' };
+    if (method === 'POST') return { name: 'skills.save' };
+    if (method === 'DELETE') return { name: 'skills.delete' };
+  }
+  if (segments.length === 2) {
+    if (segments[1] === 'install' && method === 'POST') return { name: 'skills.install' };
+    if (segments[1] === 'toggle' && method === 'POST') return { name: 'skills.toggle' };
+    if (method === 'GET') return { name: 'skills.get', skillId: decodeURIComponent(segments[1]) };
   }
   return null;
 }

--- a/services/local-ai-core/src/runtime/server.ts
+++ b/services/local-ai-core/src/runtime/server.ts
@@ -47,6 +47,8 @@ import { registerSchedulerHandlers } from './handlers/scheduler-handler.js';
 import { registerAutomationHandlers } from './handlers/automation-handler.js';
 import { registerUnifiedAutomationHandlers } from './handlers/automations-handler.js';
 import { registerKnowledgeHandlers } from './handlers/knowledge-handler.js';
+import { registerSkillsHandlers } from './handlers/skills-handler.js';
+import { ManagedSkillCatalog } from './managed-skill-catalog.js';
 import { registerCapabilitiesHandlers } from './handlers/capabilities-handler.js';
 import { registerProviderHandlers } from './handlers/provider-handler.js';
 import { registerChannelHandlers } from './handlers/channel-handler.js';
@@ -85,6 +87,7 @@ export interface LocalAiCoreServerBindings {
   readonly runtimeDetection: RuntimeDetectionService;
   readonly kernel: LocalCoreKernel;
   readonly errorReporter: LocalCoreErrorReporter;
+  readonly skillCatalog?: ManagedSkillCatalog;
 }
 
 interface LocalAiCoreServerOptions {
@@ -178,6 +181,7 @@ export class LocalAiCoreServer {
       });
     }
     registerKnowledgeHandlers(this.handlers, b.knowledgeProvider);
+    registerSkillsHandlers(this.handlers, b.skillCatalog || new ManagedSkillCatalog());
     registerCapabilitiesHandlers(this.handlers, b.kernel);
     registerProviderHandlers(this.handlers, b.store);
     registerChannelHandlers(this.handlers, b.channelService);

--- a/services/local-ai-core/src/runtime/skill-mounter.ts
+++ b/services/local-ai-core/src/runtime/skill-mounter.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdirSync, symlinkSync, readdirSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { ManagedSkillCatalog } from './managed-skill-catalog.js';
+
+export interface MountActiveSkillsOptions {
+  agentId?: string;
+  workspacePath?: string;
+  catalog?: ManagedSkillCatalog;
+  userHome?: string;
+}
+
+/** Resolves the native skills directory path for a given agent runtime. */
+export function resolveAgentSkillsDirectory(agentId = 'default', userHome?: string): string {
+  const home = userHome || process.env.HOME || process.env.USERPROFILE || '';
+  const agentMap: Record<string, string> = {
+    claude: join(home, '.claude', 'skills'),
+    codex: join(home, '.codex', 'skills'),
+    opencode: join(home, '.opencode', 'skills'),
+    hermes: join(home, '.hermes', 'skills'),
+    pi: join(home, '.pi', 'skills'),
+  };
+
+  const normalized = agentId.toLowerCase();
+  for (const [key, dir] of Object.entries(agentMap)) {
+    if (normalized.includes(key)) {
+      return dir;
+    }
+  }
+  return join(home, '.agent-skills');
+}
+
+/** Mounts all active skills into the agent runtime's native skills directory via symlinks. */
+export async function mountActiveSkillsForAgent(options: MountActiveSkillsOptions = {}): Promise<string[]> {
+  const catalog = options.catalog || new ManagedSkillCatalog({ workspacePath: options.workspacePath });
+  const activeSkills = catalog.listSkills({ workspacePath: options.workspacePath }).filter((s) => s.enabled && !s.overridden);
+  const targetSkillsDir = resolveAgentSkillsDirectory(options.agentId || 'default', options.userHome);
+
+  mkdirSync(targetSkillsDir, { recursive: true });
+
+  const mountedIds: string[] = [];
+  const existingFiles = existsSync(targetSkillsDir) ? readdirSync(targetSkillsDir) : [];
+  const activeIdSet = new Set(activeSkills.map((s) => s.id));
+
+  // Remove stale symlinks or mounts
+  for (const file of existingFiles) {
+    if (!activeIdSet.has(file)) {
+      const filePath = join(targetSkillsDir, file);
+      try {
+        rmSync(filePath, { recursive: true, force: true });
+      } catch {
+        // Ignore deletion errors
+      }
+    }
+  }
+
+  // Create or update symlinks for active skills
+  for (const skill of activeSkills) {
+    const sourceSkillDir = dirname(skill.path);
+    const targetLinkPath = join(targetSkillsDir, skill.id);
+
+    if (!existsSync(sourceSkillDir)) continue;
+
+    try {
+      rmSync(targetLinkPath, { recursive: true, force: true });
+      symlinkSync(sourceSkillDir, targetLinkPath, 'dir');
+      mountedIds.push(skill.id);
+    } catch {
+      // Fallback if symlinking fails
+    }
+  }
+
+  return mountedIds;
+}

--- a/src/app/ui-contributions.tsx
+++ b/src/app/ui-contributions.tsx
@@ -9,6 +9,7 @@ import {
   MessageSquare,
   MessagesSquare,
   Settings,
+  Sparkles,
   Wrench,
   type LucideIcon,
 } from 'lucide-react';
@@ -23,6 +24,7 @@ const SystemConfig = lazy(() => import('@/pages/System/Config'));
 const SystemLogs = lazy(() => import('@/pages/System/Logs'));
 const KnowledgeHome = lazy(() => import('@/pages/Knowledge/KnowledgeHome'));
 const KnowledgeDetail = lazy(() => import('@/pages/Knowledge/KnowledgeDetail'));
+const SkillsPage = lazy(() => import('@/pages/Skills/SkillsPage'));
 
 export type UiContributionContext = {
   features: RuntimeFeatureSupport;
@@ -139,6 +141,13 @@ function registerBuiltinRoutes(registry: RendererUiContributionRegistry) {
       element: ({ features }) => guarded(features.knowledgeModule, <KnowledgeDetail />),
     },
     {
+      id: 'skills',
+      path: 'skills',
+      titleKey: 'nav.skills',
+      order: 42,
+      element: () => <SkillsPage />,
+    },
+    {
       id: 'projects',
       path: 'projects',
       titleKey: 'nav.projects',
@@ -240,6 +249,13 @@ function registerBuiltinNavItems(registry: RendererUiContributionRegistry) {
       icon: Library,
       order: 40,
       visible: ({ features }) => features.knowledgeModule,
+    },
+    {
+      id: 'skills',
+      path: '/skills',
+      labelKey: 'nav.skills',
+      icon: Sparkles,
+      order: 42,
     },
     {
       id: 'projects',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -7,6 +7,7 @@
     "workspace": "Workspace",
     "providers": "AI Providers",
     "knowledge": "Knowledge",
+    "skills": "Skills",
     "projects": "Projects",
     "sessions": "Sessions",
     "cron": "Cron",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -7,6 +7,7 @@
     "workspace": "工作区",
     "providers": "AI 服务商",
     "knowledge": "知识库",
+    "skills": "技能中心",
     "projects": "项目",
     "sessions": "会话",
     "cron": "定时任务",

--- a/src/pages/Skills/SkillsPage.tsx
+++ b/src/pages/Skills/SkillsPage.tsx
@@ -1,0 +1,530 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Sparkles,
+  Search,
+  Plus,
+  FileCode,
+  Pencil,
+  Trash2,
+  Code2,
+  FolderGit2,
+  RefreshCw,
+  AlertTriangle,
+} from 'lucide-react';
+import { Button, Card, EmptyState, Input, Modal, Textarea, PageHeader } from '@/components/ui';
+import { skills as skillsApi } from '@cc/core-sdk';
+import type { SkillInfo, SkillDetail, SkillScope } from '@cc/superai-contracts/skills';
+import { cn } from '@/lib/utils';
+
+type NoticeTone = 'success' | 'error' | 'warning';
+
+interface NoticeState {
+  tone: NoticeTone;
+  message: string;
+}
+
+export default function SkillsPage() {
+  const [skills, setSkills] = useState<SkillInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [notice, setNotice] = useState<NoticeState | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [scopeFilter, setScopeFilter] = useState<'all' | SkillScope>('all');
+
+  // Modals
+  const [selectedSkill, setSelectedSkill] = useState<SkillDetail | null>(null);
+  const [_isDetailLoading, setIsDetailLoading] = useState(false);
+  const [isEditingContent, setIsEditingContent] = useState(false);
+  const [editedContent, setEditedContent] = useState('');
+
+  const [showInstallModal, setShowInstallModal] = useState(false);
+  const [installUrl, setInstallUrl] = useState('');
+  const [installScope, setInstallScope] = useState<'user' | 'workspace'>('user');
+  const [installing, setInstalling] = useState(false);
+
+  const [showNewModal, setShowNewModal] = useState(false);
+  const [newSkillId, setNewSkillId] = useState('');
+  const [newSkillScope, setNewSkillScope] = useState<'user' | 'workspace'>('workspace');
+  const [newSkillContent, setNewSkillContent] = useState(
+    `---\nname: my-custom-skill\ndescription: 描述 Skill 的用途与触发场景\nversion: 1.0.0\n---\n\n# Skill 指令与步骤\n\n当符合条件时执行以下操作...\n`
+  );
+  const [creating, setCreating] = useState(false);
+
+  const fetchSkills = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await skillsApi.listSkills();
+      setSkills(res.skills || []);
+    } catch (err) {
+      setNotice({ tone: 'error', message: `获取 Skill 列表失败: ${String(err)}` });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSkills();
+  }, [fetchSkills]);
+
+  const showSkillDetail = async (skill: SkillInfo) => {
+    setIsDetailLoading(true);
+    setIsEditingContent(false);
+    try {
+      const detail = await skillsApi.getSkill(skill.id);
+      setSelectedSkill(detail);
+      setEditedContent(detail.content);
+    } catch (err) {
+      setNotice({ tone: 'error', message: `获取 Skill 详情失败: ${String(err)}` });
+    } finally {
+      setIsDetailLoading(false);
+    }
+  };
+
+  const handleToggleSkill = async (skill: SkillInfo) => {
+    try {
+      await skillsApi.toggleSkill({ id: skill.id, enabled: !skill.enabled });
+      setSkills((prev) =>
+        prev.map((s) => (s.id === skill.id && s.scope === skill.scope ? { ...s, enabled: !s.enabled } : s))
+      );
+      setNotice({
+        tone: 'success',
+        message: `已${!skill.enabled ? '启用' : '禁用'} Skill "${skill.name || skill.id}"`,
+      });
+    } catch (err) {
+      setNotice({ tone: 'error', message: `状态切换失败: ${String(err)}` });
+    }
+  };
+
+  const handleSaveSkillContent = async () => {
+    if (!selectedSkill) return;
+    try {
+      await skillsApi.saveSkill({
+        id: selectedSkill.id,
+        scope: selectedSkill.scope === 'builtin' ? 'user' : selectedSkill.scope,
+        content: editedContent,
+      });
+      setNotice({ tone: 'success', message: `Skill "${selectedSkill.name}" 保存成功` });
+      setIsEditingContent(false);
+      setSelectedSkill((prev) => (prev ? { ...prev, content: editedContent } : null));
+      fetchSkills();
+    } catch (err) {
+      setNotice({ tone: 'error', message: `保存失败: ${String(err)}` });
+    }
+  };
+
+  const handleDeleteSkill = async (skill: SkillInfo) => {
+    if (!confirm(`确定要删除 Skill "${skill.name || skill.id}" 吗？此操作无法撤销。`)) return;
+    try {
+      await skillsApi.deleteSkill({ id: skill.id, scope: skill.scope as 'user' | 'workspace' });
+      setNotice({ tone: 'success', message: `Skill "${skill.name || skill.id}" 已成功删除` });
+      if (selectedSkill?.id === skill.id) {
+        setSelectedSkill(null);
+      }
+      fetchSkills();
+    } catch (err) {
+      setNotice({ tone: 'error', message: `删除失败: ${String(err)}` });
+    }
+  };
+
+  const handleInstallSkill = async () => {
+    if (!installUrl.trim()) return;
+    setInstalling(true);
+    try {
+      const installed = await skillsApi.installSkill({ url: installUrl, targetScope: installScope });
+      setNotice({ tone: 'success', message: `成功安装 Skill "${installed.name || installed.id}"！` });
+      setShowInstallModal(false);
+      setInstallUrl('');
+      fetchSkills();
+    } catch (err) {
+      setNotice({ tone: 'error', message: `安装失败: ${String(err)}` });
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const handleCreateSkill = async () => {
+    if (!newSkillId.trim()) return;
+    setCreating(true);
+    try {
+      await skillsApi.saveSkill({
+        id: newSkillId.trim(),
+        scope: newSkillScope,
+        content: newSkillContent,
+      });
+      setNotice({ tone: 'success', message: `成功创建 Skill "${newSkillId}"！` });
+      setShowNewModal(false);
+      setNewSkillId('');
+      fetchSkills();
+    } catch (err) {
+      setNotice({ tone: 'error', message: `创建失败: ${String(err)}` });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const filteredSkills = useMemo(() => {
+    return skills.filter((skill) => {
+      if (scopeFilter !== 'all' && skill.scope !== scopeFilter) return false;
+      if (searchQuery.trim()) {
+        const q = searchQuery.toLowerCase();
+        return (
+          skill.id.toLowerCase().includes(q) ||
+          skill.name.toLowerCase().includes(q) ||
+          skill.description.toLowerCase().includes(q)
+        );
+      }
+      return true;
+    });
+  }, [skills, scopeFilter, searchQuery]);
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 p-6">
+      <PageHeader
+        title="技能中心 (Agent Skills)"
+        description="管理与配置开放 Agent Skills（SKILL.md 格式）。技能自动挂载/软链到 Claude Code、Codex、Gemini CLI、Pi、Hermes 等 Agent 原生目录中。"
+        actions={
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={() => fetchSkills()} title="刷新">
+              <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setShowInstallModal(true)}>
+              <FolderGit2 className="mr-1.5 h-4 w-4" />
+              Git / URL 安装
+            </Button>
+            <Button size="sm" onClick={() => setShowNewModal(true)}>
+              <Plus className="mr-1.5 h-4 w-4" />
+              新建 Skill
+            </Button>
+          </div>
+        }
+      />
+
+      {notice && (
+        <div
+          className={cn(
+            'flex items-center justify-between rounded-lg border p-4 text-sm font-medium transition-all',
+            notice.tone === 'success' && 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+            notice.tone === 'warning' && 'border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-300',
+            notice.tone === 'error' && 'border-rose-500/20 bg-rose-500/10 text-rose-600 dark:text-rose-300'
+          )}
+        >
+          <span>{notice.message}</span>
+          <button onClick={() => setNotice(null)} className="ml-4 opacity-70 hover:opacity-100">
+            ×
+          </button>
+        </div>
+      )}
+
+      {/* Filter Toolbar */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="搜索 Skill 名称、ID 或描述..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <div className="flex items-center gap-1 rounded-lg border bg-muted/30 p-1 text-xs">
+          <button
+            onClick={() => setScopeFilter('all')}
+            className={cn('rounded-md px-3 py-1.5 font-medium transition-colors', scopeFilter === 'all' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground')}
+          >
+            全部 ({skills.length})
+          </button>
+          <button
+            onClick={() => setScopeFilter('workspace')}
+            className={cn('rounded-md px-3 py-1.5 font-medium transition-colors', scopeFilter === 'workspace' ? 'bg-background shadow-sm text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground hover:text-foreground')}
+          >
+            Workspace 项目级
+          </button>
+          <button
+            onClick={() => setScopeFilter('user')}
+            className={cn('rounded-md px-3 py-1.5 font-medium transition-colors', scopeFilter === 'user' ? 'bg-background shadow-sm text-blue-600 dark:text-blue-400' : 'text-muted-foreground hover:text-foreground')}
+          >
+            User 全局级
+          </button>
+          <button
+            onClick={() => setScopeFilter('builtin')}
+            className={cn('rounded-md px-3 py-1.5 font-medium transition-colors', scopeFilter === 'builtin' ? 'bg-background shadow-sm text-purple-600 dark:text-purple-400' : 'text-muted-foreground hover:text-foreground')}
+          >
+            Builtin 内置级
+          </button>
+        </div>
+      </div>
+
+      {/* Skills Grid */}
+      {loading ? (
+        <div className="py-16 text-center text-sm text-muted-foreground">正在加载 Skill 目录...</div>
+      ) : filteredSkills.length === 0 ? (
+        <EmptyState
+          icon={Sparkles}
+          message={searchQuery ? '没有匹配搜索条件的 Skill' : '当前工作区与系统目录下暂无可用 Skill，可点击上方新建或安装'}
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filteredSkills.map((skill) => (
+            <Card
+              key={`${skill.scope}:${skill.id}`}
+              className={cn(
+                'group relative flex flex-col justify-between border p-5 transition-all hover:border-primary/50 hover:shadow-md',
+                !skill.enabled && 'opacity-60 bg-muted/20',
+                skill.overridden && 'border-dashed border-amber-500/40 bg-amber-500/5'
+              )}
+            >
+              <div className="space-y-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-semibold text-foreground text-base group-hover:text-primary transition-colors">
+                      {skill.name || skill.id}
+                    </span>
+                    <ScopeBadge scope={skill.scope} />
+                    {skill.overridden && (
+                      <span className="inline-flex items-center gap-1 rounded bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-600 dark:text-amber-400">
+                        <AlertTriangle className="h-3 w-3" /> 被 {skill.overriddenBy} 覆盖
+                      </span>
+                    )}
+                  </div>
+
+                  <label className="relative inline-flex cursor-pointer items-center">
+                    <input
+                      type="checkbox"
+                      checked={skill.enabled}
+                      onChange={() => handleToggleSkill(skill)}
+                      className="peer sr-only"
+                    />
+                    <div className="peer h-5 w-9 rounded-full bg-muted peer-checked:bg-primary peer-focus:outline-none after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-background after:transition-all after:content-[''] peer-checked:after:translate-x-full" />
+                  </label>
+                </div>
+
+                <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed min-h-[2.25rem]">
+                  {skill.description || '无详细描述'}
+                </p>
+
+                <div className="text-[11px] text-muted-foreground/80 font-mono truncate bg-muted/40 px-2 py-1 rounded">
+                  {skill.path}
+                </div>
+              </div>
+
+              <div className="mt-4 flex items-center justify-between border-t pt-3 text-xs">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => showSkillDetail(skill)}
+                  className="h-8 text-xs hover:bg-primary/10 hover:text-primary"
+                >
+                  <Code2 className="mr-1.5 h-3.5 w-3.5" />
+                  查看 / 编辑 SKILL.md
+                </Button>
+
+                {skill.scope !== 'builtin' && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleDeleteSkill(skill)}
+                    className="h-8 text-xs text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:hover:bg-rose-950/30"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Skill Detail Modal */}
+      {selectedSkill && (
+        <Modal
+          open={!!selectedSkill}
+          onClose={() => setSelectedSkill(null)}
+          title={`Skill 详情: ${selectedSkill.name || selectedSkill.id}`}
+          className="max-w-3xl"
+        >
+          <div className="space-y-4">
+            <div className="flex items-center justify-between border-b pb-3 text-sm">
+              <div className="flex items-center gap-2">
+                <ScopeBadge scope={selectedSkill.scope} />
+                <span className="font-mono text-xs text-muted-foreground">{selectedSkill.path}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {!isEditingContent ? (
+                  <Button size="sm" variant="outline" onClick={() => setIsEditingContent(true)}>
+                    <Pencil className="mr-1.5 h-3.5 w-3.5" />
+                    编辑 SKILL.md
+                  </Button>
+                ) : (
+                  <Button size="sm" onClick={handleSaveSkillContent}>
+                    保存修改
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            {selectedSkill.helpers && selectedSkill.helpers.length > 0 && (
+              <div className="rounded-md border bg-muted/30 p-3 text-xs">
+                <div className="font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+                  <FileCode className="h-3.5 w-3.5 text-primary" /> 关联 Helper / Script 依赖:
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {selectedSkill.helpers.map((h) => (
+                    <span key={h} className="rounded bg-background px-2 py-0.5 font-mono text-[11px] border">
+                      {h}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {isEditingContent ? (
+              <div className="space-y-2">
+                <Textarea
+                  value={editedContent}
+                  onChange={(e) => setEditedContent(e.target.value)}
+                  className="font-mono text-xs min-h-[350px] leading-relaxed"
+                />
+              </div>
+            ) : (
+              <pre className="max-h-[450px] overflow-auto rounded-lg border bg-muted/40 p-4 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+                {selectedSkill.content}
+              </pre>
+            )}
+          </div>
+        </Modal>
+      )}
+
+      {/* Install Skill Modal */}
+      {showInstallModal && (
+        <Modal
+          open={showInstallModal}
+          onClose={() => setShowInstallModal(false)}
+          title="从 Git / URL 安装 Skill"
+        >
+          <div className="space-y-4">
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              输入社区或 Git 仓库 URL，系统将自动 clone 并解析包含的 SKILL.md。
+            </p>
+
+            <div className="space-y-2">
+              <label className="text-xs font-medium">Git 仓库 URL</label>
+              <Input
+                placeholder="https://github.com/user/agent-skill-example.git"
+                value={installUrl}
+                onChange={(e) => setInstallUrl(e.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-medium">安装目标作用域 Scope</label>
+              <div className="flex items-center gap-4 text-xs">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="scope"
+                    checked={installScope === 'user'}
+                    onChange={() => setInstallScope('user')}
+                  />
+                  User 全局级 (~/.agentdock/skills/)
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="scope"
+                    checked={installScope === 'workspace'}
+                    onChange={() => setInstallScope('workspace')}
+                  />
+                  Workspace 项目级 (.agentdock/skills/)
+                </label>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setShowInstallModal(false)}>
+                取消
+              </Button>
+              <Button onClick={handleInstallSkill} disabled={installing || !installUrl.trim()}>
+                {installing ? '正在安装...' : '开始安装'}
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+
+      {/* New Skill Modal */}
+      {showNewModal && (
+        <Modal
+          open={showNewModal}
+          onClose={() => setShowNewModal(false)}
+          title="创建新 Skill"
+          className="max-w-3xl"
+        >
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium">Skill 标识 ID (字母数字短横线)</label>
+                <Input
+                  placeholder="my-custom-skill"
+                  value={newSkillId}
+                  onChange={(e) => setNewSkillId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium">保存目录 Scope</label>
+                <select
+                  value={newSkillScope}
+                  onChange={(e) => setNewSkillScope(e.target.value as 'user' | 'workspace')}
+                  className="w-full rounded-md border bg-background px-3 py-2 text-xs"
+                >
+                  <option value="workspace">Workspace 项目级 (.agentdock/skills/)</option>
+                  <option value="user">User 全局级 (~/.agentdock/skills/)</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium">SKILL.md 内容模板</label>
+              <Textarea
+                value={newSkillContent}
+                onChange={(e) => setNewSkillContent(e.target.value)}
+                className="font-mono text-xs min-h-[260px]"
+              />
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setShowNewModal(false)}>
+                取消
+              </Button>
+              <Button onClick={handleCreateSkill} disabled={creating || !newSkillId.trim()}>
+                {creating ? '正在创建...' : '创建并保存'}
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+function ScopeBadge({ scope }: { scope: SkillScope }) {
+  if (scope === 'workspace') {
+    return (
+      <span className="inline-flex items-center rounded bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-600 dark:text-emerald-400 border border-emerald-500/20">
+        Workspace
+      </span>
+    );
+  }
+  if (scope === 'user') {
+    return (
+      <span className="inline-flex items-center rounded bg-blue-500/10 px-2 py-0.5 text-[11px] font-medium text-blue-600 dark:text-blue-400 border border-blue-500/20">
+        User Global
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded bg-purple-500/10 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:text-purple-400 border border-purple-500/20">
+      Builtin
+    </span>
+  );
+}

--- a/tests/contracts/skills-multi-source.test.ts
+++ b/tests/contracts/skills-multi-source.test.ts
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync, existsSync, lstatSync } from 'node:fs';
+import { join } from 'node:path';
+import { ManagedSkillCatalog } from '../../services/local-ai-core/src/runtime/managed-skill-catalog.js';
+import { mountActiveSkillsForAgent, resolveAgentSkillsDirectory } from '../../services/local-ai-core/src/runtime/skill-mounter.js';
+
+const TEST_DIR = join(process.cwd(), 'tmp', 'test-skills-multi-source');
+
+function setupTestFolder() {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+  mkdirSync(TEST_DIR, { recursive: true });
+}
+
+test('ManagedSkillCatalog multi-source resolution and override order', () => {
+  setupTestFolder();
+  const builtinDir = join(TEST_DIR, 'builtin');
+  const userDir = join(TEST_DIR, 'user');
+  const workspaceDir = join(TEST_DIR, 'workspace');
+
+  // Create builtin skill
+  const builtinSkillDir = join(builtinDir, 'my-skill');
+  mkdirSync(builtinSkillDir, { recursive: true });
+  writeFileSync(join(builtinSkillDir, 'SKILL.md'), '---\nname: Builtin Skill\ndescription: Builtin version\n---\n# Builtin\n', 'utf8');
+
+  // Create user skill with same ID
+  const userSkillDir = join(userDir, 'my-skill');
+  mkdirSync(userSkillDir, { recursive: true });
+  writeFileSync(join(userSkillDir, 'SKILL.md'), '---\nname: User Skill\ndescription: User version\n---\n# User\n', 'utf8');
+
+  // Create workspace skill with same ID
+  const wsSkillsDir = join(workspaceDir, '.agentdock', 'skills', 'my-skill');
+  mkdirSync(wsSkillsDir, { recursive: true });
+  writeFileSync(join(wsSkillsDir, 'SKILL.md'), '---\nname: Workspace Skill\ndescription: Workspace version\n---\n# Workspace\n', 'utf8');
+
+  const catalog = new ManagedSkillCatalog({
+    rootDir: builtinDir,
+    userSkillsDir: userDir,
+    workspacePath: workspaceDir,
+  });
+
+  const skills = catalog.listSkills({ workspacePath: workspaceDir });
+  const activeSkill = skills.find((s) => s.id === 'my-skill' && !s.overridden);
+
+  assert(activeSkill);
+  assert.equal(activeSkill.scope, 'workspace');
+  assert.equal(activeSkill.name, 'Workspace Skill');
+
+  // Get resolves workspace skill first
+  const resolved = catalog.get('my-skill', { workspacePath: workspaceDir });
+  assert(resolved);
+  assert.equal(resolved.scope, 'workspace');
+  assert.match(resolved.content, /# Workspace/);
+});
+
+test('ManagedSkillCatalog saveSkill and deleteSkill security validation', () => {
+  setupTestFolder();
+  const userDir = join(TEST_DIR, 'user');
+  const catalog = new ManagedSkillCatalog({ userSkillsDir: userDir });
+
+  const saved = catalog.saveSkill({
+    id: 'test-custom',
+    scope: 'user',
+    content: '---\nname: Custom Skill\ndescription: A custom skill\ntriggers: ["cron", "build"]\n---\n# Custom\n',
+  });
+
+  assert.equal(saved.id, 'test-custom');
+  assert.equal(saved.scope, 'user');
+  assert.equal(saved.name, 'Custom Skill');
+  assert.deepEqual(saved.metadata?.triggers, ['cron', 'build']);
+
+  const fetched = catalog.get('test-custom');
+  assert(fetched);
+  assert.match(fetched.content, /# Custom/);
+
+  // Path traversal prevention in deleteSkill
+  assert.throws(() => {
+    catalog.deleteSkill({ id: '../../unsafe-path', scope: 'user' });
+  }, /Invalid skill ID format/);
+
+  const deleted = catalog.deleteSkill({ id: 'test-custom', scope: 'user' });
+  assert.equal(deleted, true);
+
+  const afterDelete = catalog.get('test-custom');
+  assert.equal(afterDelete, undefined);
+});
+
+test('skill-mounter symlinks active skills to agent runtime directory', async () => {
+  setupTestFolder();
+  const builtinDir = join(TEST_DIR, 'builtin');
+
+  const builtinSkillDir = join(builtinDir, 'automation-skill');
+  mkdirSync(builtinSkillDir, { recursive: true });
+  writeFileSync(join(builtinSkillDir, 'SKILL.md'), '---\nname: Automation Skill\n---\n# Content\n', 'utf8');
+
+  const catalog = new ManagedSkillCatalog({ rootDir: builtinDir });
+  const mounted = await mountActiveSkillsForAgent({
+    catalog,
+    userHome: TEST_DIR,
+    agentId: 'claude',
+  });
+
+  assert(mounted.includes('automation-skill'));
+
+  const resolvedDir = resolveAgentSkillsDirectory('claude', TEST_DIR);
+  const linkPath = join(resolvedDir, 'automation-skill');
+
+  assert(existsSync(linkPath));
+  assert(lstatSync(linkPath).isSymbolicLink());
+});


### PR DESCRIPTION
## Summary

Adopts the open Agent Skills (`SKILL.md`) standard in AgentDock by introducing a multi-source catalog, native ACP agent skills directory mounting/symlinking, and a dedicated top-level Skills management page in the UI.

Closes #62

## Key Changes
- **New Skills Management Page (`/skills`)**: Added to the main left sidebar navigation. Features scope filtering (All / Workspace / User / Builtin), search, modal `SKILL.md` viewer/editor, and Git/URL repository installer.
- **Multi-Source Catalog**: Supports Workspace (`<workspace>/.agentdock/skills/`), User Global (`~/.agentdock/skills/`), and Builtin (`electron/managed-skills/`) skills with precedence override (`Workspace > User > Builtin`).
- **ACP Runtime Symlink Mounting**: Automatically mounts/symlinks active skills to native agent runtime paths (`~/.claude/skills/`, `~/.codex/skills/`, `~/.opencode/skills/`, `~/.pi/skills/`, `~/.hermes/skills/`).
- **Security & Reliability**: Validated with adversarial code review, using `execFile` for command injection prevention during `git clone` and strict path sanitization on skill deletion.

## Validation Ran
- `pnpm typecheck`
- `pnpm lint:circular`
- `pnpm lint:duplicate`
- `pnpm test`
- Adversarial Code Review Subagent Audit