### PR TITLE
Hoist lark/weixin gateway route builders to base class

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -165,38 +165,6 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     return this.sendScheduledCard(workspaceId, route.channelId, text);
   }
 
-  registerScheduledThreadBridge(input: {
-    workspaceId: string;
-    platform: string;
-    route: ChannelRoute;
-    threadId: string;
-    sessionKey: string;
-  }) {
-    const instanceId = input.route.instanceId || extractChannelInstanceId(input.platform, 'lark') || 'default';
-    const platformKey = channelPlatformKey('lark', instanceId);
-    const route: LarkThreadRoute = {
-      workspaceId: input.workspaceId,
-      instanceId,
-      platformKey,
-      platformUserId: input.route.participantId || '',
-      chatId: input.route.channelId,
-      threadId: input.threadId,
-    };
-    const previousRoute = this.threadRouting.get(input.sessionKey);
-    this.threadRouting.set(input.sessionKey, route);
-    if (!this.outboundTurns.has(input.sessionKey)) {
-      this.createTurnState(input.sessionKey);
-    }
-    return () => {
-      if (previousRoute) {
-        this.threadRouting.set(input.sessionKey, previousRoute);
-      } else {
-        this.threadRouting.delete(input.sessionKey);
-      }
-    };
-  }
-
-
   protected async sendSessionCommandResult(input: {
     workspaceId: string;
     currentThreadId: string;
@@ -650,15 +618,8 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     return openId;
   }
 
-  protected makeThreadRoute(input: ChannelSessionCommandInput, threadId: string): LarkThreadRoute {
-    return {
-      workspaceId: input.workspaceId,
-      instanceId: input.instanceId,
-      platformKey: input.platformKey,
-      platformUserId: input.platformUserId,
-      chatId: input.chatId,
-      threadId,
-    };
+  protected createScheduledTurnState(sessionKey: string): LarkTurnState {
+    return createLarkTurnState(sessionKey);
   }
 
   protected collectBindings(config: DesktopConnectConfig | null | undefined): LarkWorkspaceBinding[] {

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -23,6 +23,7 @@ import type { LocalPlatformUserRow } from '../../router/workspace-router-types.j
 import type { EventBus } from '@cc/plugin-sdk';
 import { createChannelThreadMessageInput } from '../shared/content.js';
 import { buildChannelFileSendPayload } from '../../runtime/channel-service-helpers.js';
+import { channelPlatformKey, extractChannelInstanceId } from '../shared/channel-keys.js';
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
 import { resolveChannelThreadRoute } from '../shared/thread-routing.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
@@ -149,8 +150,22 @@ export abstract class BaseChannelGateway<
 
   // ==================== Abstract (platform-specific) ====================
 
-  /** Create a thread route object for the given command input and resolved thread id. */
-  protected abstract makeThreadRoute(input: ChannelSessionCommandInput, threadId: string): TThreadRoute;
+  /** All current channel route types are structurally identical to GatewayThreadRoute; override only if a future channel adds route-specific fields. */
+  protected makeThreadRoute(input: ChannelSessionCommandInput, threadId: string): TThreadRoute {
+    return {
+      workspaceId: input.workspaceId,
+      instanceId: input.instanceId,
+      platformKey: input.platformKey,
+      platformUserId: input.platformUserId,
+      chatId: input.chatId,
+      threadId,
+    } as TThreadRoute;
+  }
+
+  /** Called by registerScheduledThreadBridge to seed outboundTurns. Returns undefined by default so channels that don't track turn state can register scheduled bridges without overriding. */
+  protected createScheduledTurnState(_sessionKey: string): TTurnState | undefined {
+    return undefined;
+  }
 
   /** Collect enabled workspace bindings from the desktop config. */
   protected abstract collectBindings(config: DesktopConnectConfig | null | undefined): TBinding[];
@@ -380,17 +395,21 @@ export abstract class BaseChannelGateway<
     threadId: string;
     sessionKey: string;
   }) {
-    const instanceId = (input.route as { instanceId?: string }).instanceId || 'default';
+    const instanceId = input.route.instanceId || extractChannelInstanceId(input.platform, this.platform) || 'default';
     const route: GatewayThreadRoute = {
       workspaceId: input.workspaceId,
       instanceId,
-      platformKey: `${this.platform}${instanceId !== 'default' ? `:${instanceId}` : ''}`,
+      platformKey: channelPlatformKey(this.platform, instanceId),
       platformUserId: input.route.participantId || '',
       chatId: input.route.channelId,
       threadId: input.threadId,
     };
     const previousRoute = this.threadRouting.get(input.sessionKey);
     this.threadRouting.set(input.sessionKey, route as TThreadRoute);
+    if (!this.outboundTurns.has(input.sessionKey)) {
+      const turn = this.createScheduledTurnState(input.sessionKey);
+      if (turn) this.outboundTurns.set(input.sessionKey, turn);
+    }
     return () => {
       if (previousRoute) {
         this.threadRouting.set(input.sessionKey, previousRoute as TThreadRoute);

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -24,7 +24,7 @@ import { FileSystemInboundAttachmentStore, resolveInboundAttachmentUri } from '.
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
 import { BaseChannelGateway, type GatewayBinding, type GatewayRuntimeState, type GatewayThreadRoute } from '../shared/base-channel-gateway.js';
 import { resolveInboundChannelAuthorization } from '../shared/inbound-authorization.js';
-import { channelPlatformKey, extractChannelInstanceId, runtimeKey } from '../shared/channel-keys.js';
+import { channelPlatformKey, runtimeKey } from '../shared/channel-keys.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
 import {
@@ -95,15 +95,8 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
 
   // ==================== Abstract implementations ====================
 
-  protected makeThreadRoute(input: ChannelSessionCommandInput, threadId: string): WeixinThreadRoute {
-    return {
-      workspaceId: input.workspaceId,
-      instanceId: input.instanceId,
-      platformKey: input.platformKey,
-      platformUserId: input.platformUserId,
-      chatId: input.chatId,
-      threadId,
-    };
+  protected createScheduledTurnState(sessionKey: string): WeixinTurnState {
+    return createWeixinTurnState(sessionKey);
   }
 
   protected collectBindings(config: DesktopConnectConfig | null | undefined): WeixinWorkspaceBinding[] {
@@ -334,37 +327,6 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
   }
 
 
-
-  registerScheduledThreadBridge(input: {
-    workspaceId: string;
-    platform: string;
-    route: ChannelRoute;
-    threadId: string;
-    sessionKey: string;
-  }) {
-    const instanceId = input.route.instanceId || extractChannelInstanceId(input.platform, 'weixin') || 'default';
-    const platformKey = channelPlatformKey('weixin', instanceId);
-    const route: WeixinThreadRoute = {
-      workspaceId: input.workspaceId,
-      instanceId,
-      platformKey,
-      platformUserId: input.route.participantId || '',
-      chatId: input.route.channelId,
-      threadId: input.threadId,
-    };
-    const previousRoute = this.threadRouting.get(input.sessionKey);
-    this.threadRouting.set(input.sessionKey, route);
-    if (!this.outboundTurns.has(input.sessionKey)) {
-      this.outboundTurns.set(input.sessionKey, createWeixinTurnState(input.sessionKey));
-    }
-    return () => {
-      if (previousRoute) {
-        this.threadRouting.set(input.sessionKey, previousRoute);
-      } else {
-        this.threadRouting.delete(input.sessionKey);
-      }
-    };
-  }
 
   async sendOutboundMessage(workspaceId: string, input: ChannelOutboundMessageInput): Promise<ChannelOutboundMessageResult> {
     const state = this.resolveRuntimeState(workspaceId, input.route?.instanceId).state;


### PR DESCRIPTION
## Summary
- Hoists the duplicated `registerScheduledThreadBridge` and `makeThreadRoute` methods from `LocalCoreLarkGateway` and `LocalCoreWeixinGateway` into `BaseChannelGateway`. The base class also picks up the more-correct `extractChannelInstanceId` fallback and `channelPlatformKey` helper that the subclasses were using in their overrides.
- Adds a new `createScheduledTurnState` template-method hook so each subclass can seed its turn state without re-implementing the surrounding route-storage-and-rollback logic.
- Eliminates cross-file clones **#8** (12 lines) and **#10** (12 lines) from `pnpm lint:duplicate`. Net: −58 lines.
- Continues the daily refactor series (#54, #55, #56, #57, #58, #61, #65, #69) targeting top duplicate-code clones.

## Approach
- `makeThreadRoute` changed from `protected abstract` to concrete in the base class, returning the 6-field route shape cast as `TThreadRoute`. All current channel route types are structurally identical to `GatewayThreadRoute`, so the cast is safe.
- `registerScheduledThreadBridge` improved in the base class to use `extractChannelInstanceId(input.platform, this.platform)` fallback (matches the old subclass behavior) and `channelPlatformKey(this.platform, instanceId)` helper (functionally equivalent to the old inline template literal, but reusable).
- New `protected createScheduledTurnState(_sessionKey): TTurnState | undefined` hook (default no-op returning `undefined`). Base class calls it only when `outboundTurns` doesn't already have an entry for the session.
- Subclasses delete the overrides and add 1-line `createScheduledTurnState` overrides returning `createLarkTurnState(sessionKey)` / `createWeixinTurnState(sessionKey)`.

## What I deliberately did NOT change
- The route types `LarkThreadRoute` / `WeixinThreadRoute` remain structurally identical-but-separate from `GatewayThreadRoute`. Aliasing them (`type LarkThreadRoute = GatewayThreadRoute`) is a separate cleanup, deferred to a follow-up.

## Review rounds
- **Round 1**: 3 parallel agents (Code Reuse / Code Quality / Efficiency). All three returned **APPROVE** with minor stylistic suggestions.
  - Code Reuse suggested aliasing the route types — declined (separate cleanup, deferred).
  - Code Quality flagged JSDoc explaining WHAT instead of WHY — applied in round 2.
  - Code Quality suggested renaming hook to `createScheduledBridgeTurnState` — declined (docstring reference suffices for discoverability).
  - Code Quality noted subclass overrides narrow return type (`LarkTurnState` vs base `TTurnState | undefined`) — declined (TS accepts, more ergonomic).
  - Efficiency confirmed behavior preservation on all 4 axes (instanceId fallback, platformKey, turn-state hook, type safety).
- **Round 2**: reworded both JSDoc comments to explain WHY per CLAUDE.md convention. Tests still pass.

## Validation
- `pnpm test`: 626 tests, **625 pass / 0 fail / 1 skipped**.
- `tsc --noEmit`: clean across touched files.

## Category
`chore` · `refactor` · `dedup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)