### PR TITLE
Fix lark QR onboarding and harden SQLite crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ flowchart LR
 - 配置存储彻底迁移到 SQLite：移除 config.toml 及全部文件兼容层（legacy 导入、settings configPath、内嵌 provider 迁移、registry 备份/合并舞步），`runtime_config` 表成为工作区配置的唯一事实来源，`workspace_registry` 降级为派生镜像。
 - 修复定时任务绑定旧 agent runtime 的问题：side-thread 定时任务（Automation/Monitor）复用时校验线程 agent 类型与工作区当前 agent 是否一致，不一致时自动在新 agent 下重建会话线程，任务随工作区 agent 切换自愈。
 - 技能中心页面新增「安装 Obsidian 技能包」按钮：一键从 `kepano/obsidian-skills` 克隆并导入 5 个官方维护的 Obsidian 技能（obsidian-markdown、obsidian-bases、json-canvas、obsidian-cli、defuddle）到用户级目录，并通过既有的 skill-mounter 自动挂载到 Claude Code / Codex / opencode / Hermes / Pi 的原生 skills 目录（Issue #72 首批切片）。
+- 修复飞书扫码新增机器人后 App ID/Secret 为空的问题：扫码前不再向配置落库空凭据实例（QR 注册接口支持临时实例，凭据确认后才写入配置），轮询改为弹窗关闭后后台继续、出错自动退避重试而非静默停止，并为 QR 注册/轮询全过程补充网关日志便于回溯。
 
 ### 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ flowchart LR
 - 修复定时任务绑定旧 agent runtime 的问题：side-thread 定时任务（Automation/Monitor）复用时校验线程 agent 类型与工作区当前 agent 是否一致，不一致时自动在新 agent 下重建会话线程，任务随工作区 agent 切换自愈。
 - 技能中心页面新增「安装 Obsidian 技能包」按钮：一键从 `kepano/obsidian-skills` 克隆并导入 5 个官方维护的 Obsidian 技能（obsidian-markdown、obsidian-bases、json-canvas、obsidian-cli、defuddle）到用户级目录，并通过既有的 skill-mounter 自动挂载到 Claude Code / Codex / opencode / Hermes / Pi 的原生 skills 目录（Issue #72 首批切片）。
 - 修复飞书扫码新增机器人后 App ID/Secret 为空的问题：扫码前不再向配置落库空凭据实例（QR 注册接口支持临时实例，凭据确认后才写入配置），轮询改为弹窗关闭后后台继续、出错自动退避重试而非静默停止，并为 QR 注册/轮询全过程补充网关日志便于回溯。
+- 修复 Local AI Core 因 `database is locked` 崩溃导致服务不可用的问题：所有 SQLite 存储启用 WAL + `busy_timeout`（写冲突等待而非立即抛错），ACP 传输层对单条事件处理错误做隔离（不再整进程退出），`agentdock serve` 监督 Core 子进程、意外退出时交由 systemd 自动拉起。
 
 ### 2026-08-13
 

--- a/bin/agentdock.mjs
+++ b/bin/agentdock.mjs
@@ -316,7 +316,9 @@ async function runServe(flags) {
     await waitForCore(coreOrigin);
   }
   const server = startWebServer({ host, port, coreOrigin });
+  let shuttingDown = false;
   const shutdown = () => {
+    shuttingDown = true;
     server.close();
     if (coreProcess) {
       coreProcess.kill('SIGTERM');
@@ -324,6 +326,18 @@ async function runServe(flags) {
   };
   process.once('SIGINT', shutdown);
   process.once('SIGTERM', shutdown);
+  if (coreProcess) {
+    coreProcess.on('exit', (code, signal) => {
+      if (shuttingDown) {
+        return;
+      }
+      // Never leave the web server proxying to a dead core: exit so the
+      // supervisor (systemd Restart=always) brings the whole stack back up.
+      console.error(`[agentdock] Local AI Core exited unexpectedly (code=${code} signal=${signal}); exiting for supervisor restart`);
+      server.close();
+      process.exit(code ?? 1);
+    });
+  }
 }
 
 const { command, flags } = parseArgs(process.argv.slice(2));

--- a/packages/knowledge-api/src/sqlite-store.ts
+++ b/packages/knowledge-api/src/sqlite-store.ts
@@ -91,6 +91,10 @@ export class KnowledgeSqliteStore {
 
     const shouldMigrate = !existsSync(this.dbPath) && existsSync(this.legacyStorePath);
     this.db = new DatabaseSync(this.dbPath);
+    // WAL + busy timeout: without them a concurrent write throws
+    // `database is locked` immediately instead of waiting briefly.
+    this.db.exec('PRAGMA journal_mode = WAL');
+    this.db.exec('PRAGMA busy_timeout = 5000');
 
     try {
       this.initializeSchema();

--- a/services/local-ai-core/src/acp/local-core-acp-transport.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-transport.ts
@@ -234,11 +234,11 @@ export class LocalCoreAcpTransport {
         continue;
       }
       if (payload.method && payload.id !== undefined) {
-        this.options.onAgentRequest(session, payload);
+        this.dispatchAgentEvent('onAgentRequest', session, payload);
         continue;
       }
       if (payload.method) {
-        this.options.onAgentNotification(session, payload);
+        this.dispatchAgentEvent('onAgentNotification', session, payload);
         continue;
       }
       if (payload.id !== undefined) {
@@ -261,6 +261,17 @@ export class LocalCoreAcpTransport {
           pending.resolve(payload.result);
         }
       }
+    }
+  }
+
+  private dispatchAgentEvent(kind: 'onAgentRequest' | 'onAgentNotification', session: AcpSessionState, payload: any) {
+    try {
+      this.options[kind](session, payload);
+    } catch (error) {
+      // A single event (e.g. a message write hitting a transient store error)
+      // must never take down the whole core process: log it, drop the event,
+      // and keep consuming the agent stream.
+      this.options.log?.(`[localcore-acp:${session.threadId}] ${kind} failed: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -79,7 +79,7 @@ import {
   type AutomationRunUpdateInput,
   type AutomationStateUpdateInput,
 } from './automation-store.js';
-import { ensureLocalCoreAcpSchema } from './schema.js';
+import { configureSqlitePragmas, ensureLocalCoreAcpSchema } from './schema.js';
 import { LocalPlatformStore } from './platform-store.js';
 import { LocalSchedulerStore } from './scheduler-store.js';
 import { LocalSecurityStore } from './security-store.js';
@@ -111,6 +111,7 @@ export class LocalCoreAcpStore {
     const runtimeDir = dirname(dbPath);
     mkdirSync(dirname(dbPath), { recursive: true });
     this.db = new DatabaseSync(dbPath);
+    configureSqlitePragmas(this.db);
     this.threads = new LocalThreadStore(this.db);
     this.trace = new LocalCoreTraceStore(this.db);
     this.workspaceRegistry = new LocalWorkspaceRegistryStore(this.db);

--- a/services/local-ai-core/src/acp/store/schema.ts
+++ b/services/local-ai-core/src/acp/store/schema.ts
@@ -1,5 +1,18 @@
 import type { DatabaseSync } from 'node:sqlite';
 
+/**
+ * Apply the connection settings every AgentDock SQLite store needs. The
+ * default rollback-journal mode has no busy timeout, so any write contention
+ * (e.g. a message upsert racing another store write) throws `database is
+ * locked` immediately. WAL lets readers coexist with a single writer and
+ * `busy_timeout` makes brief lock waits succeed instead of throwing, so a
+ * transient write conflict can never crash the process.
+ */
+export function configureSqlitePragmas(db: DatabaseSync) {
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA busy_timeout = 5000');
+}
+
 export function ensureLocalCoreAcpSchema(db: DatabaseSync) {
   db.exec(`
     PRAGMA foreign_keys = ON;

--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -110,17 +110,21 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
   }
 
   async getQrCode(workspaceId: string, instanceId?: string): Promise<LocalCoreChannelQrCode> {
-    const binding = await this.getBinding(workspaceId, instanceId);
+    const binding = await this.resolveQrBinding(workspaceId, instanceId);
     const data = await requestAppRegistration(binding);
     const ticket = String(data.device_code || '').trim();
     const userCode = String(data.user_code || '').trim();
     if (!ticket || !userCode) {
+      this.options.log?.(`localcore-lark qr begin failed for ${workspaceId}/${binding.instanceId}: response did not include device_code/user_code`);
       throw new Error('Lark app registration did not return a device code and user code.');
     }
+    const expiresIn = Number(data.expires_in || DEFAULT_LARK_QR_EXPIRES_IN) || DEFAULT_LARK_QR_EXPIRES_IN;
+    const interval = Number(data.interval || 5) || 5;
+    this.options.log?.(`localcore-lark qr begin workspace=${workspaceId} instance=${binding.instanceId} brand=${binding.brand} userCode=${userCode} expiresIn=${expiresIn} interval=${interval}`);
     return {
       ticket,
-      expiresIn: Number(data.expires_in || DEFAULT_LARK_QR_EXPIRES_IN) || DEFAULT_LARK_QR_EXPIRES_IN,
-      interval: Number(data.interval || 5) || 5,
+      expiresIn,
+      interval,
       qrCodeUrl: `${getLarkOpenBase(binding)}${LARK_APP_REGISTRATION_SETUP_PATH}?user_code=${encodeURIComponent(userCode)}&from=openclaw`,
       instanceId: binding.instanceId,
       displayName: binding.displayName,
@@ -128,26 +132,38 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
   }
 
   async checkQrCodeStatus(workspaceId: string, ticket: string, instanceId?: string): Promise<LocalCoreLarkQrCodeStatus> {
-    const binding = await this.getBinding(workspaceId, instanceId);
-    const data = await pollAppRegistration(binding, ticket);
+    const binding = await this.resolveQrBinding(workspaceId, instanceId);
+    let data: Record<string, unknown>;
+    try {
+      data = await pollAppRegistration(binding, ticket);
+    } catch (error) {
+      this.options.log?.(`localcore-lark qr poll request failed for ${workspaceId}/${binding.instanceId}: ${formatSafeError(error)}`);
+      throw error;
+    }
     const error = String(data.error || '').trim();
     if (error === 'authorization_pending' || error === 'slow_down') {
+      this.options.log?.(`localcore-lark qr poll workspace=${workspaceId} instance=${binding.instanceId}: waiting (${error})`);
       return { status: 'wait' };
     }
     if (error === 'expired_token' || error === 'invalid_grant') {
+      this.options.log?.(`localcore-lark qr poll workspace=${workspaceId} instance=${binding.instanceId}: expired (${error})`);
       return { status: 'expired' };
     }
     if (error === 'access_denied') {
+      this.options.log?.(`localcore-lark qr poll workspace=${workspaceId} instance=${binding.instanceId}: rejected (access_denied)`);
       throw new Error('Lark app registration was rejected.');
     }
     if (error) {
+      this.options.log?.(`localcore-lark qr poll workspace=${workspaceId} instance=${binding.instanceId}: unexpected error=${error} description=${String(data.error_description || '')}`);
       throw new Error(`Lark app registration failed: ${String(data.error_description || error)}`);
     }
     const appId = String(data.client_id || '').trim();
     const appSecret = String(data.client_secret || '').trim();
     if (!appId || !appSecret) {
+      this.options.log?.(`localcore-lark qr poll workspace=${workspaceId} instance=${binding.instanceId}: confirmed but credentials incomplete (client_id=${appId ? 'present' : 'missing'} client_secret=${appSecret ? 'present' : 'missing'})`);
       return { status: 'wait' };
     }
+    this.options.log?.(`localcore-lark qr poll workspace=${workspaceId} instance=${binding.instanceId}: confirmed app=${maskLarkAppId(appId)}`);
     return {
       status: 'confirmed',
       credentials: {
@@ -155,6 +171,46 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
         appSecret,
       },
     };
+  }
+
+  /**
+   * Resolves the binding for QR registration. Unlike runtime operations, the
+   * Feishu device flow only needs the brand and identifiers, so an instance
+   * that has not been persisted yet (client generates the QR before the bot
+   * credentials exist) gets an ephemeral binding instead of an error. This
+   * keeps empty-credential instances out of the saved config until the flow
+   * actually confirms.
+   */
+  private async resolveQrBinding(workspaceId: string, instanceId?: string): Promise<LarkWorkspaceBinding> {
+    try {
+      return await this.getBinding(workspaceId, instanceId);
+    } catch {
+      const config = await this.options.readConfig();
+      const projects = Array.isArray(config?.projects) ? config!.projects : [];
+      const project = projects.find((entry) => (entry.workspace_id || entry.name) === workspaceId);
+      if (!project) {
+        throw new Error(`No lark binding configured for workspace "${workspaceId}"`);
+      }
+      const resolvedInstanceId = String(instanceId || '').trim() || 'default';
+      const existingCount = this.collectBindings(config).filter((entry) => entry.workspaceId === workspaceId).length;
+      return {
+        workspaceId,
+        instanceId: resolvedInstanceId,
+        displayName: `Lark ${existingCount + 1}`,
+        platformKey: channelPlatformKey('lark', resolvedInstanceId),
+        appId: '',
+        appSecret: '',
+        encryptKey: '',
+        verificationToken: '',
+        autoApprove: false,
+        cardActionsEnabled: this.defaultCardActionsEnabled,
+        groupReplyAll: false,
+        downloadsDir: '',
+        brand: 'feishu',
+        enabled: false,
+        project,
+      };
+    }
   }
 
   async sendScheduledCard(workspaceId: string, chatId: string, text: string) {

--- a/src/pages/Desktop/Workspace.tsx
+++ b/src/pages/Desktop/Workspace.tsx
@@ -29,7 +29,6 @@ import {
   clone,
   createPlatformDraft,
   createProjectDialogDraft,
-  desktopProjectWorkspaceId,
   ensureProjects,
   fromSandboxForm,
   getPlatformInstanceId,
@@ -65,9 +64,6 @@ export default function DesktopWorkspace() {
   const [pending, setPending] = useState('');
   const [notice, setNotice] = useState<Notice | null>(null);
   const configDraftRef = useRef<DesktopConnectConfig | null>(null);
-  const platformDialogRef = useRef<PlatformDialogState | null>(null);
-  const selectedIndexRef = useRef(selectedIndex);
-  const selectedProjectWorkspaceIdRef = useRef('');
 
   const loadAll = useCallback(async (projectName = '') => {
     setLoading(true);
@@ -109,15 +105,6 @@ export default function DesktopWorkspace() {
   useEffect(() => {
     configDraftRef.current = configDraft;
   }, [configDraft]);
-
-  useEffect(() => {
-    platformDialogRef.current = platformDialog;
-  }, [platformDialog]);
-
-  useEffect(() => {
-    selectedIndexRef.current = selectedIndex;
-    selectedProjectWorkspaceIdRef.current = selectedProject ? desktopProjectWorkspaceId(selectedProject) : '';
-  }, [selectedIndex, selectedProject?.name, selectedProject?.workspace_id]);
 
   useEffect(() => {
     if (!configDraft || !requestedProject) return;
@@ -233,13 +220,18 @@ export default function DesktopWorkspace() {
 
   const openPlatformDialog = (index: number | null) => {
     setWeixinQr(null);
-    setLarkQr(null);
     if (index === null) {
+      // A brand-new draft has a fresh instance id, so an in-flight QR for
+      // another instance is no longer relevant.
+      setLarkQr(null);
       setPlatformDialog({ index, draft: createPlatformDraft() });
       return;
     }
     const platform = selectedProject?.platforms?.[index];
     if (platform) {
+      // Keep an in-flight QR when the user reopens the dialog for the same
+      // instance (the background poll may have already confirmed it).
+      setLarkQr((current) => current && getPlatformInstanceId(platform) === current.instanceId ? current : null);
       setPlatformDialog({ index, draft: clone(platform) });
     }
   };
@@ -328,11 +320,7 @@ export default function DesktopWorkspace() {
     selectedProject,
     configDraft,
     platformDialog,
-    persistPlatformDialogDraft,
-    selectedProjectWorkspaceIdRef,
-    platformDialogRef,
     configDraftRef,
-    selectedIndexRef,
     setNotice,
     setConfigDraft,
     setPersistedConfig,
@@ -434,8 +422,9 @@ export default function DesktopWorkspace() {
         onUpdateDraft={updatePlatformDialogDraft}
         onClose={() => {
           setPlatformDialog(null);
+          // Keep larkQr alive: the background poll may still confirm a scan
+          // that happened while the dialog was open.
           setWeixinQr(null);
-          setLarkQr(null);
         }}
         onApply={handleApplyPlatformDialog}
         onGenerateWeixinQr={handleGenerateWeixinQr}

--- a/src/pages/Desktop/workspace-hooks.ts
+++ b/src/pages/Desktop/workspace-hooks.ts
@@ -12,6 +12,7 @@ import type { DesktopConnectConfig } from '@cc/superai-contracts';
 import {
   clone,
   createPlatformDraft,
+  desktopProjectWorkspaceId,
   ensureProjects,
   getPlatformInstanceId,
   normalizePlatformDraft,
@@ -29,11 +30,7 @@ interface UseLarkQrParams {
   selectedProject: { name?: string; workspace_id?: string } | null;
   configDraft: DesktopConnectConfig | null;
   platformDialog: PlatformDialogState | null;
-  persistPlatformDialogDraft: () => Promise<unknown>;
-  selectedProjectWorkspaceIdRef: React.RefObject<string>;
-  platformDialogRef: React.RefObject<PlatformDialogState | null>;
   configDraftRef: React.RefObject<DesktopConnectConfig | null>;
-  selectedIndexRef: React.RefObject<number>;
   setNotice: (notice: Notice | null) => void;
   setConfigDraft: React.Dispatch<React.SetStateAction<DesktopConnectConfig | null>>;
   setPersistedConfig: React.Dispatch<React.SetStateAction<DesktopConnectConfig | null>>;
@@ -52,17 +49,19 @@ interface LarkCredentials {
 /**
  * Owns the Lark QR-code binding flow: generating the QR, polling for the scan
  * result, persisting the returned credentials, and activating the gateway.
- * Pulls live values through refs so the polling loop never goes stale.
+ *
+ * The flow deliberately does NOT persist the platform before scanning: the QR
+ * registration endpoints accept an ephemeral instance, so an instance only
+ * enters the saved config once the bot credentials are confirmed. The polling
+ * loop keeps running in the background (even with the dialog closed) and keeps
+ * retrying on transient errors instead of dying silently, so a completed scan
+ * is never lost to a stopped poller.
  */
 export function useLarkQr({
   selectedProject,
   configDraft,
   platformDialog,
-  persistPlatformDialogDraft,
-  selectedProjectWorkspaceIdRef,
-  platformDialogRef,
   configDraftRef,
-  selectedIndexRef,
   setNotice,
   setConfigDraft,
   setPersistedConfig,
@@ -83,22 +82,25 @@ export function useLarkQr({
     }
   }, []);
 
-  const saveLarkCredentialsFromQr = useCallback(async (credentials: LarkCredentials) => {
-    const workspaceId = selectedProjectWorkspaceIdRef.current;
-    const targetInstanceId = getPlatformInstanceId(platformDialogRef.current?.draft);
+  const saveLarkCredentialsFromQr = useCallback(async (credentials: LarkCredentials, workspaceId: string, targetInstanceId: string) => {
     const currentConfig = configDraftRef.current;
-    if (!currentConfig) return;
+    if (!currentConfig) {
+      setNotice({ tone: 'error', message: 'Lark bot credentials were received, but the workspace config is not loaded. Refresh the page and retry.' });
+      return;
+    }
     const nextConfig = clone(currentConfig);
     const nextProjects = ensureProjects(nextConfig);
-    const projectIndex = selectedIndexRef.current;
+    const projectIndex = nextProjects.findIndex((project) => desktopProjectWorkspaceId(project) === workspaceId);
+    if (projectIndex < 0) {
+      setNotice({ tone: 'error', message: `Lark bot credentials were received for workspace "${workspaceId}", but the project is no longer in the config.` });
+      return;
+    }
     const project = nextProjects[projectIndex];
-    if (!project) return;
     const platforms = [...(project.platforms || [])];
-    const currentDialog = platformDialogRef.current;
-    const currentIndex = currentDialog?.index ?? platforms.findIndex((platform) =>
+    const currentIndex = platforms.findIndex((platform) =>
       normalizePlatformDraft(platform).type === 'lark' && getPlatformInstanceId(platform) === targetInstanceId
     );
-    const currentPlatform = currentIndex >= 0 ? platforms[currentIndex] : currentDialog?.draft || createPlatformDraft('lark');
+    const currentPlatform = currentIndex >= 0 ? platforms[currentIndex] : createPlatformDraft('lark');
     const nextPlatform = normalizePlatformDraft({
       ...currentPlatform,
       type: 'lark',
@@ -124,36 +126,44 @@ export function useLarkQr({
     const savedConfig = clone(saved.config || nextConfig);
     setPersistedConfig(savedConfig);
     setConfigDraft(clone(savedConfig));
-    setPlatformDialog((current) => current ? { ...current, index: current.index ?? (currentIndex >= 0 ? currentIndex : platforms.length - 1), draft: nextPlatform } : current);
+    setPlatformDialog((current) => {
+      if (!current || getPlatformInstanceId(current.draft) !== targetInstanceId) return current;
+      return {
+        ...current,
+        index: current.index ?? (currentIndex >= 0 ? currentIndex : platforms.length - 1),
+        draft: nextPlatform,
+      };
+    });
     await activateLarkGatewayAfterBind(workspaceId, targetInstanceId);
     setNotice({ tone: 'success', message: 'Lark bot bound, saved, and ready to send messages.' });
     const projectName = nextProjects[projectIndex]?.name;
     if (projectName) await loadAll(projectName);
-  }, [activateLarkGatewayAfterBind, loadAll, selectedProjectWorkspaceIdRef, platformDialogRef, configDraftRef, selectedIndexRef, setPersistedConfig, setConfigDraft, setPlatformDialog, setNotice]);
+  }, [activateLarkGatewayAfterBind, loadAll, configDraftRef, setPersistedConfig, setConfigDraft, setPlatformDialog, setNotice]);
 
   const handleGenerateLarkQr = useCallback(async () => {
     if (!selectedProject?.name || !configDraft) return;
     setLarkQrLoading(true);
     try {
-      await persistPlatformDialogDraft();
-      const result = await getLarkQrCode(selectedProject.workspace_id || selectedProject.name, getPlatformInstanceId(platformDialog?.draft));
-      setLarkQr({ ...result, status: 'wait', createdAt: Date.now() });
+      const workspaceId = selectedProject.workspace_id || selectedProject.name;
+      const instanceId = getPlatformInstanceId(platformDialog?.draft);
+      const result = await getLarkQrCode(workspaceId, instanceId);
+      setLarkQr({ ...result, status: 'wait', createdAt: Date.now(), workspaceId, instanceId });
       setNotice(null);
     } catch (err) {
       setNotice({ tone: 'error', message: describeError(err) });
     } finally {
       setLarkQrLoading(false);
     }
-  }, [selectedProject, configDraft, platformDialog, persistPlatformDialogDraft, setNotice]);
+  }, [selectedProject, configDraft, platformDialog, setNotice]);
 
   const handleCheckLarkQr = useCallback(async () => {
-    if (!selectedProject?.name || !larkQr?.ticket || !configDraft) return;
+    if (!larkQr?.ticket) return;
     setLarkQrLoading(true);
     try {
-      const result = await checkLarkQrCodeStatus(selectedProject.workspace_id || selectedProject.name, larkQr.ticket, getPlatformInstanceId(platformDialog?.draft));
+      const result = await checkLarkQrCodeStatus(larkQr.workspaceId, larkQr.ticket, larkQr.instanceId);
       setLarkQr((current) => current ? { ...current, status: result.status, botName: result.credentials?.botName } : current);
       if (result.status === 'confirmed' && result.credentials) {
-        await saveLarkCredentialsFromQr(result.credentials);
+        await saveLarkCredentialsFromQr(result.credentials, larkQr.workspaceId, larkQr.instanceId);
       } else if (result.status === 'expired') {
         setNotice({ tone: 'warning', message: 'Lark QR code expired. Generate a new QR code and scan again.' });
       }
@@ -162,17 +172,18 @@ export function useLarkQr({
     } finally {
       setLarkQrLoading(false);
     }
-  }, [selectedProject, larkQr, configDraft, platformDialog, saveLarkCredentialsFromQr, setNotice]);
+  }, [larkQr, saveLarkCredentialsFromQr, setNotice]);
 
   useEffect(() => {
-    if (!selectedProject?.name || !larkQr?.ticket || platformDialog?.draft.type !== 'lark') return;
+    if (!larkQr?.ticket) return;
     if (larkQr.status && !['wait', 'signed'].includes(larkQr.status)) return;
 
     let cancelled = false;
     let timer: number | undefined;
     const createdAt = larkQr.createdAt || Date.now();
     const expiresAt = createdAt + Math.max(larkQr.expiresIn || 0, 1) * 1000;
-    const pollDelay = Math.max(3, Math.min(Number(larkQr.interval || 5) || 5, 15)) * 1000;
+    const basePollDelay = Math.max(3, Math.min(Number(larkQr.interval || 5) || 5, 15)) * 1000;
+    let consecutiveErrors = 0;
 
     const schedule = (delay: number) => {
       timer = window.setTimeout(() => {
@@ -188,25 +199,33 @@ export function useLarkQr({
         return;
       }
       try {
-        const result = await checkLarkQrCodeStatus(selectedProject.workspace_id || selectedProject.name || '', larkQr.ticket, getPlatformInstanceId(platformDialogRef.current?.draft));
+        const result = await checkLarkQrCodeStatus(larkQr.workspaceId, larkQr.ticket, larkQr.instanceId);
         if (cancelled) return;
+        consecutiveErrors = 0;
         setLarkQr((current) => current?.ticket === larkQr.ticket ? { ...current, status: result.status, botName: result.credentials?.botName } : current);
         if (result.status === 'confirmed' && result.credentials) {
-          await saveLarkCredentialsFromQr(result.credentials);
+          await saveLarkCredentialsFromQr(result.credentials, larkQr.workspaceId, larkQr.instanceId);
           return;
         }
         if (result.status === 'expired') {
           setNotice({ tone: 'warning', message: 'Lark QR code expired. Generate a new QR code and scan again.' });
           return;
         }
-        schedule(pollDelay);
+        schedule(basePollDelay);
       } catch (err) {
         if (cancelled) return;
-        setNotice({ tone: 'error', message: describeError(err) });
+        // Never stop polling on transient errors: the Feishu registration flow
+        // may still complete while we wait, and the confirmed credentials are
+        // only handed out once. Back off so a broken endpoint is not hammered.
+        consecutiveErrors += 1;
+        if (consecutiveErrors === 1) {
+          setNotice({ tone: 'warning', message: `Lark QR status check failed, retrying: ${describeError(err)}` });
+        }
+        schedule(Math.min(basePollDelay * Math.pow(2, consecutiveErrors - 1), 30000));
       }
     };
 
-    schedule(Math.min(2000, pollDelay));
+    schedule(Math.min(2000, basePollDelay));
     return () => {
       cancelled = true;
       if (timer) window.clearTimeout(timer);
@@ -217,9 +236,8 @@ export function useLarkQr({
     larkQr?.interval,
     larkQr?.status,
     larkQr?.ticket,
-    platformDialog?.draft.type,
-    selectedProject?.name,
-    platformDialogRef,
+    larkQr?.workspaceId,
+    larkQr?.instanceId,
     saveLarkCredentialsFromQr,
     setNotice,
   ]);

--- a/src/pages/Desktop/workspace-model.ts
+++ b/src/pages/Desktop/workspace-model.ts
@@ -70,6 +70,9 @@ export type WeixinQrState = {
 
 export type LarkQrState = WeixinQrState & {
   botName?: string;
+  /** Captured at QR generation so polling and credential saving survive dialog close. */
+  workspaceId: string;
+  instanceId: string;
 };
 
 export const PROVIDER_PRESETS: Array<DesktopProviderConfig & { id: string; label: string }> = [

--- a/tests/electron/workspace-task-store.test.ts
+++ b/tests/electron/workspace-task-store.test.ts
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
 import { LocalCoreAcpStore } from '../../services/local-ai-core/src/acp/local-core-acp-store.js';
+import { configureSqlitePragmas } from '../../services/local-ai-core/src/acp/store/schema.js';
 import { LocalCoreAcpBackend } from '../../services/local-ai-core/src/acp/local-core-acp-backend.js';
 import { buildAgentPath, LocalCoreAcpSessionCoordinator } from '../../services/local-ai-core/src/acp/local-core-acp-session-coordinator.js';
 import { LocalCoreAcpTransport } from '../../services/local-ai-core/src/acp/local-core-acp-transport.js';
@@ -948,6 +950,74 @@ test('ACP transport reports missing agent commands without an unhandled process 
 
   const error = await closed;
   assert.equal(error.message, 'ACP agent command not found: agentdock-command-that-does-not-exist');
+});
+
+test('ACP transport isolates notification and request handler errors instead of crashing', () => {
+  const logs: string[] = [];
+  const transport = new LocalCoreAcpTransport({
+    log: (message: string) => logs.push(message),
+    onAgentRequest: () => {
+      throw new Error('request handler boom');
+    },
+    onAgentNotification: () => {
+      throw new Error('notification handler boom');
+    },
+    onSessionClosed: () => {},
+  });
+  const session = {
+    threadId: 'thread-error-isolation',
+    stdoutBuffer: '',
+    pending: new Map(),
+  } as any;
+
+  // A throwing notification handler must not propagate out of the stdout
+  // event (the crash class that killed the core with "database is locked").
+  assert.doesNotThrow(() => {
+    (transport as any).handleStdout(session, '{"method":"message","params":{}}\n');
+  });
+  // A throwing request handler must not propagate either.
+  assert.doesNotThrow(() => {
+    (transport as any).handleStdout(session, '{"method":"initialize","id":1,"params":{}}\n');
+  });
+  // The stream keeps being consumed after handler failures.
+  assert.doesNotThrow(() => {
+    (transport as any).handleStdout(session, 'garbage line\n{"method":"message","params":{}}\n');
+  });
+  assert.ok(logs.some((line) => line.includes('notification handler boom')));
+  assert.ok(logs.some((line) => line.includes('request handler boom')));
+  assert.ok(logs.some((line) => line.includes('ACP stdout parse failed')));
+});
+
+test('SQLite stores run in WAL mode with a busy timeout', () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'store-pragma-'));
+  try {
+    const store = new LocalCoreAcpStore(userDataPath);
+    // journal_mode is persisted in the database header, so a separate
+    // connection observes the mode the store set.
+    const probe = new DatabaseSync(join(userDataPath, 'runtime', 'local-core.db'));
+    const mode = probe.prepare('PRAGMA journal_mode').get() as { journal_mode: string };
+    assert.equal(mode.journal_mode, 'wal');
+    probe.close();
+    store.close();
+  } finally {
+    rmSync(userDataPath, { recursive: true, force: true });
+  }
+});
+
+test('configureSqlitePragmas sets WAL and a busy timeout on the connection', () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'pragma-helper-'));
+  try {
+    const db = new DatabaseSync(join(userDataPath, 'pragma.db'));
+    configureSqlitePragmas(db);
+    const mode = db.prepare('PRAGMA journal_mode').get() as { journal_mode: string };
+    // SQLite returns the busy timeout under the column name "timeout".
+    const timeout = db.prepare('PRAGMA busy_timeout').get() as { timeout: number };
+    assert.equal(mode.journal_mode, 'wal');
+    assert.equal(timeout.timeout, 5000);
+    db.close();
+  } finally {
+    rmSync(userDataPath, { recursive: true, force: true });
+  }
 });
 
 test('ACP scheduled session can override permission mode without changing thread mode', async () => {

--- a/tests/integration/lark-gateway.test.ts
+++ b/tests/integration/lark-gateway.test.ts
@@ -2169,6 +2169,119 @@ test('lark app registration QR confirmation returns app credentials', async () =
   }
 });
 
+test('lark QR registration works for an instance that is not persisted in config', async () => {
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ body: string }> = [];
+  let call = 0;
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    call += 1;
+    requests.push({ body: String(init?.body || '') });
+    if (call === 1) {
+      return new Response(JSON.stringify({
+        device_code: 'device-code-ephemeral',
+        user_code: 'EPH-1234',
+        expires_in: 300,
+        interval: 5,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      client_id: 'cli_ephemeral_1',
+      client_secret: 'secret-ephemeral',
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }) as typeof fetch;
+
+  const logs: string[] = [];
+  try {
+    const gateway = new LocalCoreLarkGateway({
+      store: {} as any,
+      readConfig: async () => ({
+        projects: [
+          {
+            name: 'default',
+            agent: { type: 'localcore-acp', providers: [] },
+            // The lark platform has NOT been persisted yet: the QR flow must
+            // still be able to begin and poll against an ephemeral instance.
+            platforms: [],
+          },
+        ],
+      } as any),
+      getWorkspaceRouter: () => ({} as any),
+      eventBus: { emit: () => {}, on: () => () => {} } as any,
+      log: (message: string) => logs.push(message),
+    });
+
+    const qr = await gateway.getQrCode('default', 'lark-ephemeral-1');
+    assert.equal(qr.ticket, 'device-code-ephemeral');
+    assert.equal(qr.instanceId, 'lark-ephemeral-1');
+    assert.equal(qr.displayName, 'Lark 1');
+    assert.equal(qr.qrCodeUrl, 'https://open.feishu.cn/page/openclaw?user_code=EPH-1234&from=openclaw');
+
+    const result = await gateway.checkQrCodeStatus('default', 'device-code-ephemeral', 'lark-ephemeral-1');
+    assert.deepEqual(result, {
+      status: 'confirmed',
+      credentials: {
+        appId: 'cli_ephemeral_1',
+        appSecret: 'secret-ephemeral',
+      },
+    });
+    assert.ok(logs.some((line) => line.includes('qr begin') && line.includes('instance=lark-ephemeral-1')));
+    // The app id is masked in logs; the first six characters are preserved.
+    assert.ok(logs.some((line) => line.includes('qr poll') && line.includes('confirmed app=cli_ep')));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('lark QR poll logs pending, expired, rejected, and incomplete-credential transitions', async () => {
+  const originalFetch = globalThis.fetch;
+  let call = 0;
+  globalThis.fetch = (async () => {
+    call += 1;
+    const payload = call === 1
+      ? { error: 'authorization_pending', error_description: '', code: 20094 }
+      : call === 2
+        ? { error: 'expired_token', error_description: '', code: 20099 }
+        : call === 3
+          ? { error: 'access_denied', error_description: '', code: 20097 }
+          : { client_id: 'cli_partial', code: 0 };
+    return new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }) as typeof fetch;
+
+  const logs: string[] = [];
+  try {
+    const gateway = new LocalCoreLarkGateway({
+      store: {} as any,
+      readConfig: async () => ({
+        projects: [
+          {
+            name: 'default',
+            agent: { type: 'localcore-acp', providers: [] },
+            platforms: [{ type: 'lark', options: { instance_id: 'lark-pending', app_id: 'cli_a', app_secret: 'secret-a' } }],
+          },
+        ],
+      } as any),
+      getWorkspaceRouter: () => ({} as any),
+      eventBus: { emit: () => {}, on: () => () => {} } as any,
+      log: (message: string) => logs.push(message),
+    });
+
+    assert.deepEqual(await gateway.checkQrCodeStatus('default', 'ticket-1', 'lark-pending'), { status: 'wait' });
+    assert.deepEqual(await gateway.checkQrCodeStatus('default', 'ticket-1', 'lark-pending'), { status: 'expired' });
+    await assert.rejects(
+      () => gateway.checkQrCodeStatus('default', 'ticket-1', 'lark-pending'),
+      /rejected/,
+    );
+    // A confirmed poll without a client_secret must stay pending, not confirm.
+    assert.deepEqual(await gateway.checkQrCodeStatus('default', 'ticket-1', 'lark-pending'), { status: 'wait' });
+    assert.ok(logs.some((line) => line.includes('waiting (authorization_pending)')));
+    assert.ok(logs.some((line) => line.includes('expired (expired_token)')));
+    assert.ok(logs.some((line) => line.includes('rejected (access_denied)')));
+    assert.ok(logs.some((line) => line.includes('credentials incomplete (client_id=present client_secret=missing)')));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('lark channel keeps multiple bot instances in one workspace isolated', async () => {
   const gateway = new LocalCoreLarkGateway({
     store: {


### PR DESCRIPTION
## 背景
两个问题：
1. **飞书扫码新增机器人后 appid/appsecret 为空**：扫码前 `persistPlatformDialogDraft` 就把空凭据实例落库（僵尸 "Lark 2"），轮询一遇错误/关弹窗即静默停止，确认结果永远到不了保存环节。
2. **生产事故**：Local AI Core 因 `database is locked`（SQLITE_BUSY）未捕获异常整进程崩溃（journal_mode=delete + 无 busy_timeout），且 `agentdock serve` 不监督 Core 子进程，崩溃后无人拉起，服务实际不可用。

## 改动

### commit 1: Fix lark QR onboarding persisting empty credentials
- 扫码前不再持久化空凭据实例：QR 注册接口（begin/poll）支持未持久化的临时实例，凭据确认后才写入配置（`resolveQrBinding` 虚拟 binding）
- 轮询永不静默死亡：弹窗关闭后后台继续轮询；出错按 5s→10s→20s→30s 退避重试；workspaceId/instanceId 在生成时快照，不依赖弹窗/选中项目
- 网关全程日志：qr begin / poll waiting / expired / rejected / unexpected error / confirmed（appId 打码）/ credentials incomplete
- 凭据保存失败路径补错误提示（不再静默丢弃）

### commit 2: Harden SQLite stores and supervise core child in serve
- 所有 SQLite 存储（local-core.db + knowledge.db）启用 `journal_mode=WAL` + `busy_timeout=5000`
- ACP 传输层事件分发加 try/catch：单条消息写入失败只记日志，不再整进程退出
- `agentdock serve` 监督 Core 子进程：意外退出时 serve 退出，由 systemd `Restart=always` 拉起整个栈

## 验证
- `pnpm typecheck` ✅ · `pnpm lint:circular` 0 环 ✅ · `pnpm test` **628 tests / 627 pass / 0 fail** ✅
- 新增测试：未持久化实例 QR 全流程、四种 poll 转换日志、传输层错误隔离、WAL/busy_timeout 生效
- 生产服务器已人工验证崩溃链路并完成 WAL 手工加固（发布后应用自动幂等设置）