### PR TITLE
Consolidate safe JSON parsing into kernel parseJsonSafe

### DIFF
--- a/services/local-ai-core/src/acp/store/utils.ts
+++ b/services/local-ai-core/src/acp/store/utils.ts
@@ -4,6 +4,7 @@ import type {
 } from '@cc/superai-contracts';
 import type { DesktopBridgeEvent, DesktopBridgeEventKind } from '@cc/superai-contracts';
 
+// Compat alias: the kernel-level helper is parseJsonSafe; store modules import it as parseJson.
 export { parseJsonSafe as parseJson } from '../../kernel/parse-json-safe.js';
 
 export class SqlPredicateBuilder {

--- a/services/local-ai-core/src/acp/store/utils.ts
+++ b/services/local-ai-core/src/acp/store/utils.ts
@@ -4,13 +4,7 @@ import type {
 } from '@cc/superai-contracts';
 import type { DesktopBridgeEvent, DesktopBridgeEventKind } from '@cc/superai-contracts';
 
-export function parseJson<T>(value: string, fallback: T): T {
-  try {
-    return JSON.parse(value) as T;
-  } catch {
-    return fallback;
-  }
-}
+export { parseJsonSafe as parseJson } from '../../kernel/parse-json-safe.js';
 
 export class SqlPredicateBuilder {
   readonly predicates: string[] = [];

--- a/services/local-ai-core/src/channel/lark/inbound.ts
+++ b/services/local-ai-core/src/channel/lark/inbound.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { parseJsonSafe } from '../../kernel/parse-json-safe.js';
 
 export type LarkInboundMention = Record<string, any>;
 
@@ -39,12 +40,7 @@ export function normalizeLarkInboundMessageEvent(
     return { ok: false, reason: 'missing-message-or-sender', detail: JSON.stringify(Object.keys(data || {})) };
   }
 
-  let parsedContent: Record<string, unknown> = {};
-  try {
-    parsedContent = JSON.parse(String(message.content || '{}'));
-  } catch {
-    parsedContent = {};
-  }
+  const parsedContent = parseJsonSafe<Record<string, unknown>>(String(message.content || '{}'), {});
 
   const messageType = String(message.message_type || '').trim().toLowerCase();
   const chatType = String(message.chat_type || '').trim().toLowerCase();

--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -303,7 +303,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
         return;
       }
       const bridgeThreadId = route.threadId || binding.thread_id;
-      if (this.mutedThreadBridgeCounts.has(bridgeThreadId)) {
+      if (this.isThreadBridgeMuted(bridgeThreadId)) {
         this.options.log?.(`localcore-lark bridge muted for thread=${bridgeThreadId} type=${event.type}`);
         return;
       }

--- a/services/local-ai-core/src/channel/lark/registration.ts
+++ b/services/local-ai-core/src/channel/lark/registration.ts
@@ -1,3 +1,4 @@
+import { parseJsonSafe } from '../../kernel/parse-json-safe.js';
 import type { LarkWorkspaceBinding } from './types.js';
 
 export const DEFAULT_LARK_QR_EXPIRES_IN = 180;
@@ -47,12 +48,9 @@ async function callAppRegistration(
     body: form.toString(),
   });
   const text = await response.text();
-  let parsed: Record<string, unknown> = {};
-  try {
-    parsed = text ? JSON.parse(text) as Record<string, unknown> : {};
-  } catch {
-    // Non-JSON body (e.g. an HTML error page); fall through to the status-based error.
-  }
+  // Non-JSON bodies (e.g. an HTML error page) fall back to {} and surface the
+  // status-based error below.
+  const parsed: Record<string, unknown> = text ? parseJsonSafe<Record<string, unknown>>(text, {}) : {};
   if (!response.ok) {
     // The device-flow poll endpoint answers pending/expired polls with an
     // HTTP 400 whose JSON body carries the OAuth error code; the caller

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -674,6 +674,10 @@ export abstract class BaseChannelGateway<
     return this.options.store.getPlatformThreadBinding(route.workspaceId, route.chatId, route.platformUserId, platformKey);
   }
 
+  protected isThreadBridgeMuted(threadId: string): boolean {
+    return this.mutedThreadBridgeCounts.has(threadId);
+  }
+
   /** Runtime readiness check for bridge events; gateways with a transport client override to require it. */
   protected isBridgeRuntimeReady(state: TRuntimeState): boolean {
     return state.connected;

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -261,7 +261,10 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
       const binding = this.getBridgeBinding(route, routePlatformKey);
       if (!binding) return;
       const bridgeThreadId = route.threadId || binding.thread_id;
-      if (this.mutedThreadBridgeCounts.has(bridgeThreadId)) return;
+      if (this.isThreadBridgeMuted(bridgeThreadId)) {
+        this.options.log?.(`localcore-weixin bridge muted for thread=${bridgeThreadId} type=${event.type}`);
+        return;
+      }
 
       const turn = getOrCreateWeixinTurnState(this.outboundTurns, sessionKey);
       if (event.replyCtx) {

--- a/services/local-ai-core/src/kernel/parse-json-safe.ts
+++ b/services/local-ai-core/src/kernel/parse-json-safe.ts
@@ -1,0 +1,7 @@
+export function parseJsonSafe<T>(text: string, fallback: T): T {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return fallback;
+  }
+}

--- a/services/local-ai-core/src/sandbox/opensandbox-client.ts
+++ b/services/local-ai-core/src/sandbox/opensandbox-client.ts
@@ -1,4 +1,5 @@
 import { LocalCoreError, formatSafeError } from '../kernel/local-core-errors.js';
+import { parseJsonSafe } from '../kernel/parse-json-safe.js';
 
 export type OpenSandboxVolume = {
   host: string;
@@ -124,7 +125,7 @@ export class OpenSandboxClient {
       });
     }
     const text = await response.text();
-    const json = text ? parseJson(text) : {};
+    const json = text ? parseJsonSafe<Record<string, unknown> | null>(text, null) : {};
     if (!response.ok) {
       throw new LocalCoreError(response.status === 401 || response.status === 403 ? 'sandbox_unauthorized' : 'sandbox_request_failed', `OpenSandbox ${method} ${path} failed with ${response.status}.`, {
         details: {
@@ -136,13 +137,5 @@ export class OpenSandboxClient {
       });
     }
     return (json || {}) as T;
-  }
-}
-
-function parseJson(text: string) {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
   }
 }

--- a/tests/electron/parse-json-safe.test.ts
+++ b/tests/electron/parse-json-safe.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseJsonSafe } from '../../services/local-ai-core/src/kernel/parse-json-safe.js';
+
+test('parseJsonSafe returns parsed values and falls back on invalid JSON', () => {
+  assert.deepEqual(parseJsonSafe<Record<string, unknown>>('{"a":1}', {}), { a: 1 });
+  assert.deepEqual(parseJsonSafe('[1,2]', []), [1, 2]);
+  assert.deepEqual(parseJsonSafe('not json', { fallback: true }), { fallback: true });
+  assert.equal(parseJsonSafe<unknown>('not json', null), null);
+  assert.equal(parseJsonSafe<unknown>('', null), null);
+});


### PR DESCRIPTION
## Summary
- Promote the safe-JSON-parse helper (try/`JSON.parse`/catch-to-fallback) that existed in **four** places into a single kernel-level `parseJsonSafe` (services/local-ai-core/src/kernel/parse-json-safe.ts): the ACP store utils `parseJson` (now a documented compat re-export consumed by ~9 store modules), a private copy in the OpenSandbox client, the inline guard added yesterday in the Lark registration transport, and (per review) the Lark inbound content parse
- Add `isThreadBridgeMuted()` to `BaseChannelGateway` shared by both gateways' `onBridgeEvent` mute check — WeChat gains the muted-thread log line Lark already had (observability parity; fires only while a thread is actually muted)

## Category
b) Code reuse — finishes the follow-up documented in PR #82's review ("extract a shared parseJsonSafe to kernel/, now on its third copy")

## Review rounds
- Round 1 (3 parallel reviewers): Efficiency APPROVE (leaf module, no new dependency edges, store read-path semantics byte-identical); Code Quality APPROVE (re-export alias shape correct, wrapper justified by the refcount-map invariant, log frequency bounded); Code Reuse approved pending the `inbound.ts` miss it found
- Round 2 fixes applied: migrated `channel/lark/inbound.ts` content parse to `parseJsonSafe`; added the compat-alias comment on the store re-export
- Declined with reasoning: `trace-store.ts` run-span parsing (post-parse object narrowing on the parse *result*, not just failure — a plain swap changes semantics; only 1 of its 3 blocks would fit); `packages/knowledge-api` `parseMetadata` (packages cannot import from services; would require moving the helper into a package — separate decision)

## Validation
- `pnpm test`: 639 pass / 0 fail / 1 skipped; BDD 80 scenarios / 286 steps passed
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)