### PR TITLE
Extract SqlPredicateBuilder to dedupe store WHERE-clause construction

### DIFF
--- a/services/local-ai-core/src/acp/store/agent-task-store.ts
+++ b/services/local-ai-core/src/acp/store/agent-task-store.ts
@@ -10,7 +10,7 @@ import type {
 } from '@cc/superai-contracts';
 import { normalizeAgentTaskStatus } from '@cc/superai-contracts';
 import type { LocalAgentTaskRow } from './acp-store-types.js';
-import { parseJson, redactSecrets } from './utils.js';
+import { clampLimit, SqlPredicateBuilder, parseJson, redactSecrets } from './utils.js';
 import type { AuditEventCreateInput } from './security-store.js';
 
 export class LocalAgentTaskStore {
@@ -65,30 +65,18 @@ export class LocalAgentTaskStore {
   }
 
   list(query: AgentTaskListQuery = {}): AgentTaskListResponse {
-    const predicates: string[] = [];
-    const params: Array<string | number> = [];
-    if (query.workspaceId) {
-      predicates.push('workspace_id = ?');
-      params.push(query.workspaceId);
-    }
-    if (query.runtimeId) {
-      predicates.push('runtime_id = ?');
-      params.push(query.runtimeId);
-    }
-    if (query.status) {
-      const statuses = (Array.isArray(query.status) ? query.status : [query.status]).map((status) => normalizeAgentTaskStatus(status));
-      predicates.push(`status IN (${statuses.map(() => '?').join(', ')})`);
-      params.push(...statuses);
-    }
-    const limit = Math.max(1, Math.min(Number(query.limit || 50), 100));
-    const where = predicates.length ? `WHERE ${predicates.join(' AND ')}` : '';
+    const filter = new SqlPredicateBuilder()
+      .eq('workspace_id', query.workspaceId)
+      .eq('runtime_id', query.runtimeId)
+      .in('status', query.status, normalizeAgentTaskStatus);
+    const limit = clampLimit(query.limit);
     const rows = this.db.prepare(`
       SELECT *
       FROM agent_tasks
-      ${where}
+      ${filter.whereClause()}
       ORDER BY updated_at DESC
       LIMIT ?
-    `).all(...params, limit) as LocalAgentTaskRow[];
+    `).all(...filter.params, limit) as LocalAgentTaskRow[];
     return { tasks: rows.map((row) => this.toAgentTask(row)) };
   }
 

--- a/services/local-ai-core/src/acp/store/automation-store.ts
+++ b/services/local-ai-core/src/acp/store/automation-store.ts
@@ -21,6 +21,7 @@ import type {
   LocalAutomationRunRow,
   LocalScheduledJobRow,
 } from './acp-store-types.js';
+import { SqlPredicateBuilder } from './utils.js';
 
 export type AutomationStateUpdateInput = {
   health?: AutomationDefinition['health'];
@@ -60,22 +61,15 @@ export class LocalAutomationStore {
   constructor(private readonly db: DatabaseSync) {}
 
   list(workspaceId?: string, originKind?: NonNullable<AutomationDefinition['originKind']>): AutomationDefinition[] {
-    const conditions: string[] = [];
-    const params: string[] = [];
-    if (workspaceId) {
-      conditions.push('workspace_id = ?');
-      params.push(workspaceId);
-    }
-    if (originKind) {
-      conditions.push('origin_kind = ?');
-      params.push(originKind);
-    }
+    const filter = new SqlPredicateBuilder()
+      .eq('workspace_id', workspaceId)
+      .eq('origin_kind', originKind);
     const rows = this.db.prepare(`
       SELECT ${AUTOMATION_COLUMNS}
       FROM automations
-      ${conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''}
+      ${filter.whereClause()}
       ORDER BY updated_at DESC
-    `).all(...params) as LocalAutomationRow[];
+    `).all(...filter.params) as LocalAutomationRow[];
     return rows.map((row) => this.toDefinition(row));
   }
 

--- a/services/local-ai-core/src/acp/store/platform-store.ts
+++ b/services/local-ai-core/src/acp/store/platform-store.ts
@@ -8,20 +8,13 @@ import type {
   LocalPlatformThreadBindingRow,
   LocalPlatformUserRow,
 } from './acp-store-types.js';
+import { SqlPredicateBuilder } from './utils.js';
 
-function buildWorkspacePlatformWhere(workspaceId?: string, platform?: string): { where: string; params: string[] } {
-  const params: string[] = [];
-  const predicates: string[] = [];
-  if (workspaceId) {
-    predicates.push('workspace_id = ?');
-    params.push(workspaceId);
-  }
-  if (platform) {
-    predicates.push('platform = ?');
-    params.push(platform);
-  }
-  const where = predicates.length > 0 ? `WHERE ${predicates.join(' AND ')}` : '';
-  return { where, params };
+function buildWorkspacePlatformWhere(workspaceId?: string, platform?: string): { where: string; params: Array<string | number> } {
+  const builder = new SqlPredicateBuilder()
+    .eq('workspace_id', workspaceId)
+    .eq('platform', platform);
+  return { where: builder.whereClause(), params: builder.params };
 }
 
 export class LocalPlatformStore {

--- a/services/local-ai-core/src/acp/store/security-store.ts
+++ b/services/local-ai-core/src/acp/store/security-store.ts
@@ -20,7 +20,7 @@ import type {
   LocalAuditEventRow,
   LocalWorkspaceSecuritySettingsRow,
 } from './acp-store-types.js';
-import { defaultPermissions, parseJson, redactSecrets } from './utils.js';
+import { clampLimit, defaultPermissions, parseJson, redactSecrets, SqlPredicateBuilder } from './utils.js';
 
 export type AuditEventCreateInput = {
   type: AuditEventType;
@@ -162,30 +162,18 @@ export class LocalSecurityStore {
   }
 
   listApprovalRequests(query: ApprovalRequestListQuery = {}): ApprovalRequestListResponse {
-    const predicates: string[] = [];
-    const params: Array<string | number> = [];
-    if (query.workspaceId) {
-      predicates.push('workspace_id = ?');
-      params.push(query.workspaceId);
-    }
-    if (query.taskId) {
-      predicates.push('task_id = ?');
-      params.push(query.taskId);
-    }
-    if (query.status) {
-      const statuses = (Array.isArray(query.status) ? query.status : [query.status]).map((status) => normalizeApprovalRequestStatus(status));
-      predicates.push(`status IN (${statuses.map(() => '?').join(', ')})`);
-      params.push(...statuses);
-    }
-    const limit = Math.max(1, Math.min(Number(query.limit || 50), 100));
-    const where = predicates.length ? `WHERE ${predicates.join(' AND ')}` : '';
+    const filter = new SqlPredicateBuilder()
+      .eq('workspace_id', query.workspaceId)
+      .eq('task_id', query.taskId)
+      .in('status', query.status, normalizeApprovalRequestStatus);
+    const limit = clampLimit(query.limit);
     const rows = this.db.prepare(`
       SELECT *
       FROM approval_requests
-      ${where}
+      ${filter.whereClause()}
       ORDER BY updated_at DESC
       LIMIT ?
-    `).all(...params, limit) as LocalApprovalRequestRow[];
+    `).all(...filter.params, limit) as LocalApprovalRequestRow[];
     return { approvals: rows.map((row) => this.toApprovalRequest(row)) };
   }
 
@@ -258,34 +246,19 @@ export class LocalSecurityStore {
   }
 
   listAuditEvents(query: AuditEventListQuery = {}): AuditEventListResponse {
-    const predicates: string[] = [];
-    const params: Array<string | number> = [];
-    if (query.workspaceId) {
-      predicates.push('workspace_id = ?');
-      params.push(query.workspaceId);
-    }
-    if (query.taskId) {
-      predicates.push('task_id = ?');
-      params.push(query.taskId);
-    }
-    if (query.approvalId) {
-      predicates.push('approval_id = ?');
-      params.push(query.approvalId);
-    }
-    if (query.type) {
-      const types = Array.isArray(query.type) ? query.type : [query.type];
-      predicates.push(`type IN (${types.map(() => '?').join(', ')})`);
-      params.push(...types);
-    }
-    const limit = Math.max(1, Math.min(Number(query.limit || 50), 100));
-    const where = predicates.length ? `WHERE ${predicates.join(' AND ')}` : '';
+    const filter = new SqlPredicateBuilder()
+      .eq('workspace_id', query.workspaceId)
+      .eq('task_id', query.taskId)
+      .eq('approval_id', query.approvalId)
+      .in('type', query.type);
+    const limit = clampLimit(query.limit);
     const rows = this.db.prepare(`
       SELECT *
       FROM audit_events
-      ${where}
+      ${filter.whereClause()}
       ORDER BY created_at DESC
       LIMIT ?
-    `).all(...params, limit) as LocalAuditEventRow[];
+    `).all(...filter.params, limit) as LocalAuditEventRow[];
     return { events: rows.map((row) => this.toAuditEvent(row)) };
   }
 

--- a/services/local-ai-core/src/acp/store/utils.ts
+++ b/services/local-ai-core/src/acp/store/utils.ts
@@ -12,6 +12,43 @@ export function parseJson<T>(value: string, fallback: T): T {
   }
 }
 
+export class SqlPredicateBuilder {
+  readonly predicates: string[] = [];
+  readonly params: Array<string | number> = [];
+
+  eq(column: string, value: string | number | undefined | null): this {
+    if (value === undefined || value === null || value === '') {
+      return this;
+    }
+    this.predicates.push(`${column} = ?`);
+    this.params.push(value);
+    return this;
+  }
+
+  in<T>(column: string, value: T | T[] | undefined | null, normalize?: (item: T) => string): this {
+    if (value === undefined || value === null || value === '') {
+      return this;
+    }
+    const items = (Array.isArray(value) ? value : [value]).map((item) => (normalize ? normalize(item) : String(item)));
+    // An empty array means "no filter" (matching all rows), not an impossible
+    // predicate — `IN ()` would be a SQLite syntax error at runtime.
+    if (!items.length) {
+      return this;
+    }
+    this.predicates.push(`${column} IN (${items.map(() => '?').join(', ')})`);
+    this.params.push(...items);
+    return this;
+  }
+
+  whereClause(): string {
+    return this.predicates.length ? `WHERE ${this.predicates.join(' AND ')}` : '';
+  }
+}
+
+export function clampLimit(limit: unknown, fallback = 50, max = 100): number {
+  return Math.max(1, Math.min(Number(limit || fallback), max));
+}
+
 export function normalizeBridgeKind(value: string | null | undefined): DesktopBridgeEventKind | undefined {
   switch (value) {
     case 'assistant':

--- a/tests/electron/security-approval-store.test.ts
+++ b/tests/electron/security-approval-store.test.ts
@@ -80,6 +80,24 @@ test('approval requests persist, resolve, attach to tasks, and audit lifecycle',
   store.close();
 });
 
+test('empty status filter returns all rows instead of building invalid IN () SQL', () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'approval-empty-filter-'));
+  const store = new LocalCoreAcpStore(userDataPath);
+  for (const title of ['first', 'second', 'third']) {
+    store.createApprovalRequest({
+      workspaceId: 'workspace-a',
+      kind: 'command',
+      riskLevel: 'medium',
+      title,
+      description: 'do work',
+      requestedAction: 'do work',
+    });
+  }
+  assert.equal(store.listApprovalRequests({ status: [] }).approvals.length, 3);
+  assert.equal(store.listAgentTasks({ status: [] }).tasks.length, 0);
+  store.close();
+});
+
 test('command risk classification and secret redaction cover baseline rules', () => {
   const high = classifyCommandRisk('git reset --hard HEAD');
   assert.equal(high.riskLevel, 'high');


### PR DESCRIPTION
## Summary
- Replace five hand-rolled `conditions[]`/`params[]` WHERE-clause blocks across the ACP stores with a shared `SqlPredicateBuilder` (plus `clampLimit`) in `store/utils.ts`: `agent-task-store.list()`, `security-store.listApprovalRequests()/listAuditEvents()`, `platform-store.buildWorkspacePlatformWhere()`, and `automation-store.list()`
- Behavior-preserving for all populated filters (predicate order, limit semantics, normalize callbacks unchanged). One deliberate improvement: an empty filter array (e.g. `status: []`) previously generated invalid `IN ()` SQL (SQLite syntax error at runtime); it now means "no filter" and returns all rows, with a WHY comment and a regression test

## Motivation
Continues the daily de-dup series driven by `pnpm lint:duplicate` — this was a top-10 clone block. Also surfaced by prior reviews as the last remaining hand-rolled instance after PR #54.

## Review rounds
- Round 1: 3 parallel reviewers (Code Reuse: approve + flagged missed `automation-store` occurrence; Code Quality: request changes pending empty-array regression test + WHY comment; Efficiency: approve, verified behavior preservation across all call sites)
- Round 2 fixes applied: added `automation-store.list()` to the refactor, added WHY comment on the empty-array skip, added regression test `empty status filter returns all rows instead of building invalid IN () SQL`
- Declined suggestions (not blocking): column-name allowlist guard in the builder (no current call site passes dynamic input), pure-function unit test for the builder (covered indirectly via store-level tests)

## Validation
- `pnpm test`: 637 pass / 0 fail / 1 skipped; BDD 80 scenarios / 286 steps passed
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)