### PR TITLE
Fix Lark QR poll treating OAuth pending responses as failures

### DIFF
--- a/services/local-ai-core/src/channel/lark/registration.ts
+++ b/services/local-ai-core/src/channel/lark/registration.ts
@@ -58,7 +58,7 @@ async function callAppRegistration(
     // HTTP 400 whose JSON body carries the OAuth error code; the caller
     // translates those into wait/expired states, so return the body instead
     // of throwing.
-    if (options.returnOAuthErrorBody && typeof parsed.error === 'string' && parsed.error) {
+    if (options.returnOAuthErrorBody && response.status === 400 && typeof parsed.error === 'string' && parsed.error) {
       return parsed;
     }
     throw new Error(`Lark app registration failed (${response.status}): ${String(parsed.error_description || parsed.error || text || response.statusText)}`);

--- a/services/local-ai-core/src/channel/lark/registration.ts
+++ b/services/local-ai-core/src/channel/lark/registration.ts
@@ -26,10 +26,14 @@ export async function pollAppRegistration(binding: LarkWorkspaceBinding, deviceC
   return callAppRegistration(binding, {
     action: 'poll',
     device_code: deviceCode,
-  });
+  }, { returnOAuthErrorBody: true });
 }
 
-async function callAppRegistration(binding: LarkWorkspaceBinding, formValues: Record<string, string>): Promise<Record<string, unknown>> {
+async function callAppRegistration(
+  binding: LarkWorkspaceBinding,
+  formValues: Record<string, string>,
+  options: { returnOAuthErrorBody?: boolean } = {},
+): Promise<Record<string, unknown>> {
   const form = new URLSearchParams();
   for (const [key, value] of Object.entries(formValues)) {
     form.set(key, value);
@@ -43,8 +47,20 @@ async function callAppRegistration(binding: LarkWorkspaceBinding, formValues: Re
     body: form.toString(),
   });
   const text = await response.text();
-  const parsed = text ? JSON.parse(text) as Record<string, unknown> : {};
+  let parsed: Record<string, unknown> = {};
+  try {
+    parsed = text ? JSON.parse(text) as Record<string, unknown> : {};
+  } catch {
+    // Non-JSON body (e.g. an HTML error page); fall through to the status-based error.
+  }
   if (!response.ok) {
+    // The device-flow poll endpoint answers pending/expired polls with an
+    // HTTP 400 whose JSON body carries the OAuth error code; the caller
+    // translates those into wait/expired states, so return the body instead
+    // of throwing.
+    if (options.returnOAuthErrorBody && typeof parsed.error === 'string' && parsed.error) {
+      return parsed;
+    }
     throw new Error(`Lark app registration failed (${response.status}): ${String(parsed.error_description || parsed.error || text || response.statusText)}`);
   }
   return parsed;

--- a/tests/integration/lark-gateway.test.ts
+++ b/tests/integration/lark-gateway.test.ts
@@ -2237,6 +2237,11 @@ test('lark QR poll logs pending, expired, rejected, and incomplete-credential tr
   let call = 0;
   globalThis.fetch = (async () => {
     call += 1;
+    // Device-flow polls answer pending/expired/denied states with HTTP 400
+    // plus an OAuth error body; confirmation arrives as HTTP 200.
+    if (call === 5) {
+      return new Response('<html>Bad Gateway</html>', { status: 502, headers: { 'Content-Type': 'text/html' } });
+    }
     const payload = call === 1
       ? { error: 'authorization_pending', error_description: '', code: 20094 }
       : call === 2
@@ -2244,7 +2249,8 @@ test('lark QR poll logs pending, expired, rejected, and incomplete-credential tr
         : call === 3
           ? { error: 'access_denied', error_description: '', code: 20097 }
           : { client_id: 'cli_partial', code: 0 };
-    return new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    const status = call >= 4 ? 200 : 400;
+    return new Response(JSON.stringify(payload), { status, headers: { 'Content-Type': 'application/json' } });
   }) as typeof fetch;
 
   const logs: string[] = [];
@@ -2273,6 +2279,11 @@ test('lark QR poll logs pending, expired, rejected, and incomplete-credential tr
     );
     // A confirmed poll without a client_secret must stay pending, not confirm.
     assert.deepEqual(await gateway.checkQrCodeStatus('default', 'ticket-1', 'lark-pending'), { status: 'wait' });
+    // A non-JSON error page must surface its HTTP status, not a JSON SyntaxError.
+    await assert.rejects(
+      () => gateway.checkQrCodeStatus('default', 'ticket-1', 'lark-pending'),
+      /Lark app registration failed \(502\)/,
+    );
     assert.ok(logs.some((line) => line.includes('waiting (authorization_pending)')));
     assert.ok(logs.some((line) => line.includes('expired (expired_token)')));
     assert.ok(logs.some((line) => line.includes('rejected (access_denied)')));


### PR DESCRIPTION
## Summary
- `callAppRegistration` in `services/local-ai-core/src/channel/lark/registration.ts` threw on every non-OK HTTP status. The Feishu device-flow poll endpoint answers pending/expired/denied polls with **HTTP 400 + an OAuth error body** (`authorization_pending`, `expired_token`, `access_denied` — RFC 8628 convention), so `checkQrCodeStatus` never got to map those to `wait`/`expired` states: every pending poll cycle threw, was logged as an error, and the client fell into throw/backoff churn instead of steady wait polling
- Poll now passes `returnOAuthErrorBody` (narrowed to HTTP 400 with a string `error` field); `begin` keeps throwing. `JSON.parse` is guarded so a non-JSON error page (e.g. HTML 502) surfaces its HTTP status instead of a raw `SyntaxError`
- Regression test updated: error payloads now arrive with status 400 exactly as production sends (the old code fails the `wait` assertion), plus a new 502/HTML rejection case

## Category
Bug fix (found in daily log review: 5× `localcore-lark qr poll request failed ... (400): authorization_pending` in `~/.agentdock/logs/error.log` since Aug 15)

## Review rounds
- Round 1 (3 parallel reviewers): Code Quality APPROVE (suggested narrowing the passthrough to HTTP 400 for status fidelity); Efficiency APPROVE (verified poll-loop termination and renderer backoff bounds, no regression); Code Reuse found no blocking items (flagged the now-triplicated safe-JSON-parse)
- Round 2 fix applied: `response.status === 400` added to the passthrough guard per the Quality reviewer's suggestion

## Declined / follow-ups (documented)
- Extract a shared `parseJsonSafe` to `kernel/` and adopt it in `registration.ts` + `opensandbox-client.ts` (third copy of the pattern; deferred to keep this bug-fix PR minimal)
- `weixinApiPost/Get` discard error bodies and unguard `(await res.json())` — same fragility class, separate channel, follow-up
- `slow_down` maps to plain `wait` without increasing the poll interval (cosmetic, bounded by the ~180s expiry window)

## Validation
- `pnpm test`: 638 pass / 0 fail / 1 skipped; BDD 80 scenarios / 286 steps passed
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)