### PR TITLE
Share monitor-to-scheduled-job adapter and thread message insert

### DIFF
--- a/services/local-ai-core/src/acp/store/thread-store.ts
+++ b/services/local-ai-core/src/acp/store/thread-store.ts
@@ -136,40 +136,23 @@ export class LocalThreadStore {
     this.db.prepare('DELETE FROM threads WHERE id = ?').run(threadId);
   }
 
-  appendMessage(threadId: string, ...[role, content, kind, toolCall, bridgeKind, bridgeStatus]: MessageContentArgs) {
+  appendMessage(threadId: string, ...args: MessageContentArgs) {
     const timestamp = new Date().toISOString();
-    const nextSequenceRow = this.db.prepare('SELECT COALESCE(MAX(seq), -1) + 1 AS next_seq FROM messages WHERE thread_id = ?').get(threadId) as { next_seq: number };
-    const nextSeq = Number(nextSequenceRow?.next_seq || 0);
-    const id = `${timestamp}-${role}-${nextSeq}`;
-    const excerpt = normalizeMessageContent(content);
+    const excerpt = normalizeMessageContent(args[1]);
     this.db.exec('BEGIN IMMEDIATE');
     try {
-      this.db.prepare(`
-        INSERT INTO messages (id, thread_id, role, content, tool_call_json, bridge_kind, bridge_status, timestamp, kind, seq)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(
-        id,
-        threadId,
-        role,
-        content,
-        toolCall ? JSON.stringify(toolCall) : null,
-        bridgeKind || null,
-        bridgeStatus || null,
-        timestamp,
-        kind,
-        nextSeq,
-      );
+      const id = this.insertMessageRow(threadId, undefined, timestamp, ...args);
       this.db.prepare(`
         UPDATE threads
         SET updated_at = ?, history_count = history_count + 1, excerpt = ?
         WHERE id = ?
       `).run(timestamp, excerpt, threadId);
       this.db.exec('COMMIT');
+      return { id, timestamp };
     } catch (error) {
       this.db.exec('ROLLBACK');
       throw error;
     }
-    return { id, timestamp };
   }
 
   upsertMessage(threadId: string, id: string, ...[role, content, kind, toolCall, bridgeKind, bridgeStatus]: MessageContentArgs) {
@@ -185,12 +168,7 @@ export class LocalThreadStore {
           WHERE id = ? AND thread_id = ?
         `).run(content, toolCall ? JSON.stringify(toolCall) : null, bridgeKind || null, bridgeStatus || null, timestamp, kind, id, threadId);
       } else {
-        const nextSequenceRow = this.db.prepare('SELECT COALESCE(MAX(seq), -1) + 1 AS next_seq FROM messages WHERE thread_id = ?').get(threadId) as { next_seq: number };
-        const nextSeq = Number(nextSequenceRow?.next_seq || 0);
-        this.db.prepare(`
-          INSERT INTO messages (id, thread_id, role, content, tool_call_json, bridge_kind, bridge_status, timestamp, kind, seq)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `).run(id, threadId, role, content, toolCall ? JSON.stringify(toolCall) : null, bridgeKind || null, bridgeStatus || null, timestamp, kind, nextSeq);
+        this.insertMessageRow(threadId, id, timestamp, role, content, kind, toolCall, bridgeKind, bridgeStatus);
         this.db.prepare(`
           UPDATE threads
           SET history_count = history_count + 1
@@ -208,6 +186,33 @@ export class LocalThreadStore {
       throw error;
     }
     return { id, timestamp };
+  }
+
+  private insertMessageRow(
+    threadId: string,
+    id: string | undefined,
+    timestamp: string,
+    ...[role, content, kind, toolCall, bridgeKind, bridgeStatus]: MessageContentArgs
+  ) {
+    const nextSequenceRow = this.db.prepare('SELECT COALESCE(MAX(seq), -1) + 1 AS next_seq FROM messages WHERE thread_id = ?').get(threadId) as { next_seq: number };
+    const nextSeq = Number(nextSequenceRow?.next_seq || 0);
+    const messageId = id ?? `${timestamp}-${role}-${nextSeq}`;
+    this.db.prepare(`
+      INSERT INTO messages (id, thread_id, role, content, tool_call_json, bridge_kind, bridge_status, timestamp, kind, seq)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      messageId,
+      threadId,
+      role,
+      content,
+      toolCall ? JSON.stringify(toolCall) : null,
+      bridgeKind || null,
+      bridgeStatus || null,
+      timestamp,
+      kind,
+      nextSeq,
+    );
+    return messageId;
   }
 
   updateRun(runId: string, threadId: string, status: LocalRunRow['status']) {

--- a/services/local-ai-core/src/acp/store/thread-store.ts
+++ b/services/local-ai-core/src/acp/store/thread-store.ts
@@ -138,21 +138,23 @@ export class LocalThreadStore {
 
   appendMessage(threadId: string, ...args: MessageContentArgs) {
     const timestamp = new Date().toISOString();
-    const excerpt = normalizeMessageContent(args[1]);
+    const [, content] = args;
+    const excerpt = normalizeMessageContent(content);
+    let id: string;
     this.db.exec('BEGIN IMMEDIATE');
     try {
-      const id = this.insertMessageRow(threadId, undefined, timestamp, ...args);
+      id = this.insertMessageRow(threadId, undefined, timestamp, ...args);
       this.db.prepare(`
         UPDATE threads
         SET updated_at = ?, history_count = history_count + 1, excerpt = ?
         WHERE id = ?
       `).run(timestamp, excerpt, threadId);
       this.db.exec('COMMIT');
-      return { id, timestamp };
     } catch (error) {
       this.db.exec('ROLLBACK');
       throw error;
     }
+    return { id, timestamp };
   }
 
   upsertMessage(threadId: string, id: string, ...[role, content, kind, toolCall, bridgeKind, bridgeStatus]: MessageContentArgs) {

--- a/services/local-ai-core/src/automation/automation-monitor-repository.ts
+++ b/services/local-ai-core/src/automation/automation-monitor-repository.ts
@@ -60,22 +60,5 @@ export class AutomationMonitorRepository {
   getPlatformThreadBindingByThreadId(threadId: string) {
     return this.store.getPlatformThreadBindingByThreadId(threadId);
   }
-
-  toScheduledLike(monitor: AutomationMonitor) {
-    return {
-      id: monitor.id,
-      workspaceId: monitor.workspaceId,
-      platform: monitor.platform,
-      route: monitor.route,
-      executionMode: monitor.executionMode,
-      triggerType: 'once' as const,
-      promptTemplate: monitor.promptTemplate,
-      description: monitor.title,
-      enabled: monitor.enabled,
-      concurrencyPolicy: monitor.concurrencyPolicy,
-      createdAt: monitor.createdAt,
-      updatedAt: monitor.updatedAt,
-    };
-  }
 }
 

--- a/services/local-ai-core/src/automation/automation-monitor-service.ts
+++ b/services/local-ai-core/src/automation/automation-monitor-service.ts
@@ -22,6 +22,7 @@ import {
   monitorToAutomationInput,
 } from './legacy-automation-mappers.js';
 import type { AutomationService } from './automation-service.js';
+import { automationMonitorToScheduledJob } from './automation-schedule-utils.js';
 import {
   normalizeAutomationError,
   normalizeProviderEventSnapshot,
@@ -323,20 +324,10 @@ export class AutomationMonitorService {
   listMonitorsForThread(threadId: string): AutomationMonitor[] {
     const binding = this.options.store.getPlatformThreadBindingByThreadId(threadId);
     return this.listMonitors().filter((monitor) =>
-      monitor.route.threadId === threadId || (binding ? scheduledJobMatchesPlatformBinding({
-        id: monitor.id,
-        workspaceId: monitor.workspaceId,
-        platform: monitor.platform,
-        route: monitor.route,
-        executionMode: monitor.executionMode,
-        triggerType: 'once',
-        promptTemplate: monitor.promptTemplate,
-        description: monitor.title,
-        enabled: monitor.enabled,
-        concurrencyPolicy: 'skip_if_running',
-        createdAt: monitor.createdAt,
-        updatedAt: monitor.updatedAt,
-      }, binding) : false)
+      monitor.route.threadId === threadId || (binding ? scheduledJobMatchesPlatformBinding(
+        automationMonitorToScheduledJob(monitor),
+        binding,
+      ) : false)
     );
   }
 

--- a/services/local-ai-core/src/automation/automation-schedule-utils.ts
+++ b/services/local-ai-core/src/automation/automation-schedule-utils.ts
@@ -1,6 +1,8 @@
 import type {
   AutomationDefinition,
   AutomationEvaluation,
+  AutomationMonitor,
+  ScheduledJob,
 } from '@cc/superai-contracts';
 import type { AutomationActionExecutionResult } from './automation-action-executor.js';
 import { normalizeAutomationError } from './automation-event-utils.js';
@@ -35,6 +37,23 @@ export function calculateInitialNextCheckAt(
       || nextActivationAt(automation.activation, now);
   }
   return next?.toISOString() || null;
+}
+
+export function automationMonitorToScheduledJob(monitor: AutomationMonitor): ScheduledJob {
+  return {
+    id: monitor.id,
+    workspaceId: monitor.workspaceId,
+    platform: monitor.platform,
+    route: monitor.route,
+    executionMode: monitor.executionMode,
+    triggerType: 'once' as const,
+    promptTemplate: monitor.promptTemplate,
+    description: monitor.title,
+    enabled: monitor.enabled,
+    concurrencyPolicy: monitor.concurrencyPolicy,
+    createdAt: monitor.createdAt,
+    updatedAt: monitor.updatedAt,
+  };
 }
 
 export function isAutomationConsumedOnce(

--- a/services/local-ai-core/src/automation/automation-schedule-utils.ts
+++ b/services/local-ai-core/src/automation/automation-schedule-utils.ts
@@ -40,6 +40,7 @@ export function calculateInitialNextCheckAt(
 }
 
 export function automationMonitorToScheduledJob(monitor: AutomationMonitor): ScheduledJob {
+  // 'once' is a matcher-neutral placeholder: route matchers only read workspace/platform/channel/participant.
   return {
     id: monitor.id,
     workspaceId: monitor.workspaceId,

--- a/services/local-ai-core/src/cli/lac.ts
+++ b/services/local-ai-core/src/cli/lac.ts
@@ -13,6 +13,7 @@ import { normalizeChannelPlatform, normalizeScheduledJobExecutionMode } from '@c
 import { toPublicScheduledJobId } from '../scheduler/job-id.js';
 import { getChannelPlatformBase, getChannelPlatformInstanceId, scheduledJobMatchesCliContext } from '../scheduler/scheduled-job-route.js';
 import { toPublicAutomationMonitorId } from '../automation/monitor-id.js';
+import { automationMonitorToScheduledJob } from '../automation/automation-schedule-utils.js';
 import { parseDurationMs, parseMonitorCondition } from './monitor-cli-parsers.js';
 import { formatSafeError } from '../kernel/local-core-errors.js';
 
@@ -799,20 +800,7 @@ function presentMonitor(monitor: AutomationMonitor): AutomationMonitor {
 }
 
 function monitorMatchesCliContext(monitor: AutomationMonitor, context: CliContext) {
-  return scheduledJobMatchesCliContext({
-    id: monitor.id,
-    workspaceId: monitor.workspaceId,
-    platform: monitor.platform,
-    route: monitor.route,
-    executionMode: monitor.executionMode,
-    triggerType: 'once',
-    promptTemplate: monitor.promptTemplate,
-    description: monitor.title,
-    enabled: monitor.enabled,
-    concurrencyPolicy: monitor.concurrencyPolicy,
-    createdAt: monitor.createdAt,
-    updatedAt: monitor.updatedAt,
-  }, context);
+  return scheduledJobMatchesCliContext(automationMonitorToScheduledJob(monitor), context);
 }
 
 void (async () => {


### PR DESCRIPTION
## Summary
- Category: **b — code reuse** (daily optimization pass; service logs clean, no code bugs found)
- `AutomationMonitor → ScheduledJob` projection was hand-inlined in three places with drift (the service copy hardcoded `concurrencyPolicy: 'skip_if_running'`; an unused `toScheduledLike` repository method held a third copy). Added a single pure `automationMonitorToScheduledJob()` in `automation/automation-schedule-utils.ts`, used by `AutomationMonitorService.listMonitorsForThread` and the `lac monitor list` CLI filter; deleted the unused repository method. Matcher behavior is identical — both matchers only read workspace/platform/channel/participant.
- `LocalThreadStore.appendMessage`/`upsertMessage` duplicated the message seq-computation + 10-column INSERT. Extracted a private `insertMessageRow()`; append's seq read now also happens inside the `BEGIN IMMEDIATE` transaction, slightly shrinking a pre-existing read-then-insert window.

## Motivation
Both blocks were top jscpd clones (`pnpm lint:duplicate`, #8 and #7). Continues the de-dup series (#75, #78, #85, #87). Overall duplicate rate 3.72% → 3.63%.

## Review
3 parallel reviewers (reuse / quality / efficiency), 1 fix round:
- Reuse: clean — verified no equivalent projection exists (`legacy-automation-mappers.automationToScheduledJob` maps a different source type and would throw here); adapter placement correct; deletion safe (zero references repo-wide).
- Efficiency: clean — 0 import cycles; adapter short-circuited by threadId match; no measurable new cost; seq-race window improved.
- Quality: applied destructure-instead-of-`args[1]`, return-after-catch symmetry, and a WHY comment on the matcher-neutral `triggerType: 'once'`. Declined the options-object param reshape for the private 2-caller helper (churn without clarity gain).

## Validation
- `pnpm test`: 645 pass / 0 fail / 1 skipped; BDD 80 scenarios, 286 steps passed
- `pnpm typecheck`: clean; `pnpm lint:duplicate`: target clones gone
- Diff: +62 / −73 across 5 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)