### PR TITLE
Extract shared bridge-event prologue into BaseChannelGateway

### DIFF
--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -83,6 +83,10 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
   private readonly outboundTransport: LarkOutboundTransport;
   readonly platform = 'lark';
 
+  protected isBridgeRuntimeReady(state: LarkRuntimeState): boolean {
+    return Boolean(state.connected && state.client);
+  }
+
   constructor(options: LocalCoreLarkGatewayOptions) {
     super(options);
     this.inboundHandler = new LarkInboundHandler({
@@ -287,39 +291,11 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
 
 
   async onBridgeEvent(event: DesktopBridgeEvent) {
-    if (!event.sessionKey) {
-      this.options.log?.(`localcore-lark bridge event ignored without sessionKey: ${event.type}`);
+    const context = this.resolveBridgeEventContext(event);
+    if (!context) {
       return;
     }
-    const sessionKey = event.sessionKey;
-    const route = this.threadRouting.get(sessionKey);
-    if (!route) {
-      return;
-    }
-    const routeInstanceId = route.instanceId || 'default';
-    const routePlatformKey = route.platformKey || channelPlatformKey('lark', routeInstanceId);
-    const state = this.runtime.get(runtimeKey(route.workspaceId, routeInstanceId)) || this.runtime.get(route.workspaceId);
-    if (!state?.client || !state.connected) {
-      this.options.log?.(`localcore-lark bridge event ignored because workspace is not connected: ${route.workspaceId}`);
-      return;
-    }
-    const initialBinding = this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, routePlatformKey);
-    if (!initialBinding) {
-      this.options.log?.(`localcore-lark bridge binding miss for workspace=${route.workspaceId} chat=${route.chatId} user=${route.platformUserId}`);
-      return;
-    }
-    if (
-      event.type !== 'preview_start'
-      && event.type !== 'update_message'
-      && event.type !== 'reply'
-      && event.type !== 'buttons'
-      && event.type !== 'typing_start'
-      && event.type !== 'typing_stop'
-      && event.type !== 'status'
-    ) {
-      this.options.log?.(`localcore-lark bridge event ignored type=${event.type}`);
-      return;
-    }
+    const { sessionKey, route, state, platformKey: routePlatformKey } = context;
     const current = this.scheduleOutboundChain(sessionKey, async () => {
       const binding = this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, routePlatformKey);
       if (!binding) {

--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -297,7 +297,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
     }
     const { sessionKey, route, state, platformKey: routePlatformKey } = context;
     const current = this.scheduleOutboundChain(sessionKey, async () => {
-      const binding = this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, routePlatformKey);
+      const binding = this.getBridgeBinding(route, routePlatformKey);
       if (!binding) {
         this.options.log?.(`localcore-lark bridge binding disappeared for sessionKey=${sessionKey}`);
         return;

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -87,7 +87,7 @@ function resolveRuntimeKey(workspaceId: string, instanceId?: string): string {
   return instanceId ? `${workspaceId}::${instanceId}` : workspaceId;
 }
 
-const RENDERABLE_BRIDGE_EVENT_TYPES = new Set<string>([
+const RENDERABLE_BRIDGE_EVENT_TYPES = new Set<DesktopBridgeEvent['type']>([
   'preview_start',
   'update_message',
   'reply',
@@ -646,6 +646,12 @@ export abstract class BaseChannelGateway<
       this.options.log?.(`localcore-${this.platform} bridge event ignored without sessionKey: ${event.type}`);
       return undefined;
     }
+    // Filter on the event alone before any lookups so non-renderable types
+    // (which stream continuously during turns) skip the binding read entirely.
+    if (!RENDERABLE_BRIDGE_EVENT_TYPES.has(event.type)) {
+      this.options.log?.(`localcore-${this.platform} bridge event ignored type=${event.type}`);
+      return undefined;
+    }
     const route = this.threadRouting.get(event.sessionKey);
     if (!route) {
       return undefined;
@@ -657,16 +663,15 @@ export abstract class BaseChannelGateway<
       this.options.log?.(`localcore-${this.platform} bridge event ignored because workspace is not connected: ${route.workspaceId}`);
       return undefined;
     }
-    const initialBinding = this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, platformKey);
-    if (!initialBinding) {
+    if (!this.getBridgeBinding(route, platformKey)) {
       this.options.log?.(`localcore-${this.platform} bridge binding miss for workspace=${route.workspaceId} chat=${route.chatId} user=${route.platformUserId}`);
       return undefined;
     }
-    if (!RENDERABLE_BRIDGE_EVENT_TYPES.has(event.type)) {
-      this.options.log?.(`localcore-${this.platform} bridge event ignored type=${event.type}`);
-      return undefined;
-    }
     return { sessionKey: event.sessionKey, route, state, platformKey };
+  }
+
+  protected getBridgeBinding(route: TThreadRoute, platformKey: string) {
+    return this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, platformKey);
   }
 
   /** Runtime readiness check for bridge events; gateways with a transport client override to require it. */

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -87,6 +87,16 @@ function resolveRuntimeKey(workspaceId: string, instanceId?: string): string {
   return instanceId ? `${workspaceId}::${instanceId}` : workspaceId;
 }
 
+const RENDERABLE_BRIDGE_EVENT_TYPES = new Set<string>([
+  'preview_start',
+  'update_message',
+  'reply',
+  'buttons',
+  'typing_start',
+  'typing_stop',
+  'status',
+]);
+
 export abstract class BaseChannelGateway<
   TRuntimeState extends GatewayRuntimeState,
   TBinding extends GatewayBinding,
@@ -618,6 +628,50 @@ export abstract class BaseChannelGateway<
       });
     this.outboundEventChains.set(sessionKey, current);
     return current;
+  }
+
+  /**
+   * Shared onBridgeEvent prologue: resolve the session route, a connected
+   * runtime state, and a live platform thread binding for the event. Returns
+   * undefined (with a log) when the event should be dropped before any
+   * outbound work is scheduled.
+   */
+  protected resolveBridgeEventContext(event: DesktopBridgeEvent): {
+    sessionKey: string;
+    route: TThreadRoute;
+    state: TRuntimeState;
+    platformKey: string;
+  } | undefined {
+    if (!event.sessionKey) {
+      this.options.log?.(`localcore-${this.platform} bridge event ignored without sessionKey: ${event.type}`);
+      return undefined;
+    }
+    const route = this.threadRouting.get(event.sessionKey);
+    if (!route) {
+      return undefined;
+    }
+    const routeInstanceId = route.instanceId || 'default';
+    const platformKey = route.platformKey || channelPlatformKey(this.platform, routeInstanceId);
+    const state = this.runtime.get(resolveRuntimeKey(route.workspaceId, routeInstanceId)) || this.runtime.get(route.workspaceId);
+    if (!state || !this.isBridgeRuntimeReady(state)) {
+      this.options.log?.(`localcore-${this.platform} bridge event ignored because workspace is not connected: ${route.workspaceId}`);
+      return undefined;
+    }
+    const initialBinding = this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, platformKey);
+    if (!initialBinding) {
+      this.options.log?.(`localcore-${this.platform} bridge binding miss for workspace=${route.workspaceId} chat=${route.chatId} user=${route.platformUserId}`);
+      return undefined;
+    }
+    if (!RENDERABLE_BRIDGE_EVENT_TYPES.has(event.type)) {
+      this.options.log?.(`localcore-${this.platform} bridge event ignored type=${event.type}`);
+      return undefined;
+    }
+    return { sessionKey: event.sessionKey, route, state, platformKey };
+  }
+
+  /** Runtime readiness check for bridge events; gateways with a transport client override to require it. */
+  protected isBridgeRuntimeReady(state: TRuntimeState): boolean {
+    return state.connected;
   }
 
   protected clearRuntimeError(state: TRuntimeState) {

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -35,6 +35,7 @@ import {
 import {
   API_TIMEOUT_MS,
   getWeixinUploadUrl,
+  createWeixinClientId,
   IMAGE_ITEM_TYPE,
   isWeixinApiError,
   sendWeixinFileMessage,
@@ -257,7 +258,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     const { sessionKey, route, state, platformKey: routePlatformKey } = context;
 
     const current = this.scheduleOutboundChain(sessionKey, async () => {
-      const binding = this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, routePlatformKey);
+      const binding = this.getBridgeBinding(route, routePlatformKey);
       if (!binding) return;
       const bridgeThreadId = route.threadId || binding.thread_id;
       if (this.mutedThreadBridgeCounts.has(bridgeThreadId)) return;
@@ -561,7 +562,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
     uploaded: UploadedWeixinFile,
     contextToken?: string,
   ): Promise<string> {
-    const clientId = `openclaw-weixin-${crypto.randomUUID()}`;
+    const clientId = createWeixinClientId();
     const resp = await sendWeixinFileMessage(binding, toUserId, fileName, uploaded, contextToken, { clientId });
     if (isWeixinApiError(resp)) {
       throw new Error(`WeChat send file failed: ret=${resp.ret} errcode=${resp.errcode}${resp.errmsg ? ` errmsg=${resp.errmsg}` : ''}`);

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -250,38 +250,11 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
 
 
   async onBridgeEvent(event: DesktopBridgeEvent) {
-    if (!event.sessionKey) {
-      this.options.log?.(`localcore-weixin bridge event ignored without sessionKey: ${event.type}`);
+    const context = this.resolveBridgeEventContext(event);
+    if (!context) {
       return;
     }
-    const sessionKey = event.sessionKey;
-    const route = this.threadRouting.get(sessionKey);
-    if (!route) {
-      return;
-    }
-    const routeInstanceId = route.instanceId || 'default';
-    const routePlatformKey = route.platformKey || channelPlatformKey('weixin', routeInstanceId);
-    const state = this.runtime.get(runtimeKey(route.workspaceId, routeInstanceId)) || this.runtime.get(route.workspaceId);
-    if (!state?.connected) {
-      this.options.log?.(`localcore-weixin bridge event ignored because workspace is not connected: ${route.workspaceId}`);
-      return;
-    }
-    const initialBinding = this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, routePlatformKey);
-    if (!initialBinding) {
-      this.options.log?.(`localcore-weixin bridge binding miss for workspace=${route.workspaceId}`);
-      return;
-    }
-    if (
-      event.type !== 'preview_start'
-      && event.type !== 'update_message'
-      && event.type !== 'reply'
-      && event.type !== 'buttons'
-      && event.type !== 'typing_start'
-      && event.type !== 'typing_stop'
-      && event.type !== 'status'
-    ) {
-      return;
-    }
+    const { sessionKey, route, state, platformKey: routePlatformKey } = context;
 
     const current = this.scheduleOutboundChain(sessionKey, async () => {
       const binding = this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, routePlatformKey);

--- a/services/local-ai-core/src/channel/weixin/transport.ts
+++ b/services/local-ai-core/src/channel/weixin/transport.ts
@@ -109,10 +109,17 @@ export function getWeixinUpdates(
   );
 }
 
+const MESSAGE_STATE_IN_PROGRESS = 1;
+const MESSAGE_STATE_FINAL = 2;
+
+export function createWeixinClientId() {
+  return `openclaw-weixin-${crypto.randomUUID()}`;
+}
+
 function buildBotMessagePayload(
   toUserId: string,
   clientId: string | undefined,
-  messageState: number,
+  messageState: typeof MESSAGE_STATE_IN_PROGRESS | typeof MESSAGE_STATE_FINAL,
   itemList: Array<Record<string, unknown>>,
   contextToken?: string,
 ) {
@@ -120,7 +127,7 @@ function buildBotMessagePayload(
     msg: {
       from_user_id: '',
       to_user_id: toUserId,
-      client_id: clientId || `openclaw-weixin-${crypto.randomUUID()}`,
+      client_id: clientId || createWeixinClientId(),
       message_type: 2,
       message_state: messageState,
       item_list: itemList,
@@ -143,7 +150,7 @@ export function sendWeixinTextMessageChunk(
     buildBotMessagePayload(
       toUserId,
       options.clientId,
-      options.final === false ? 1 : 2,
+      options.final === false ? MESSAGE_STATE_IN_PROGRESS : MESSAGE_STATE_FINAL,
       [{ type: TEXT_ITEM_TYPE, text_item: { text } }],
       contextToken,
     ),
@@ -165,7 +172,7 @@ export function sendWeixinFileMessage(
     buildBotMessagePayload(
       toUserId,
       options.clientId,
-      2,
+      MESSAGE_STATE_FINAL,
       [{
         type: FILE_ITEM_TYPE,
         file_item: {

--- a/services/local-ai-core/src/channel/weixin/transport.ts
+++ b/services/local-ai-core/src/channel/weixin/transport.ts
@@ -109,6 +109,27 @@ export function getWeixinUpdates(
   );
 }
 
+function buildBotMessagePayload(
+  toUserId: string,
+  clientId: string | undefined,
+  messageState: number,
+  itemList: Array<Record<string, unknown>>,
+  contextToken?: string,
+) {
+  return {
+    msg: {
+      from_user_id: '',
+      to_user_id: toUserId,
+      client_id: clientId || `openclaw-weixin-${crypto.randomUUID()}`,
+      message_type: 2,
+      message_state: messageState,
+      item_list: itemList,
+      ...(contextToken ? { context_token: contextToken } : {}),
+    },
+    base_info: { channel_version: WEIXIN_CHANNEL_VERSION },
+  };
+}
+
 export function sendWeixinTextMessageChunk(
   binding: WeixinWorkspaceBinding,
   toUserId: string,
@@ -119,18 +140,13 @@ export function sendWeixinTextMessageChunk(
   return weixinApiPost<SendMessageResp>(
     binding,
     'ilink/bot/sendmessage',
-    {
-      msg: {
-        from_user_id: '',
-        to_user_id: toUserId,
-        client_id: options.clientId || `openclaw-weixin-${crypto.randomUUID()}`,
-        message_type: 2,
-        message_state: options.final === false ? 1 : 2,
-        item_list: [{ type: TEXT_ITEM_TYPE, text_item: { text } }],
-        ...(contextToken ? { context_token: contextToken } : {}),
-      },
-      base_info: { channel_version: WEIXIN_CHANNEL_VERSION },
-    },
+    buildBotMessagePayload(
+      toUserId,
+      options.clientId,
+      options.final === false ? 1 : 2,
+      [{ type: TEXT_ITEM_TYPE, text_item: { text } }],
+      contextToken,
+    ),
     API_TIMEOUT_MS,
   );
 }
@@ -146,29 +162,24 @@ export function sendWeixinFileMessage(
   return weixinApiPost<SendMessageResp>(
     binding,
     'ilink/bot/sendmessage',
-    {
-      msg: {
-        from_user_id: '',
-        to_user_id: toUserId,
-        client_id: options.clientId || `openclaw-weixin-${crypto.randomUUID()}`,
-        message_type: 2,
-        message_state: 2,
-        item_list: [{
-          type: FILE_ITEM_TYPE,
-          file_item: {
-            media: {
-              encrypt_query_param: uploaded.encryptedQueryParam,
-              aes_key: Buffer.from(uploaded.aesKeyHex).toString('base64'),
-              encrypt_type: 1,
-            },
-            file_name: fileName,
-            len: String(uploaded.fileSize),
+    buildBotMessagePayload(
+      toUserId,
+      options.clientId,
+      2,
+      [{
+        type: FILE_ITEM_TYPE,
+        file_item: {
+          media: {
+            encrypt_query_param: uploaded.encryptedQueryParam,
+            aes_key: Buffer.from(uploaded.aesKeyHex).toString('base64'),
+            encrypt_type: 1,
           },
-        }],
-        ...(contextToken ? { context_token: contextToken } : {}),
-      },
-      base_info: { channel_version: WEIXIN_CHANNEL_VERSION },
-    },
+          file_name: fileName,
+          len: String(uploaded.fileSize),
+        },
+      }],
+      contextToken,
+    ),
     API_TIMEOUT_MS,
   );
 }

--- a/tests/integration/channel-gateways.test.ts
+++ b/tests/integration/channel-gateways.test.ts
@@ -30,3 +30,35 @@ test('channel gateways ignore unowned bridge events without route miss log noise
 
   assert.deepEqual(logs, []);
 });
+
+test('channel gateways drop non-renderable bridge events before any binding read', async () => {
+  const logs: string[] = [];
+  const options = {
+    store: {
+      getPlatformThreadBinding: () => {
+        throw new Error('binding read must not happen for non-renderable events');
+      },
+    } as any,
+    readConfig: async () => null,
+    getWorkspaceRouter: () => ({} as any),
+    eventBus: { emit: () => {}, on: () => () => {} } as any,
+    log: (line: string) => logs.push(line),
+  };
+  const route = {
+    workspaceId: 'workspace-a',
+    instanceId: 'default',
+    platformKey: 'lark:default',
+    platformUserId: 'user-a',
+    chatId: 'chat-a',
+    threadId: 'thread-a',
+  };
+  const larkGateway = new LocalCoreLarkGateway(options as any);
+  const weixinGateway = new LocalCoreWeixinGateway(options as any);
+  (larkGateway as any).threadRouting.set('session-key-a', route);
+  (weixinGateway as any).threadRouting.set('session-key-a', { ...route, platformKey: 'weixin:default' });
+
+  await larkGateway.onBridgeEvent({ type: 'card', sessionKey: 'session-key-a', content: 'card body' } as any);
+  await weixinGateway.onBridgeEvent({ type: 'card', sessionKey: 'session-key-a', content: 'card body' } as any);
+
+  assert.equal(logs.filter((line) => line.includes('bridge event ignored type=card')).length, 2);
+});


### PR DESCRIPTION
## Summary
- Extract the identical `onBridgeEvent` validation prologue (sessionKey → route → connected runtime → thread binding → event-type allowlist) that was copy-pasted in the Lark and WeChat gateways into `resolveBridgeEventContext()` on `BaseChannelGateway`, with an `isBridgeRuntimeReady()` hook (Lark overrides to also require its transport client) and a `getBridgeBinding()` helper used at all three lookup sites
- Deduplicate the WeChat bot-message envelope in `channel/weixin/transport.ts` via `buildBotMessagePayload()` + `createWeixinClientId()`, with named `MESSAGE_STATE_*` constants

## Category
b) Code reuse (continues the `lint:duplicate` de-dup series; clones #5/#7/#8) + a small c) performance win: the type filter now runs before any lookups, so non-renderable streaming events skip the synchronous binding read.

## Deliberate behavior notes
- WeChat now logs (previously silent) when an event type is not renderable or the sessionKey is missing — observability parity with Lark
- WeChat binding-miss log now includes chat/user ids (Lark format)
- Check order otherwise preserved exactly for both gateways (verified by review)

## Review rounds
- Round 1 (3 parallel reviewers): Code Reuse approved + flagged 3 remaining dupes; Code Quality requested changes (stringly-typed `Set<string>` allowlist); Efficiency approved + suggested hoisting the type filter ahead of the SQLite read
- Round 2 fixes applied exactly as prescribed: `Set<DesktopBridgeEvent['type']>`, type filter hoisted before all lookups, `getBridgeBinding()` shared helper, `createWeixinClientId()` export, `MESSAGE_STATE_*` constants, and an integration test pinning the drop behavior (`tests/integration/channel-gateways.test.ts`)
- Declined / follow-ups (documented): muted-thread check extraction (~2 lines per gateway, next in series), `resolveRuntimeKey` vs `runtimeKey` consolidation (pre-existing near-dup with different optional-instanceId semantics)

## Validation
- `pnpm test`: 638 pass / 0 fail / 1 skipped; BDD 80 scenarios / 286 steps passed
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)