### PR TITLE
Dedupe mock stock quote event builders and weixin poller callbacks

### DIFF
--- a/services/local-ai-core/src/automation/mock-stock-provider.ts
+++ b/services/local-ai-core/src/automation/mock-stock-provider.ts
@@ -47,6 +47,7 @@ export class StockQuoteProvider implements MonitorProviderRuntime {
     sourceConfig: Record<string, unknown>,
     lastState?: Record<string, unknown>,
   ): MonitorEvent {
+    // Mock mode may honor a config previousPrice override; lastState only reflects the previous mock event.
     const previousPrice = Number(lastState?.latestPrice ?? sourceConfig.previousPrice ?? latestPrice);
     return this.buildQuoteEvent(monitorId, symbol, latestPrice, previousPrice, sourceConfig, lastState, String(sourceConfig.name || symbol));
   }
@@ -100,8 +101,9 @@ export class StockQuoteProvider implements MonitorProviderRuntime {
     sourceConfig: Record<string, unknown>,
     lastState?: Record<string, unknown>,
   ): MonitorEvent {
+    // Network-failure fallback trusts only the persisted previousPrice; no config override applies here.
     const previousPrice = Number(lastState?.previousPrice ?? lastPrice);
-    return this.buildQuoteEvent(monitorId, symbol, lastPrice, previousPrice, sourceConfig, lastState);
+    return this.buildQuoteEvent(monitorId, symbol, lastPrice, previousPrice, sourceConfig, lastState, undefined);
   }
 
   private buildQuoteEvent(
@@ -111,7 +113,7 @@ export class StockQuoteProvider implements MonitorProviderRuntime {
     previousPrice: number,
     sourceConfig: Record<string, unknown>,
     lastState: Record<string, unknown> | undefined,
-    name?: string,
+    name: string | undefined,
   ): MonitorEvent {
     const changePercent = previousPrice > 0 ? ((price - previousPrice) / previousPrice) * 100 : 0;
     const now = new Date().toISOString();

--- a/services/local-ai-core/src/automation/mock-stock-provider.ts
+++ b/services/local-ai-core/src/automation/mock-stock-provider.ts
@@ -48,29 +48,7 @@ export class StockQuoteProvider implements MonitorProviderRuntime {
     lastState?: Record<string, unknown>,
   ): MonitorEvent {
     const previousPrice = Number(lastState?.latestPrice ?? sourceConfig.previousPrice ?? latestPrice);
-    const changePercent = previousPrice > 0 ? ((latestPrice - previousPrice) / previousPrice) * 100 : 0;
-    const now = new Date().toISOString();
-    const boll = extractMockBollinger(sourceConfig, latestPrice, lastState);
-    const dividend = extractMockDividend(sourceConfig, latestPrice, symbol, lastState);
-    const payload = buildEventPayload({
-      symbol,
-      name: String(sourceConfig.name || symbol),
-      latestPrice,
-      previousPrice,
-      changePercent: Number(changePercent.toFixed(2)),
-      timestamp: now,
-      boll,
-      dividend,
-    });
-
-    return {
-      id: `${monitorId}:${symbol}:${now}`,
-      sourceType: this.sourceType,
-      occurredAt: now,
-      subject: symbol,
-      summary: buildEventSummary(symbol, latestPrice, changePercent, boll, dividend),
-      payload,
-    };
+    return this.buildQuoteEvent(monitorId, symbol, latestPrice, previousPrice, sourceConfig, lastState, String(sourceConfig.name || symbol));
   }
 
   private async fetchRealQuoteEvent(
@@ -123,13 +101,26 @@ export class StockQuoteProvider implements MonitorProviderRuntime {
     lastState?: Record<string, unknown>,
   ): MonitorEvent {
     const previousPrice = Number(lastState?.previousPrice ?? lastPrice);
-    const changePercent = previousPrice > 0 ? ((lastPrice - previousPrice) / previousPrice) * 100 : 0;
+    return this.buildQuoteEvent(monitorId, symbol, lastPrice, previousPrice, sourceConfig, lastState);
+  }
+
+  private buildQuoteEvent(
+    monitorId: string,
+    symbol: string,
+    price: number,
+    previousPrice: number,
+    sourceConfig: Record<string, unknown>,
+    lastState: Record<string, unknown> | undefined,
+    name?: string,
+  ): MonitorEvent {
+    const changePercent = previousPrice > 0 ? ((price - previousPrice) / previousPrice) * 100 : 0;
     const now = new Date().toISOString();
-    const boll = extractMockBollinger(sourceConfig, lastPrice, lastState);
-    const dividend = extractMockDividend(sourceConfig, lastPrice, symbol, lastState);
+    const boll = extractMockBollinger(sourceConfig, price, lastState);
+    const dividend = extractMockDividend(sourceConfig, price, symbol, lastState);
     const payload = buildEventPayload({
       symbol,
-      latestPrice: lastPrice,
+      name,
+      latestPrice: price,
       previousPrice,
       changePercent: Number(changePercent.toFixed(2)),
       timestamp: now,
@@ -142,7 +133,7 @@ export class StockQuoteProvider implements MonitorProviderRuntime {
       sourceType: this.sourceType,
       occurredAt: now,
       subject: symbol,
-      summary: buildEventSummary(symbol, lastPrice, changePercent, boll, dividend),
+      summary: buildEventSummary(symbol, price, changePercent, boll, dividend),
       payload,
     };
   }

--- a/services/local-ai-core/src/channel/weixin/inbound-poller.ts
+++ b/services/local-ai-core/src/channel/weixin/inbound-poller.ts
@@ -26,14 +26,8 @@ function computeRetryDelay(failures: number) {
   return 60_000;
 }
 
-export async function runWeixinInboundPoller(input: {
-  binding: WeixinWorkspaceBinding;
-  signal: AbortSignal;
-  getRuntimeState: () => WeixinRuntimeState | undefined;
+type WeixinInboundCallbacks = {
   getAuthorizedUser: (workspaceId: string, platformUserId: string, platformKey: string) => unknown;
-  clearRuntimeError: (state: WeixinRuntimeState) => void;
-  setRuntimeError: (state: WeixinRuntimeState, error: ReturnType<typeof toLocalCoreErrorInfo>) => void;
-  notifyRuntimeStateChanged: () => void;
   downloadMediaItem: (
     item: WeixinRawItem,
     messageId: string,
@@ -43,7 +37,16 @@ export async function runWeixinInboundPoller(input: {
   ) => Promise<WeixinDownloadedMedia | null>;
   handleInboundMessage: (message: unknown) => Promise<void>;
   log?: (message: string) => void;
-}) {
+};
+
+export async function runWeixinInboundPoller(input: {
+  binding: WeixinWorkspaceBinding;
+  signal: AbortSignal;
+  getRuntimeState: () => WeixinRuntimeState | undefined;
+  clearRuntimeError: (state: WeixinRuntimeState) => void;
+  setRuntimeError: (state: WeixinRuntimeState, error: ReturnType<typeof toLocalCoreErrorInfo>) => void;
+  notifyRuntimeStateChanged: () => void;
+} & WeixinInboundCallbacks) {
   const { binding, signal } = input;
   const errorLogWindows = new Map<string, { at: number; count: number; errorKey: string }>();
   let buf = loadWeixinBuf(binding);
@@ -133,18 +136,7 @@ export async function runWeixinInboundPoller(input: {
 async function processWeixinInboundMsg(
   msg: any,
   binding: WeixinWorkspaceBinding,
-  input: {
-    getAuthorizedUser: (workspaceId: string, platformUserId: string, platformKey: string) => unknown;
-    downloadMediaItem: (
-      item: WeixinRawItem,
-      messageId: string,
-      index: number,
-      uploadsDir: string,
-      binding: WeixinWorkspaceBinding,
-    ) => Promise<WeixinDownloadedMedia | null>;
-    handleInboundMessage: (message: unknown) => Promise<void>;
-    log?: (message: string) => void;
-  },
+  input: WeixinInboundCallbacks,
 ) {
   const items = msg.item_list ?? [];
   const textItem = items.find((item: any) => item.type === TEXT_ITEM_TYPE);


### PR DESCRIPTION
## Summary
- Category: **b — code reuse** (daily optimization pass, clean logs day)
- `automation/mock-stock-provider.ts`: `createMockPriceEvent` and `createFallbackEvent` each hand-built bollinger/dividend extraction, payload assembly, and the `MonitorEvent` envelope. Both now delegate to a shared `buildQuoteEvent` helper; `fetchRealQuoteEvent` (real quotes) stays untouched since it sources previousPrice/changePercent/timestamp directly.
- `channel/weixin/inbound-poller.ts`: the inbound-callback block was restated in both the poller input type and `processWeixinInboundMsg`'s parameter type. Extracted a module-private `WeixinInboundCallbacks` used by both — purely type-level, no runtime statements changed.

## Motivation
Both blocks surfaced in `pnpm lint:duplicate` (jscpd) top clones from PR #84's stock monitor additions. Continues the de-dup series (#75, #78, #85).

## Review
3 parallel reviewers (reuse / quality / efficiency), 1 fix round:
- Reuse: approved; optional envelope-helper extraction for `fetchRealQuoteEvent` declined (below clone threshold, adds indirection).
- Quality: approved; applied explicit `undefined` name at the fallback call site and WHY comments on the deliberately-different previousPrice chains (mock honors `sourceConfig.previousPrice`; network fallback trusts `lastState.previousPrice` only).
- Efficiency: approved — verified single evaluation of each extractor per event, one shared timestamp for id+occurredAt, no new imports or cycles.

## Validation
- `pnpm test`: 645 pass / 0 fail / 1 skipped; BDD 80 scenarios, 286 steps passed
- Diff: +35 / −50 across 2 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)