### PR TITLE
Extract MessageContentArgs tuple for store signatures

### DIFF
--- a/services/local-ai-core/src/acp/store/acp-store-types.ts
+++ b/services/local-ai-core/src/acp/store/acp-store-types.ts
@@ -1,4 +1,4 @@
-import type { AutomationDefinition, AutomationEvaluation, AutomationRun } from '@cc/superai-contracts';
+import type { AutomationDefinition, AutomationEvaluation, AutomationRun, DesktopBridgeEvent, DesktopBridgeEventKind, DesktopBridgeToolCall } from '@cc/superai-contracts';
 
 export type LocalThreadRow = {
   id: string;
@@ -28,6 +28,15 @@ export type LocalMessageRow = {
   kind: 'final' | 'progress' | 'system';
   seq: number;
 };
+
+export type MessageContentArgs = [
+  role: LocalMessageRow['role'],
+  content: string,
+  kind: LocalMessageRow['kind'],
+  toolCall?: DesktopBridgeToolCall,
+  bridgeKind?: DesktopBridgeEventKind,
+  bridgeStatus?: DesktopBridgeEvent['bridgeStatus'],
+];
 
 export type LocalRunRow = {
   id: string;

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -56,13 +56,12 @@ import type {
   ExternalThread,
 } from '@cc/superai-contracts';
 import { LOCALCORE_ACP_AGENT_TYPE } from '@cc/superai-contracts';
-import type { DesktopBridgeEvent, DesktopBridgeEventKind, DesktopBridgeToolCall } from '@cc/superai-contracts';
 import type {
-  LocalMessageRow,
   LocalPlatformPairingRow,
   LocalPlatformThreadBindingRow,
   LocalPlatformUserRow,
   LocalRunRow,
+  MessageContentArgs,
 } from './acp-store-types.js';
 import { LocalAgentTaskStore } from './agent-task-store.js';
 import { LocalAutomationMonitorStore } from './automation-monitor-store.js';
@@ -160,29 +159,12 @@ export class LocalCoreAcpStore {
     this.threads.delete(threadId);
   }
 
-  appendMessage(
-    threadId: string,
-    role: LocalMessageRow['role'],
-    content: string,
-    kind: LocalMessageRow['kind'],
-    toolCall?: DesktopBridgeToolCall,
-    bridgeKind?: DesktopBridgeEventKind,
-    bridgeStatus?: DesktopBridgeEvent['bridgeStatus'],
-  ) {
-    return this.threads.appendMessage(threadId, role, content, kind, toolCall, bridgeKind, bridgeStatus);
+  appendMessage(threadId: string, ...args: MessageContentArgs) {
+    return this.threads.appendMessage(threadId, ...args);
   }
 
-  upsertMessage(
-    threadId: string,
-    id: string,
-    role: LocalMessageRow['role'],
-    content: string,
-    kind: LocalMessageRow['kind'],
-    toolCall?: DesktopBridgeToolCall,
-    bridgeKind?: DesktopBridgeEventKind,
-    bridgeStatus?: DesktopBridgeEvent['bridgeStatus'],
-  ) {
-    return this.threads.upsertMessage(threadId, id, role, content, kind, toolCall, bridgeKind, bridgeStatus);
+  upsertMessage(threadId: string, id: string, ...args: MessageContentArgs) {
+    return this.threads.upsertMessage(threadId, id, ...args);
   }
 
   updateRun(runId: string, threadId: string, status: LocalRunRow['status']) {

--- a/services/local-ai-core/src/acp/store/thread-store.ts
+++ b/services/local-ai-core/src/acp/store/thread-store.ts
@@ -6,11 +6,12 @@ import type {
 } from '@cc/superai-contracts';
 import { normalizeRunStatus } from '@cc/superai-contracts';
 import { LOCALCORE_ACP_AGENT_TYPE } from '@cc/superai-contracts';
-import type { DesktopBridgeEvent, DesktopBridgeEventKind, DesktopBridgeToolCall } from '@cc/superai-contracts';
+import type { DesktopBridgeToolCall } from '@cc/superai-contracts';
 import type {
   LocalMessageRow,
   LocalRunRow,
   LocalThreadRow,
+  MessageContentArgs,
 } from './acp-store-types.js';
 import { normalizeMessageContent } from '../../thread/workspace-thread-mappers.js';
 import { encodeThreadId } from '../../thread/workspace-thread-id.js';
@@ -135,15 +136,7 @@ export class LocalThreadStore {
     this.db.prepare('DELETE FROM threads WHERE id = ?').run(threadId);
   }
 
-  appendMessage(
-    threadId: string,
-    role: LocalMessageRow['role'],
-    content: string,
-    kind: LocalMessageRow['kind'],
-    toolCall?: DesktopBridgeToolCall,
-    bridgeKind?: DesktopBridgeEventKind,
-    bridgeStatus?: DesktopBridgeEvent['bridgeStatus'],
-  ) {
+  appendMessage(threadId: string, ...[role, content, kind, toolCall, bridgeKind, bridgeStatus]: MessageContentArgs) {
     const timestamp = new Date().toISOString();
     const nextSequenceRow = this.db.prepare('SELECT COALESCE(MAX(seq), -1) + 1 AS next_seq FROM messages WHERE thread_id = ?').get(threadId) as { next_seq: number };
     const nextSeq = Number(nextSequenceRow?.next_seq || 0);
@@ -179,16 +172,7 @@ export class LocalThreadStore {
     return { id, timestamp };
   }
 
-  upsertMessage(
-    threadId: string,
-    id: string,
-    role: LocalMessageRow['role'],
-    content: string,
-    kind: LocalMessageRow['kind'],
-    toolCall?: DesktopBridgeToolCall,
-    bridgeKind?: DesktopBridgeEventKind,
-    bridgeStatus?: DesktopBridgeEvent['bridgeStatus'],
-  ) {
+  upsertMessage(threadId: string, id: string, ...[role, content, kind, toolCall, bridgeKind, bridgeStatus]: MessageContentArgs) {
     const timestamp = new Date().toISOString();
     const excerpt = normalizeMessageContent(content);
     const existing = this.db.prepare('SELECT id FROM messages WHERE id = ? AND thread_id = ?').get(id, threadId) as { id: string } | undefined;


### PR DESCRIPTION
## Summary
- Hoists the duplicated 6-parameter suffix (`role`, `content`, `kind`, `toolCall`, `bridgeKind`, `bridgeStatus`) of `appendMessage` and `upsertMessage` between `LocalCoreAcpStore` (facade) and `LocalThreadStore` (impl) into a single `MessageContentArgs` tuple type in `services/local-ai-core/src/acp/store/acp-store-types.ts`.
- Eliminates cross-file clones **#4** (14 lines) and **#9** (12 lines) from `pnpm lint:duplicate`. Net: −25 lines, single source of truth for the message-write signature.
- Continues the daily refactor series (#54, #55, #56, #57, #58, #61, #65) targeting top duplicate-code clones.

## Approach
- Tuple type with labeled elements (`[role: ..., content: ..., ...]`) preserves hover/IntelliSense info at the call site.
- Facade uses `appendMessage(threadId, ...args: MessageContentArgs)` + spread-to-delegate → 4-line methods.
- Impl uses `appendMessage(threadId, ...[role, content, kind, toolCall, bridgeKind, bridgeStatus]: MessageContentArgs)` destructured at the param site → method body unchanged.
- All 9+ callers in `local-core-acp-backend.ts` and `local-core-acp-turn-coordinator.ts` continue to pass positional args unchanged.

## What I deliberately did NOT change
- `local-core-acp-turn-coordinator.ts:40-41` has a parallel signature with narrower literal types (`role: 'assistant'`, `kind: 'progress'`) instead of the wider `LocalMessageRow['role']` / `LocalMessageRow['kind']`. These narrower types are an intentional domain constraint (turn-coordinator only emits assistant progress messages), so widening to `MessageContentArgs` would lose a compile-time guard. Left as-is.

## Review rounds
- **Round 1**: 3 parallel agents (Code Reuse / Code Quality / Efficiency). All three returned **APPROVE**.
  - Code Reuse suggested extending to turn-coordinator — declined (would lose narrower literal-type guard).
  - Code Quality suggested renaming to `MessageWriteArgs` — declined (reviewer self-flagged as not worth a revision; current name is descriptive).
  - Efficiency confirmed behavior preservation and no perf regression.
- No round 2 needed.

## Validation
- `pnpm test`: 619 tests, **618 pass / 0 fail / 1 skipped**.
- `tsc --noEmit`: clean across touched files.

## Category
`chore` · `refactor` · `dedup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)