### PR TITLE
feat: Unified skills distribution layer and .agents/ interop (closes #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ flowchart LR
 
 ### 2026-08-21
 
+- 统一技能分发层与生态目录互操作（Issue #91）：
+  - **统一 CLI 技能分发**：提供 `lac skill add <owner/repo>[@ref] [--scope user|workspace]`、`list`、`update <name|all> [--force]`、`remove <name>`、`verify` 命令，支持单技能与 monorepo 多技能包安装。
+  - **.agents/ 根目录与生态互操作**：原生支持项目根目录 `.agents/` 与 `.agents/skills/` 技能扫描与加载，遵循 `.agentdock/skills/` > `.agents/skills/` > `.agents/` > `~/.agentdock/skills/` > `builtin` 的优先级继承与同名覆盖链条。
+  - **来源追踪与自演进指纹保护**：在 SQLite 中内置 `skill_sources` 表追踪来源仓库与 commit/ref，安装时生成全量内容 SHA-256 指纹；在更新或验证时检测本地修改状态（`locally-modified`），默认保护本地自演进（#64）成果不被意外覆盖（支持 `--force` 强制覆盖）。
+  - **技能中心发现与推荐 UI**：在 Skills 页面新增「发现与推荐 (Browse)」标签页，内置 Matt Pocock、Superpowers、Anthropic、Obsidian 等高星精选技能包的一键安装；在已安装列表中展示来源徽标与本地修改/丢失状态，并支持一键指纹校验与更新。
 - 支持 Token 成本跟踪与预算硬阻断治理（Issue #66）：
   - **用量与费用多维度归集**：在 Local AI Core 内置 `cost_events` 实时流水与价格计算引擎，按模型/渠道/Agent/触发源（手动、Cron、Monitor、External 等）精确核算 Token 花费，支持主流模型预设费率与服务商自定义单价。
   - **预算硬约束与 Preflight 拦截**：支持日/周/月周期及全局/工作区/Agent/自动化作用域预算策略；在触发源执行前进行预算预检（Preflight Check），超额自动阻断无监督任务（`alert_and_skip`）或强杀运行（`alert_and_kill`），并广播 `budget.limit.exceeded` 领域事件。

--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -1,5 +1,20 @@
 export type SkillScope = 'builtin' | 'user' | 'workspace';
 
+export type SkillSourceStatus = 'clean' | 'locally-modified' | 'missing';
+
+export interface SkillSource {
+  skillId: string;
+  scope: SkillScope;
+  workspaceId?: string;
+  workspacePath?: string;
+  sourceRepo: string;
+  sourceRef?: string;
+  sourceType?: 'github' | 'git';
+  contentHash: string;
+  installedAt: string;
+  status?: SkillSourceStatus;
+}
+
 export interface SkillMetadata {
   name?: string;
   description?: string;
@@ -20,6 +35,7 @@ export interface SkillInfo {
   overridden: boolean;
   overriddenBy?: SkillScope;
   metadata?: SkillMetadata;
+  source?: SkillSource;
 }
 
 export interface SkillDetail extends SkillInfo {
@@ -35,9 +51,15 @@ export interface SaveSkillInput {
 }
 
 export interface InstallSkillInput {
-  url: string;
+  id?: string;
+  url?: string;
+  repo?: string;
+  ref?: string;
+  skillsDir?: string;
   targetScope: 'user' | 'workspace';
   workspacePath?: string;
+  workspaceId?: string;
+  force?: boolean;
 }
 
 export interface InstallSkillBundleInput {
@@ -46,6 +68,9 @@ export interface InstallSkillBundleInput {
   skillsDir?: string;
   targetScope: 'user' | 'workspace';
   workspacePath?: string;
+  workspaceId?: string;
+  ref?: string;
+  repo?: string;
 }
 
 export interface InstallSkillBundleResult {
@@ -53,10 +78,39 @@ export interface InstallSkillBundleResult {
   skipped: string[];
 }
 
+export interface UpdateSkillInput {
+  id?: string;
+  all?: boolean;
+  force?: boolean;
+  workspacePath?: string;
+  workspaceId?: string;
+}
+
+export interface UpdateSkillResult {
+  updated: SkillInfo[];
+  unchanged: string[];
+  conflicts: Array<{ id: string; reason: string }>;
+}
+
+export interface VerifySkillItem {
+  id: string;
+  name: string;
+  scope: SkillScope;
+  sourceRepo: string;
+  sourceRef?: string;
+  status: SkillSourceStatus;
+  path: string;
+}
+
+export interface VerifySkillResult {
+  skills: VerifySkillItem[];
+}
+
 export interface DeleteSkillInput {
   id: string;
   scope: 'user' | 'workspace';
   workspacePath?: string;
+  workspaceId?: string;
 }
 
 export interface ToggleSkillInput {
@@ -64,3 +118,15 @@ export interface ToggleSkillInput {
   enabled: boolean;
   workspacePath?: string;
 }
+
+export interface CuratedSkillPack {
+  id: string;
+  repo: string;
+  name: string;
+  description: string;
+  stars: string;
+  skillsCount?: number;
+  tags: string[];
+  defaultRef?: string;
+}
+

--- a/packages/core-sdk/src/skills.ts
+++ b/packages/core-sdk/src/skills.ts
@@ -1,12 +1,16 @@
 import type {
   SkillInfo,
   SkillDetail,
+  SkillSource,
   SaveSkillInput,
   InstallSkillInput,
   InstallSkillBundleInput,
   InstallSkillBundleResult,
   DeleteSkillInput,
   ToggleSkillInput,
+  UpdateSkillInput,
+  UpdateSkillResult,
+  VerifySkillResult,
 } from '@cc/superai-contracts/skills';
 import { coreRequest } from './request.js';
 
@@ -36,6 +40,28 @@ export function installSkillBundle(input: InstallSkillBundleInput) {
   return coreRequest<InstallSkillBundleResult>('POST', '/skills/install-bundle', input);
 }
 
+export function addSkill(input: InstallSkillInput) {
+  return coreRequest<{ installed: SkillInfo[]; skipped: string[]; source?: SkillSource }>('POST', '/skills/add', input);
+}
+
+export function updateSkill(input: UpdateSkillInput) {
+  return coreRequest<UpdateSkillResult>('POST', '/skills/update', input);
+}
+
+export function verifySkills(options: { workspacePath?: string; skillId?: string } = {}) {
+  const params = new URLSearchParams();
+  if (options.workspacePath) params.set('workspacePath', options.workspacePath);
+  if (options.skillId) params.set('skillId', options.skillId);
+  const query = params.toString() ? `?${params.toString()}` : '';
+  return coreRequest<VerifySkillResult>('GET', `/skills/verify${query}`);
+}
+
+export function listSkillSources(options: { workspacePath?: string } = {}) {
+  const query = options.workspacePath ? `?workspacePath=${encodeURIComponent(options.workspacePath)}` : '';
+  return coreRequest<{ sources: SkillSource[] }>('GET', `/skills/sources${query}`);
+}
+
 export function toggleSkill(input: ToggleSkillInput) {
   return coreRequest<{ success: boolean }>('POST', '/skills/toggle', input);
 }
+

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -90,6 +90,8 @@ import { LocalWorkspaceRegistryStore } from './workspace-registry-store.js';
 import { LocalModelProviderStore } from './model-provider-store.js';
 import { LocalExternalStore } from './external-store.js';
 import { LocalRuntimeConfigStore } from './runtime-config-store.js';
+import { LocalSkillSourceStore } from './skill-source-store.js';
+import type { SkillSource, SkillScope } from '@cc/superai-contracts/skills';
 
 export class LocalCoreAcpStore {
   private readonly db: DatabaseSync;
@@ -109,6 +111,7 @@ export class LocalCoreAcpStore {
   readonly trace: LocalCoreTraceStore;
   readonly cost: LocalCoreCostStore;
   readonly budgets: LocalCoreBudgetStore;
+  readonly skillSources: LocalSkillSourceStore;
 
   constructor(userDataPath: string) {
     const dbPath = join(userDataPath, 'runtime', 'local-core.db');
@@ -120,6 +123,7 @@ export class LocalCoreAcpStore {
     this.trace = new LocalCoreTraceStore(this.db);
     this.cost = new LocalCoreCostStore(this.db);
     this.budgets = new LocalCoreBudgetStore(this.db);
+    this.skillSources = new LocalSkillSourceStore(this.db);
     this.workspaceRegistry = new LocalWorkspaceRegistryStore(this.db);
     this.security = new LocalSecurityStore(this.db, (taskId, input) => {
       this.agentTasks.update(taskId, input);
@@ -138,6 +142,7 @@ export class LocalCoreAcpStore {
     ensureLocalCoreAcpSchema(this.db);
     this.runtimeConfig = new LocalRuntimeConfigStore(this.db, dbPath);
   }
+
 
   close() {
     this.db.close();

--- a/services/local-ai-core/src/acp/store/schema.ts
+++ b/services/local-ai-core/src/acp/store/schema.ts
@@ -455,6 +455,20 @@ export function ensureLocalCoreAcpSchema(db: DatabaseSync) {
     );
     CREATE INDEX IF NOT EXISTS idx_budgets_workspace_scope ON budgets (workspace_id, scope_kind, scope_id);
     CREATE INDEX IF NOT EXISTS idx_budgets_enabled ON budgets (enabled);
+    CREATE TABLE IF NOT EXISTS skill_sources (
+      skill_id TEXT NOT NULL,
+      scope TEXT NOT NULL,
+      workspace_id TEXT NOT NULL DEFAULT '',
+      workspace_path TEXT NOT NULL DEFAULT '',
+      source_repo TEXT NOT NULL,
+      source_ref TEXT NOT NULL DEFAULT '',
+      source_type TEXT NOT NULL DEFAULT 'github',
+      content_hash TEXT NOT NULL,
+      installed_at TEXT NOT NULL,
+      PRIMARY KEY (skill_id, scope, workspace_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_skill_sources_repo ON skill_sources (source_repo);
+    CREATE INDEX IF NOT EXISTS idx_skill_sources_workspace ON skill_sources (workspace_id);
   `);
   ensureColumn(db, 'messages', 'tool_call_json', 'TEXT');
   ensureColumn(db, 'messages', 'bridge_kind', 'TEXT');

--- a/services/local-ai-core/src/acp/store/skill-source-store.ts
+++ b/services/local-ai-core/src/acp/store/skill-source-store.ts
@@ -1,0 +1,101 @@
+import type { DatabaseSync } from 'node:sqlite';
+import type { SkillSource, SkillScope } from '@cc/superai-contracts/skills';
+
+export interface LocalSkillSourceRow {
+  skill_id: string;
+  scope: string;
+  workspace_id: string;
+  workspace_path: string;
+  source_repo: string;
+  source_ref: string;
+  source_type: string;
+  content_hash: string;
+  installed_at: string;
+}
+
+export class LocalSkillSourceStore {
+  constructor(private readonly db: DatabaseSync) {}
+
+  upsertSource(source: SkillSource): SkillSource {
+    const workspaceId = source.workspaceId || '';
+    const workspacePath = source.workspacePath || '';
+    const sourceRef = source.sourceRef || '';
+    const sourceType = source.sourceType || 'github';
+
+    this.db.prepare(`
+      INSERT INTO skill_sources (
+        skill_id, scope, workspace_id, workspace_path,
+        source_repo, source_ref, source_type, content_hash, installed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(skill_id, scope, workspace_id) DO UPDATE SET
+        workspace_path = excluded.workspace_path,
+        source_repo = excluded.source_repo,
+        source_ref = excluded.source_ref,
+        source_type = excluded.source_type,
+        content_hash = excluded.content_hash,
+        installed_at = excluded.installed_at
+    `).run(
+      source.skillId,
+      source.scope,
+      workspaceId,
+      workspacePath,
+      source.sourceRepo,
+      sourceRef,
+      sourceType,
+      source.contentHash,
+      source.installedAt,
+    );
+
+    return this.getSource(source.skillId, source.scope, workspaceId)!;
+  }
+
+  getSource(skillId: string, scope: SkillScope, workspaceId: string = ''): SkillSource | undefined {
+    const row = this.db.prepare(`
+      SELECT * FROM skill_sources WHERE skill_id = ? AND scope = ? AND workspace_id = ?
+    `).get(skillId, scope, workspaceId) as unknown as LocalSkillSourceRow | undefined;
+
+    return row ? mapRowToSkillSource(row) : undefined;
+  }
+
+  listSources(options: { scope?: SkillScope; workspaceId?: string } = {}): SkillSource[] {
+    let sql = 'SELECT * FROM skill_sources';
+    const params: string[] = [];
+
+    if (options.scope && options.workspaceId !== undefined) {
+      sql += ' WHERE scope = ? AND workspace_id = ?';
+      params.push(options.scope, options.workspaceId);
+    } else if (options.scope) {
+      sql += ' WHERE scope = ?';
+      params.push(options.scope);
+    } else if (options.workspaceId !== undefined) {
+      sql += ' WHERE workspace_id = ?';
+      params.push(options.workspaceId);
+    }
+
+    sql += ' ORDER BY installed_at DESC';
+    const rows = this.db.prepare(sql).all(...params) as unknown as LocalSkillSourceRow[];
+    return rows.map(mapRowToSkillSource);
+  }
+
+  deleteSource(skillId: string, scope: SkillScope, workspaceId: string = ''): boolean {
+    const result = this.db.prepare(`
+      DELETE FROM skill_sources WHERE skill_id = ? AND scope = ? AND workspace_id = ?
+    `).run(skillId, scope, workspaceId);
+
+    return (result.changes ?? 0) > 0;
+  }
+}
+
+function mapRowToSkillSource(row: LocalSkillSourceRow): SkillSource {
+  return {
+    skillId: row.skill_id,
+    scope: row.scope as SkillScope,
+    workspaceId: row.workspace_id || undefined,
+    workspacePath: row.workspace_path || undefined,
+    sourceRepo: row.source_repo,
+    sourceRef: row.source_ref || undefined,
+    sourceType: (row.source_type as 'github' | 'git') || 'github',
+    contentHash: row.content_hash,
+    installedAt: row.installed_at,
+  };
+}

--- a/services/local-ai-core/src/cli/cli-helpers.ts
+++ b/services/local-ai-core/src/cli/cli-helpers.ts
@@ -1,0 +1,145 @@
+import { formatSafeError } from '../kernel/local-core-errors.js';
+import { getChannelPlatformBase, getChannelPlatformInstanceId } from '../scheduler/scheduled-job-route.js';
+
+export type JsonEnvelope<T> = {
+  ok: boolean;
+  data: T;
+  error?: string;
+};
+
+export type StdIo = {
+  stdout: Pick<NodeJS.WriteStream, 'write'>;
+  stderr: Pick<NodeJS.WriteStream, 'write'>;
+};
+
+export type CliContext = {
+  baseUrl: string;
+  workspaceId: string;
+  workspacePath: string;
+  threadId: string;
+  platform: string;
+  platformInstanceId: string;
+  routeType: string;
+  chatId: string;
+  platformUserId: string;
+};
+
+export type ParsedFlags = Map<string, string[]>;
+
+export const DEFAULT_BASE_URL = 'http://127.0.0.1:9831/api/local/v1';
+
+export async function request<T>(baseUrl: string, method: string, path: string, body?: unknown) {
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}${path}`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch (error) {
+    throw new Error(`Local AI Core is unavailable at ${baseUrl}: ${formatSafeError(error)}`);
+  }
+  const payload = (await response.json()) as JsonEnvelope<T>;
+  if (!response.ok || !payload.ok) {
+    throw new Error(payload.error || `Local AI Core request failed: ${response.status}`);
+  }
+  return payload.data;
+}
+
+export function resolveContext(flags: Map<string, string[]>, env: NodeJS.ProcessEnv): CliContext {
+  const rawPlatform = getFlag(flags, 'platform') || String(env.LOCAL_AI_PLATFORM || '');
+  const platform = rawPlatform ? getChannelPlatformBase(rawPlatform) : '';
+  const platformInstanceId =
+    getFlag(flags, 'instance-id') ||
+    String(env.LOCAL_AI_PLATFORM_INSTANCE_ID || '') ||
+    getChannelPlatformInstanceId(rawPlatform);
+  const chatId =
+    getFlag(flags, 'channel') ||
+    getFlag(flags, 'channel-id') ||
+    getFlag(flags, 'chat-id') ||
+    String(env.LOCAL_AI_CHAT_ID || '');
+  const platformUserId = getFlag(flags, 'platform-user-id') || String(env.LOCAL_AI_PLATFORM_USER_ID || '');
+  return {
+    baseUrl: getFlag(flags, 'base-url') || String(env.LOCAL_AI_CORE_BASE || DEFAULT_BASE_URL),
+    workspaceId: getFlag(flags, 'workspace') || String(env.LOCAL_AI_WORKSPACE_ID || ''),
+    workspacePath: getFlag(flags, 'workspace-path') || String(env.LOCAL_AI_WORKSPACE_PATH || ''),
+    threadId: normalizeMaybeBooleanFlag(getFlag(flags, 'thread')) || String(env.LOCAL_AI_THREAD_ID || ''),
+    platform,
+    platformInstanceId,
+    routeType:
+      String(env.LOCAL_AI_ROUTE_TYPE || '') ||
+      (platform === 'lark' && chatId && platformUserId ? 'channel.chat' : ''),
+    chatId,
+    platformUserId,
+  };
+}
+
+export function parseArgs(argv: string[]) {
+  const positionals: string[] = [];
+  const flags = new Map<string, string[]>();
+  for (let i = 0; i < argv.length; i += 1) {
+    const part = argv[i];
+    if (!part.startsWith('--')) {
+      positionals.push(part);
+      continue;
+    }
+    const key = part.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      flags.set(key, ['true']);
+      continue;
+    }
+    flags.set(key, [next]);
+    i += 1;
+  }
+  return { positionals, flags };
+}
+
+export function getFlag(flags: Map<string, string[]>, name: string) {
+  return flags.get(name)?.[0] || '';
+}
+
+export function getRequiredFlag(flags: Map<string, string[]>, name: string) {
+  const value = getFlag(flags, name);
+  if (!value) {
+    throw new Error(`Missing required flag --${name}`);
+  }
+  return value;
+}
+
+export function getBooleanFlag(flags: Map<string, string[]>, name: string, defaultValue: boolean) {
+  const value = getFlag(flags, name);
+  if (!value) {
+    return defaultValue;
+  }
+  return value !== 'false';
+}
+
+export function getOptionalBooleanFlag(flags: Map<string, string[]>, name: string) {
+  const value = getFlag(flags, name);
+  if (!value) {
+    return undefined;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  throw new Error(`Flag --${name} must be true or false`);
+}
+
+export function normalizeMaybeBooleanFlag(value: string) {
+  return value === 'true' ? '' : value;
+}
+
+export function print(
+  asJson: boolean,
+  output: Pick<NodeJS.WriteStream, 'write'>,
+  payload: unknown,
+  text: string,
+) {
+  output.write(asJson ? `${JSON.stringify(payload, null, 2)}\n` : `${text}\n`);
+}

--- a/services/local-ai-core/src/cli/lac.ts
+++ b/services/local-ai-core/src/cli/lac.ts
@@ -16,33 +16,20 @@ import { toPublicAutomationMonitorId } from '../automation/monitor-id.js';
 import { automationMonitorToScheduledJob } from '../automation/automation-schedule-utils.js';
 import { parseDurationMs, parseMonitorCondition } from './monitor-cli-parsers.js';
 import { formatSafeError } from '../kernel/local-core-errors.js';
-
-type JsonEnvelope<T> = {
-  ok: boolean;
-  data: T;
-  error?: string;
-};
-
-type StdIo = {
-  stdout: Pick<NodeJS.WriteStream, 'write'>;
-  stderr: Pick<NodeJS.WriteStream, 'write'>;
-};
-
-type CliContext = {
-  baseUrl: string;
-  workspaceId: string;
-  workspacePath: string;
-  threadId: string;
-  platform: string;
-  platformInstanceId: string;
-  routeType: string;
-  chatId: string;
-  platformUserId: string;
-};
-
-type ParsedFlags = Map<string, string[]>;
-
-const DEFAULT_BASE_URL = 'http://127.0.0.1:9831/api/local/v1';
+import { runSkillDomain } from './skill-cli-handlers.js';
+import type { StdIo, ParsedFlags, CliContext } from './cli-helpers.js';
+import {
+  request,
+  resolveContext,
+  parseArgs,
+  getFlag,
+  getRequiredFlag,
+  getBooleanFlag,
+  getOptionalBooleanFlag,
+  normalizeMaybeBooleanFlag,
+  print,
+  DEFAULT_BASE_URL,
+} from './cli-helpers.js';
 
 export async function runCli(argv: string[], env: NodeJS.ProcessEnv = process.env, io: StdIo = process) {
   try {
@@ -60,6 +47,8 @@ export async function runCli(argv: string[], env: NodeJS.ProcessEnv = process.en
         return await runScriptDomain(action, maybeId, flags, env, io, json);
       case 'scheduler':
         return await runSchedulerDomain(action, maybeId, flags, env, io, json);
+      case 'skill':
+        return await runSkillDomain(action, maybeId, flags, env, io, json);
       default:
         printUsage(io.stderr);
         return 2;
@@ -589,106 +578,6 @@ async function handleRun(jobId: string, flags: Map<string, string[]>, env: NodeJ
   return 0;
 }
 
-async function request<T>(baseUrl: string, method: string, path: string, body?: unknown) {
-  let response: Response;
-  try {
-    response = await fetch(`${baseUrl}${path}`, {
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: body ? JSON.stringify(body) : undefined,
-    });
-  } catch (error) {
-    throw new Error(`Local AI Core is unavailable at ${baseUrl}: ${formatSafeError(error)}`);
-  }
-  const payload = await response.json() as JsonEnvelope<T>;
-  if (!response.ok || !payload.ok) {
-    throw new Error(payload.error || `Local AI Core request failed: ${response.status}`);
-  }
-  return payload.data;
-}
-
-function resolveContext(flags: Map<string, string[]>, env: NodeJS.ProcessEnv): CliContext {
-  const rawPlatform = getFlag(flags, 'platform') || String(env.LOCAL_AI_PLATFORM || '');
-  const platform = rawPlatform ? getChannelPlatformBase(rawPlatform) : '';
-  const platformInstanceId = getFlag(flags, 'instance-id') ||
-    String(env.LOCAL_AI_PLATFORM_INSTANCE_ID || '') ||
-    getChannelPlatformInstanceId(rawPlatform);
-  const chatId = getFlag(flags, 'channel') || getFlag(flags, 'channel-id') || getFlag(flags, 'chat-id') || String(env.LOCAL_AI_CHAT_ID || '');
-  const platformUserId = getFlag(flags, 'platform-user-id') || String(env.LOCAL_AI_PLATFORM_USER_ID || '');
-  return {
-    baseUrl: getFlag(flags, 'base-url') || String(env.LOCAL_AI_CORE_BASE || DEFAULT_BASE_URL),
-    workspaceId: getFlag(flags, 'workspace') || String(env.LOCAL_AI_WORKSPACE_ID || ''),
-    workspacePath: getFlag(flags, 'workspace-path') || String(env.LOCAL_AI_WORKSPACE_PATH || ''),
-    threadId: normalizeMaybeBooleanFlag(getFlag(flags, 'thread')) || String(env.LOCAL_AI_THREAD_ID || ''),
-    platform,
-    platformInstanceId,
-    routeType: String(env.LOCAL_AI_ROUTE_TYPE || '') || (platform === 'lark' && chatId && platformUserId ? 'channel.chat' : ''),
-    chatId,
-    platformUserId,
-  };
-}
-
-function parseArgs(argv: string[]) {
-  const positionals: string[] = [];
-  const flags = new Map<string, string[]>();
-  for (let i = 0; i < argv.length; i += 1) {
-    const part = argv[i];
-    if (!part.startsWith('--')) {
-      positionals.push(part);
-      continue;
-    }
-    const key = part.slice(2);
-    const next = argv[i + 1];
-    if (!next || next.startsWith('--')) {
-      flags.set(key, ['true']);
-      continue;
-    }
-    flags.set(key, [next]);
-    i += 1;
-  }
-  return { positionals, flags };
-}
-
-function getFlag(flags: Map<string, string[]>, name: string) {
-  return flags.get(name)?.[0] || '';
-}
-
-function getRequiredFlag(flags: Map<string, string[]>, name: string) {
-  const value = getFlag(flags, name);
-  if (!value) {
-    throw new Error(`Missing required flag --${name}`);
-  }
-  return value;
-}
-
-function getBooleanFlag(flags: Map<string, string[]>, name: string, defaultValue: boolean) {
-  const value = getFlag(flags, name);
-  if (!value) {
-    return defaultValue;
-  }
-  return value !== 'false';
-}
-
-function getOptionalBooleanFlag(flags: Map<string, string[]>, name: string) {
-  const value = getFlag(flags, name);
-  if (!value) {
-    return undefined;
-  }
-  if (value === 'true') {
-    return true;
-  }
-  if (value === 'false') {
-    return false;
-  }
-  throw new Error(`Flag --${name} must be true or false`);
-}
-
-function normalizeMaybeBooleanFlag(value: string) {
-  return value === 'true' ? '' : value;
-}
-
 function getExecutionMode(flags: Map<string, string[]>) {
   return normalizeScheduledJobExecutionMode(getFlag(flags, 'execution-mode'));
 }
@@ -719,13 +608,14 @@ function buildSourceConfig(sourceType: string, flags: Map<string, string[]>) {
   return config;
 }
 
-function print(asJson: boolean, output: Pick<NodeJS.WriteStream, 'write'>, payload: unknown, text: string) {
-  output.write(asJson ? `${JSON.stringify(payload, null, 2)}\n` : `${text}\n`);
-}
-
 function printUsage(output: Pick<NodeJS.WriteStream, 'write'>) {
   output.write([
     'Usage:',
+    '  lac skill add <owner/repo>[@ref] [--scope user|workspace] [--skills-dir <dir>] [--force] [--json]',
+    '  lac skill list [--installed] [--workspace <id>] [--json]',
+    '  lac skill update <name|all> [--force] [--json]',
+    '  lac skill remove <name> [--scope user|workspace] [--json]',
+    '  lac skill verify [<name>] [--json]',
     '  lac scheduler add --cron "<expr>" --message "<text>" --desc "<label>" [--execution-mode same-thread|side-thread] [--json]',
     '  lac scheduler list [--workspace <id>] [--thread [<id>]] [--json]',
     '  lac scheduler info <job-id> [--json]',

--- a/services/local-ai-core/src/cli/skill-cli-handlers.ts
+++ b/services/local-ai-core/src/cli/skill-cli-handlers.ts
@@ -1,0 +1,193 @@
+import type { SkillInfo, SkillSource, SkillScope, UpdateSkillResult, VerifySkillResult } from '@cc/superai-contracts/skills';
+import type { ParsedFlags, StdIo, CliContext } from './cli-helpers.js';
+import { request, resolveContext, getFlag, getRequiredFlag, getBooleanFlag, print } from './cli-helpers.js';
+
+export async function runSkillDomain(
+  action: string,
+  maybeId: string,
+  flags: ParsedFlags,
+  env: NodeJS.ProcessEnv,
+  io: StdIo,
+  json: boolean,
+): Promise<number> {
+  switch (action) {
+    case 'add':
+    case 'install':
+      return await handleSkillAdd(maybeId, flags, env, io, json);
+    case 'list':
+    case 'ls':
+      return await handleSkillList(flags, env, io, json);
+    case 'update':
+    case 'up':
+      return await handleSkillUpdate(maybeId, flags, env, io, json);
+    case 'del':
+    case 'delete':
+    case 'remove':
+    case 'rm':
+      return await handleSkillDelete(maybeId, flags, env, io, json);
+    case 'verify':
+    case 'check':
+      return await handleSkillVerify(maybeId, flags, env, io, json);
+    default:
+      io.stderr.write(`Unknown skill action: "${action}". Supported actions: add, list, update, remove, verify.\n`);
+      return 2;
+  }
+}
+
+async function handleSkillAdd(maybeId: string, flags: ParsedFlags, env: NodeJS.ProcessEnv, io: StdIo, json: boolean) {
+  const context = resolveContext(flags, env);
+  const target = maybeId || getFlag(flags, 'repo') || getFlag(flags, 'url');
+  if (!target) {
+    throw new Error('skill add requires a repository target, e.g. "lac skill add mattpocock/skills" or "lac skill add owner/repo@ref".');
+  }
+
+  const rawScope = getFlag(flags, 'scope') || (flags.has('workspace') ? 'workspace' : 'user');
+  const targetScope: 'user' | 'workspace' = rawScope === 'workspace' ? 'workspace' : 'user';
+  const ref = getFlag(flags, 'ref') || undefined;
+  const skillsDir = getFlag(flags, 'skills-dir') || undefined;
+  const force = getBooleanFlag(flags, 'force', false);
+
+  const result = await request<{ installed: SkillInfo[]; skipped: string[]; source?: SkillSource }>(
+    context.baseUrl,
+    'POST',
+    '/skills/add',
+    {
+      repo: target,
+      ref,
+      skillsDir,
+      targetScope,
+      workspacePath: context.workspacePath || undefined,
+      workspaceId: context.workspaceId || undefined,
+      force,
+    },
+  );
+
+  const names = result.installed.map((s) => s.id).join(', ');
+  const msg = [
+    `Installed ${result.installed.length} skill(s) into ${targetScope} scope:`,
+    ...result.installed.map((s) => `  - ${s.id} (${s.name}) -> ${s.path}`),
+    result.skipped.length ? `Skipped: ${result.skipped.join(', ')}` : '',
+  ].filter(Boolean).join('\n');
+
+  print(json, io.stdout, result, msg);
+  return 0;
+}
+
+async function handleSkillList(flags: ParsedFlags, env: NodeJS.ProcessEnv, io: StdIo, json: boolean) {
+  const context = resolveContext(flags, env);
+  const params = new URLSearchParams();
+  if (context.workspacePath) params.set('workspacePath', context.workspacePath);
+  if (context.workspaceId) params.set('workspaceId', context.workspaceId);
+  const query = params.toString() ? `?${params.toString()}` : '';
+
+  const response = await request<{ skills: SkillInfo[] }>(context.baseUrl, 'GET', `/skills${query}`);
+  const skills = response.skills || [];
+
+  const installedOnly = getBooleanFlag(flags, 'installed', false);
+  const filtered = installedOnly ? skills.filter((s) => s.scope !== 'builtin' && s.source) : skills;
+
+  print(
+    json,
+    io.stdout,
+    { skills: filtered },
+    filtered.length === 0 ? 'No skills found.' : filtered.map(formatSkillLine).join('\n'),
+  );
+  return 0;
+}
+
+async function handleSkillUpdate(maybeId: string, flags: ParsedFlags, env: NodeJS.ProcessEnv, io: StdIo, json: boolean) {
+  const context = resolveContext(flags, env);
+  const isAll = maybeId === 'all' || getBooleanFlag(flags, 'all', false) || !maybeId;
+  const id = isAll ? undefined : (maybeId || getFlag(flags, 'id'));
+  const force = getBooleanFlag(flags, 'force', false);
+
+  const result = await request<UpdateSkillResult>(
+    context.baseUrl,
+    'POST',
+    '/skills/update',
+    {
+      id,
+      all: isAll,
+      force,
+      workspacePath: context.workspacePath || undefined,
+      workspaceId: context.workspaceId || undefined,
+    },
+  );
+
+  const lines: string[] = [];
+  if (result.updated.length > 0) {
+    lines.push(`Updated ${result.updated.length} skill(s): ${result.updated.map((s) => s.id).join(', ')}`);
+  }
+  if (result.unchanged.length > 0) {
+    lines.push(`Unchanged: ${result.unchanged.join(', ')}`);
+  }
+  if (result.conflicts.length > 0) {
+    lines.push('Conflicts (locally-modified):');
+    for (const c of result.conflicts) {
+      lines.push(`  - ${c.id}: ${c.reason}`);
+    }
+  }
+  if (lines.length === 0) {
+    lines.push('No skills were updated.');
+  }
+
+  print(json, io.stdout, result, lines.join('\n'));
+  return result.conflicts.length > 0 && !force ? 1 : 0;
+}
+
+async function handleSkillDelete(maybeId: string, flags: ParsedFlags, env: NodeJS.ProcessEnv, io: StdIo, json: boolean) {
+  const context = resolveContext(flags, env);
+  const id = maybeId || getRequiredFlag(flags, 'id');
+  const rawScope = getFlag(flags, 'scope') || (flags.has('workspace') ? 'workspace' : 'user');
+  const scope: 'user' | 'workspace' = rawScope === 'workspace' ? 'workspace' : 'user';
+
+  const result = await request<{ success: boolean }>(
+    context.baseUrl,
+    'DELETE',
+    '/skills',
+    {
+      id,
+      scope,
+      workspacePath: context.workspacePath || undefined,
+      workspaceId: context.workspaceId || undefined,
+    },
+  );
+
+  print(json, io.stdout, result, `Deleted skill "${id}" from ${scope} scope.`);
+  return 0;
+}
+
+async function handleSkillVerify(maybeId: string, flags: ParsedFlags, env: NodeJS.ProcessEnv, io: StdIo, json: boolean) {
+  const context = resolveContext(flags, env);
+  const skillId = maybeId || getFlag(flags, 'id') || getFlag(flags, 'skill') || undefined;
+  const params = new URLSearchParams();
+  if (context.workspacePath) params.set('workspacePath', context.workspacePath);
+  if (context.workspaceId) params.set('workspaceId', context.workspaceId);
+  if (skillId) params.set('skillId', skillId);
+  const query = params.toString() ? `?${params.toString()}` : '';
+
+  const result = await request<VerifySkillResult>(context.baseUrl, 'GET', `/skills/verify${query}`);
+  const items = result.skills || [];
+
+  if (items.length === 0) {
+    print(json, io.stdout, result, 'No tracked skill sources to verify.');
+    return 0;
+  }
+
+  const lines = items.map((item) => {
+    const src = item.sourceRef ? `${item.sourceRepo}@${item.sourceRef}` : item.sourceRepo;
+    return `${item.id.padEnd(24)} | ${item.scope.padEnd(9)} | ${src.padEnd(30)} | ${item.status}`;
+  });
+
+  print(json, io.stdout, result, lines.join('\n'));
+  return 0;
+}
+
+function formatSkillLine(skill: SkillInfo): string {
+  const src = skill.source
+    ? (skill.source.sourceRef ? `${skill.source.sourceRepo}@${skill.source.sourceRef}` : skill.source.sourceRepo)
+    : (skill.scope === 'builtin' ? 'builtin' : 'local');
+  const status = skill.source?.status || (skill.scope === 'builtin' ? 'builtin' : 'clean');
+  const enabledStr = skill.enabled ? 'enabled' : 'disabled';
+  return `${skill.id.padEnd(24)} | ${skill.scope.padEnd(9)} | ${enabledStr.padEnd(8)} | ${src.padEnd(30)} | ${status.padEnd(16)} | ${skill.name || skill.id}`;
+}

--- a/services/local-ai-core/src/runtime/handlers/skills-handler.ts
+++ b/services/local-ai-core/src/runtime/handlers/skills-handler.ts
@@ -1,6 +1,13 @@
 import type { RouteHandler } from '../server-helpers.js';
 import { json, readJsonBody } from '../server-helpers.js';
-import type { SaveSkillInput, InstallSkillInput, InstallSkillBundleInput, DeleteSkillInput, ToggleSkillInput } from '@cc/superai-contracts';
+import type {
+  SaveSkillInput,
+  InstallSkillInput,
+  InstallSkillBundleInput,
+  DeleteSkillInput,
+  ToggleSkillInput,
+  UpdateSkillInput,
+} from '@cc/superai-contracts/skills';
 import { ManagedSkillCatalog } from '../managed-skill-catalog.js';
 import { mountActiveSkillsForAgent } from '../skill-mounter.js';
 
@@ -8,10 +15,17 @@ export function registerSkillsHandlers(
   map: Map<string, RouteHandler>,
   catalog = new ManagedSkillCatalog(),
 ) {
+  registerSkillQueryHandlers(map, catalog);
+  registerSkillMutationHandlers(map, catalog);
+  registerSkillDistributionHandlers(map, catalog);
+}
+
+function registerSkillQueryHandlers(map: Map<string, RouteHandler>, catalog: ManagedSkillCatalog) {
   map.set('skills.list', async (_route, req, res) => {
     const url = new URL(req.url || '/', 'http://localhost');
     const workspacePath = url.searchParams.get('workspacePath') || undefined;
-    const skills = catalog.listSkills({ workspacePath });
+    const workspaceId = url.searchParams.get('workspaceId') || undefined;
+    const skills = catalog.listSkills({ workspacePath, workspaceId });
     json(res, 200, { skills });
   });
 
@@ -19,7 +33,8 @@ export function registerSkillsHandlers(
     const skillId = (route as { skillId: string }).skillId;
     const url = new URL(req.url || '/', 'http://localhost');
     const workspacePath = url.searchParams.get('workspacePath') || undefined;
-    const skill = catalog.getDetail(skillId, { workspacePath });
+    const workspaceId = url.searchParams.get('workspaceId') || undefined;
+    const skill = catalog.getDetail(skillId, { workspacePath, workspaceId });
     if (!skill) {
       json(res, 404, { error: `Skill ${skillId} not found.` });
       return;
@@ -27,17 +42,30 @@ export function registerSkillsHandlers(
     json(res, 200, skill);
   });
 
+  map.set('skills.verify', async (_route, req, res) => {
+    const url = new URL(req.url || '/', 'http://localhost');
+    const workspacePath = url.searchParams.get('workspacePath') || undefined;
+    const workspaceId = url.searchParams.get('workspaceId') || undefined;
+    const skillId = url.searchParams.get('skillId') || undefined;
+    const result = catalog.verifySkills({ workspacePath, workspaceId, skillId });
+    json(res, 200, result);
+  });
+
+  map.set('skills.sources', async (_route, req, res) => {
+    const url = new URL(req.url || '/', 'http://localhost');
+    const workspaceId = url.searchParams.get('workspaceId') || undefined;
+    const sources = catalog.store ? catalog.store.listSources({ workspaceId }) : [];
+    json(res, 200, { sources });
+  });
+}
+
+function registerSkillMutationHandlers(map: Map<string, RouteHandler>, catalog: ManagedSkillCatalog) {
   map.set('skills.save', async (_route, req, res) => {
     const raw = await readJsonBody(req);
-    if (!raw || typeof raw !== 'object') {
-      json(res, 400, { error: 'Invalid JSON body' });
-      return;
-    }
+    if (!raw || typeof raw !== 'object') return json(res, 400, { error: 'Invalid JSON body' });
     const body = raw as unknown as SaveSkillInput;
-    if (!body.id || typeof body.id !== 'string') {
-      json(res, 400, { error: 'Skill ID is required and must be a string.' });
-      return;
-    }
+    if (!body.id || typeof body.id !== 'string') return json(res, 400, { error: 'Skill ID is required and must be a string.' });
+    if (body.scope !== 'user' && body.scope !== 'workspace') return json(res, 400, { error: 'scope must be "user" or "workspace".' });
     try {
       const skill = catalog.saveSkill(body);
       await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
@@ -49,15 +77,9 @@ export function registerSkillsHandlers(
 
   map.set('skills.delete', async (_route, req, res) => {
     const raw = await readJsonBody(req);
-    if (!raw || typeof raw !== 'object') {
-      json(res, 400, { error: 'Invalid JSON body' });
-      return;
-    }
+    if (!raw || typeof raw !== 'object') return json(res, 400, { error: 'Invalid JSON body' });
     const body = raw as unknown as DeleteSkillInput;
-    if (!body.id || typeof body.id !== 'string') {
-      json(res, 400, { error: 'Skill ID is required and must be a string.' });
-      return;
-    }
+    if (!body.id || typeof body.id !== 'string') return json(res, 400, { error: 'Skill ID is required and must be a string.' });
     try {
       const success = catalog.deleteSkill(body);
       await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
@@ -67,17 +89,27 @@ export function registerSkillsHandlers(
     }
   });
 
+  map.set('skills.toggle', async (_route, req, res) => {
+    const raw = await readJsonBody(req);
+    if (!raw || typeof raw !== 'object') return json(res, 400, { error: 'Invalid JSON body' });
+    const body = raw as unknown as ToggleSkillInput;
+    if (!body.id || typeof body.id !== 'string') return json(res, 400, { error: 'Skill ID is required and must be a string.' });
+    try {
+      const success = catalog.toggleSkill(body);
+      await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
+      json(res, 200, { success });
+    } catch (err) {
+      json(res, 400, { error: String(err) });
+    }
+  });
+}
+
+function registerSkillDistributionHandlers(map: Map<string, RouteHandler>, catalog: ManagedSkillCatalog) {
   map.set('skills.install', async (_route, req, res) => {
     const raw = await readJsonBody(req);
-    if (!raw || typeof raw !== 'object') {
-      json(res, 400, { error: 'Invalid JSON body' });
-      return;
-    }
+    if (!raw || typeof raw !== 'object') return json(res, 400, { error: 'Invalid JSON body' });
     const body = raw as unknown as InstallSkillInput;
-    if (!body.url || typeof body.url !== 'string') {
-      json(res, 400, { error: 'Git URL is required and must be a string.' });
-      return;
-    }
+    if (!body.url && !body.repo) return json(res, 400, { error: 'Git URL or repository is required.' });
     try {
       const skill = await catalog.installSkillFromGit(body);
       await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
@@ -89,19 +121,10 @@ export function registerSkillsHandlers(
 
   map.set('skills.installBundle', async (_route, req, res) => {
     const raw = await readJsonBody(req);
-    if (!raw || typeof raw !== 'object') {
-      json(res, 400, { error: 'Invalid JSON body' });
-      return;
-    }
+    if (!raw || typeof raw !== 'object') return json(res, 400, { error: 'Invalid JSON body' });
     const body = raw as unknown as InstallSkillBundleInput;
-    if (!body.url || typeof body.url !== 'string') {
-      json(res, 400, { error: 'Git URL is required and must be a string.' });
-      return;
-    }
-    if (body.targetScope !== 'user' && body.targetScope !== 'workspace') {
-      json(res, 400, { error: 'targetScope must be "user" or "workspace".' });
-      return;
-    }
+    if (!body.url && !body.repo) return json(res, 400, { error: 'Git URL or repository is required.' });
+    if (body.targetScope !== 'user' && body.targetScope !== 'workspace') return json(res, 400, { error: 'targetScope must be "user" or "workspace".' });
     try {
       const result = await catalog.installSkillBundleFromGit(body);
       await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
@@ -111,21 +134,28 @@ export function registerSkillsHandlers(
     }
   });
 
-  map.set('skills.toggle', async (_route, req, res) => {
+  map.set('skills.add', async (_route, req, res) => {
     const raw = await readJsonBody(req);
-    if (!raw || typeof raw !== 'object') {
-      json(res, 400, { error: 'Invalid JSON body' });
-      return;
-    }
-    const body = raw as unknown as ToggleSkillInput;
-    if (!body.id || typeof body.id !== 'string') {
-      json(res, 400, { error: 'Skill ID is required and must be a string.' });
-      return;
-    }
+    if (!raw || typeof raw !== 'object') return json(res, 400, { error: 'Invalid JSON body' });
+    const body = raw as unknown as InstallSkillInput;
+    if (!body.repo && !body.url) return json(res, 400, { error: 'Repository or URL is required.' });
     try {
-      const success = catalog.toggleSkill(body);
+      const result = await catalog.installSkillFromSource(body);
       await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
-      json(res, 200, { success });
+      json(res, 200, result);
+    } catch (err) {
+      json(res, 400, { error: String(err) });
+    }
+  });
+
+  map.set('skills.update', async (_route, req, res) => {
+    const raw = await readJsonBody(req);
+    if (!raw || typeof raw !== 'object') return json(res, 400, { error: 'Invalid JSON body' });
+    const body = raw as unknown as UpdateSkillInput;
+    try {
+      const result = await catalog.updateSkill(body);
+      await mountActiveSkillsForAgent({ workspacePath: body.workspacePath, catalog });
+      json(res, 200, result);
     } catch (err) {
       json(res, 400, { error: String(err) });
     }

--- a/services/local-ai-core/src/runtime/managed-skill-catalog.ts
+++ b/services/local-ai-core/src/runtime/managed-skill-catalog.ts
@@ -1,11 +1,32 @@
 import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { resolve, join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-import type { SkillInfo, SkillDetail, SaveSkillInput, InstallSkillInput, InstallSkillBundleInput, InstallSkillBundleResult, DeleteSkillInput, ToggleSkillInput, SkillScope } from '@cc/superai-contracts';
-
-const execFileAsync = promisify(execFile);
+import type {
+  SkillInfo,
+  SkillDetail,
+  SaveSkillInput,
+  InstallSkillInput,
+  InstallSkillBundleInput,
+  InstallSkillBundleResult,
+  DeleteSkillInput,
+  ToggleSkillInput,
+  SkillScope,
+  SkillSource,
+  SkillSourceStatus,
+  UpdateSkillInput,
+  UpdateSkillResult,
+  VerifySkillItem,
+  VerifySkillResult,
+} from '@cc/superai-contracts/skills';
+import { LocalSkillSourceStore } from '../acp/store/skill-source-store.js';
+import {
+  computeSkillContentHash,
+  parseSkillRepoUrl,
+  parseFrontmatter,
+  copyTree,
+  cloneGitRepository,
+  discoverSkillsInDirectory,
+} from './skill-distribution-service.js';
 
 export interface ManagedSkill {
   id: string;
@@ -17,6 +38,7 @@ export interface ManagedSkillCatalogOptions {
   rootDir?: string;
   userSkillsDir?: string;
   workspacePath?: string;
+  store?: LocalSkillSourceStore | { skillSources: LocalSkillSourceStore };
 }
 
 /** Loads packaged, user global, and workspace packaged skills with precedence override. */
@@ -24,6 +46,7 @@ export class ManagedSkillCatalog {
   private readonly rootDir: string;
   private readonly userSkillsDir: string;
   private readonly defaultWorkspacePath?: string;
+  readonly store?: LocalSkillSourceStore;
 
   constructor(options: ManagedSkillCatalogOptions = {}) {
     this.rootDir = resolve(options.rootDir || resolveManagedSkillsRoot());
@@ -31,94 +54,100 @@ export class ManagedSkillCatalog {
     if (options.workspacePath) {
       this.defaultWorkspacePath = resolve(options.workspacePath);
     }
+    if (options.store) {
+      this.store = 'skillSources' in options.store ? options.store.skillSources : options.store;
+    }
   }
 
   /** Resolves all skills across Workspace, User, and Builtin roots with precedence override. */
-  listSkills(options: { workspacePath?: string } = {}): SkillInfo[] {
+  listSkills(options: { workspacePath?: string; workspaceId?: string } = {}): SkillInfo[] {
     const workspacePath = options.workspacePath ? resolve(options.workspacePath) : this.defaultWorkspacePath;
-    const roots: { scope: SkillScope; dir: string }[] = [
-      { scope: 'builtin', dir: this.rootDir },
-      { scope: 'user', dir: this.userSkillsDir },
+    const roots: { scope: SkillScope; dir: string; priority: number }[] = [
+      { scope: 'builtin', dir: this.rootDir, priority: 1 },
+      { scope: 'user', dir: this.userSkillsDir, priority: 2 },
     ];
     if (workspacePath) {
-      roots.push({ scope: 'workspace', dir: join(workspacePath, '.agentdock', 'skills') });
+      roots.push({ scope: 'workspace', dir: join(workspacePath, '.agents'), priority: 3 });
+      roots.push({ scope: 'workspace', dir: join(workspacePath, '.agents', 'skills'), priority: 4 });
+      roots.push({ scope: 'workspace', dir: join(workspacePath, '.agentdock', 'skills'), priority: 5 });
     }
 
     const disabledUserSkills = this.loadDisabledSkills(this.userSkillsDir);
     const disabledWorkspaceSkills = workspacePath ? this.loadDisabledSkills(join(workspacePath, '.agentdock', 'skills')) : new Set<string>();
-
     const rawMap = new Map<string, { info: SkillInfo; scopePriority: number }>();
+
+    for (const root of roots) {
+      this.scanSkillsRoot(root, rawMap, disabledUserSkills, disabledWorkspaceSkills);
+    }
+
+    const result = Array.from(rawMap.values()).map((item) => item.info);
+    if (this.store) {
+      this.attachSourceMetadataToSkills(result, options.workspaceId || '');
+    }
+    return result;
+  }
+
+  private scanSkillsRoot(
+    root: { scope: SkillScope; dir: string; priority: number },
+    rawMap: Map<string, { info: SkillInfo; scopePriority: number }>,
+    disabledUserSkills: Set<string>,
+    disabledWorkspaceSkills: Set<string>,
+  ) {
+    if (!existsSync(root.dir)) return;
     const priorityMap: Record<SkillScope, number> = { builtin: 1, user: 2, workspace: 3 };
+    try {
+      const entries = readdirSync(root.dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const id = entry.name;
+        if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) continue;
+        const skillMdPath = join(root.dir, id, 'SKILL.md');
+        if (!existsSync(skillMdPath)) continue;
 
-    for (const { scope, dir } of roots) {
-      if (!existsSync(dir)) continue;
-      try {
-        const entries = readdirSync(dir, { withFileTypes: true });
-        for (const entry of entries) {
-          if (!entry.isDirectory()) continue;
-          const id = entry.name;
-          if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) continue;
-          const skillMdPath = join(dir, id, 'SKILL.md');
-          if (!existsSync(skillMdPath)) continue;
+        let content = '';
+        try { content = readFileSync(skillMdPath, 'utf8'); } catch { continue; }
 
-          let content = '';
-          try {
-            content = readFileSync(skillMdPath, 'utf8');
-          } catch {
-            continue;
-          }
+        const { metadata } = parseFrontmatter(content);
+        const isDisabled = disabledWorkspaceSkills.has(id) || disabledUserSkills.has(id);
+        const existing = rawMap.get(id);
 
-          const { metadata } = parseFrontmatter(content);
-          const isDisabled = disabledWorkspaceSkills.has(id) || disabledUserSkills.has(id);
-          const currentPriority = priorityMap[scope];
-
-          const existing = rawMap.get(id);
-          if (!existing) {
-            rawMap.set(id, {
-              info: {
-                id,
-                name: (metadata.name as string) || id,
-                description: (metadata.description as string) || '',
-                scope,
-                path: skillMdPath,
-                enabled: !isDisabled,
-                overridden: false,
-                metadata,
-              },
-              scopePriority: currentPriority,
-            });
-          } else if (currentPriority > existing.scopePriority) {
-            // Higher priority overrides lower priority
-            const previousScope = existing.info.scope;
-            existing.info = {
-              id,
-              name: (metadata.name as string) || id,
-              description: (metadata.description as string) || '',
-              scope,
-              path: skillMdPath,
-              enabled: !isDisabled,
-              overridden: false,
-              metadata,
-            };
-            existing.scopePriority = currentPriority;
-            // Mark previous lower priority as overridden
+        if (!existing) {
+          rawMap.set(id, {
+            info: { id, name: (metadata.name as string) || id, description: (metadata.description as string) || '', scope: root.scope, path: skillMdPath, enabled: !isDisabled, overridden: false, metadata },
+            scopePriority: root.priority,
+          });
+        } else if (root.priority > existing.scopePriority) {
+          const previousScope = existing.info.scope;
+          const previousInfo = { ...existing.info };
+          existing.info = { id, name: (metadata.name as string) || id, description: (metadata.description as string) || '', scope: root.scope, path: skillMdPath, enabled: !isDisabled, overridden: false, metadata };
+          existing.scopePriority = root.priority;
+          if (previousScope !== root.scope) {
             rawMap.set(`${id}:${previousScope}`, {
-              info: {
-                ...existing.info,
-                scope: previousScope,
-                overridden: true,
-                overriddenBy: scope,
-              },
+              info: { ...previousInfo, scope: previousScope, overridden: true, overriddenBy: root.scope },
               scopePriority: priorityMap[previousScope],
             });
           }
         }
-      } catch {
-        // Ignore read errors
+      }
+    } catch {}
+  }
+
+  private attachSourceMetadataToSkills(skills: SkillInfo[], workspaceId: string) {
+    if (!this.store) return;
+    for (const skill of skills) {
+      if (skill.scope === 'builtin') continue;
+      const source = this.store.getSource(skill.id, skill.scope, workspaceId);
+      if (source) {
+        const skillDir = resolve(skill.path, '..');
+        const currentHash = computeSkillContentHash(skillDir);
+        const status: SkillSourceStatus = !existsSync(skillDir)
+          ? 'missing'
+          : currentHash === source.contentHash
+          ? 'clean'
+          : 'locally-modified';
+        skill.source = { ...source, status };
       }
     }
-
-    return Array.from(rawMap.values()).map((item) => item.info);
   }
 
   get(id: string, options: { workspacePath?: string } = {}): ManagedSkill | undefined {
@@ -127,6 +156,8 @@ export class ManagedSkillCatalog {
     const candidates: { scope: SkillScope; dir: string }[] = [];
     if (workspacePath) {
       candidates.push({ scope: 'workspace', dir: join(workspacePath, '.agentdock', 'skills') });
+      candidates.push({ scope: 'workspace', dir: join(workspacePath, '.agents', 'skills') });
+      candidates.push({ scope: 'workspace', dir: join(workspacePath, '.agents') });
     }
     candidates.push({ scope: 'user', dir: this.userSkillsDir });
     candidates.push({ scope: 'builtin', dir: this.rootDir });
@@ -134,7 +165,7 @@ export class ManagedSkillCatalog {
     for (const { scope, dir } of candidates) {
       if (!existsSync(dir)) continue;
       const path = resolve(dir, id, 'SKILL.md');
-      if (path.startsWith(`${resolve(dir)}/`) && existsSync(path)) {
+      if (path.startsWith(`${resolve(dir)}${sep}`) && existsSync(path)) {
         try {
           return { id, content: readFileSync(path, 'utf8'), scope };
         } catch {
@@ -145,58 +176,49 @@ export class ManagedSkillCatalog {
     return undefined;
   }
 
-  getDetail(id: string, options: { workspacePath?: string } = {}): SkillDetail | undefined {
+  getDetail(id: string, options: { workspacePath?: string; workspaceId?: string } = {}): SkillDetail | undefined {
     const skill = this.get(id, options);
     if (!skill) return undefined;
-    const list = this.listSkills(options);
-    const info = list.find((s) => s.id === id && s.scope === skill.scope) || {
-      id,
-      name: id,
-      description: '',
-      scope: skill.scope || 'builtin',
-      path: '',
-      enabled: true,
-      overridden: false,
-    };
-
-    const helpers: string[] = [];
-    const skillDir = resolve(info.path, '..');
-    if (existsSync(skillDir)) {
-      const collectHelpers = (currentDir: string, relBase = '') => {
-        try {
-          const items = readdirSync(currentDir, { withFileTypes: true });
-          for (const item of items) {
-            const relPath = relBase ? `${relBase}/${item.name}` : item.name;
-            if (relPath === 'SKILL.md') continue;
-            if (item.isDirectory()) {
-              collectHelpers(join(currentDir, item.name), relPath);
-            } else {
-              helpers.push(relPath);
-            }
-          }
-        } catch {
-          // Ignore
-        }
-      };
-      collectHelpers(skillDir);
-    }
-
+    const workspacePath = options.workspacePath ? resolve(options.workspacePath) : this.defaultWorkspacePath;
+    const skills = this.listSkills({ workspacePath, workspaceId: options.workspaceId });
+    const match = skills.find((s) => s.id === id && s.scope === skill.scope);
+    const { metadata } = parseFrontmatter(skill.content);
     return {
-      ...info,
+      id: skill.id,
+      name: (metadata.name as string) || skill.id,
+      description: (metadata.description as string) || '',
+      scope: skill.scope || 'builtin',
+      path: match?.path || '',
       content: skill.content,
-      helpers,
+      enabled: match?.enabled ?? true,
+      overridden: match?.overridden ?? false,
+      helpers: this.listHelperPaths(skill.id, { workspacePath }),
+      source: match?.source,
     };
   }
 
-  /** Resolves a packaged helper prioritizing Workspace -> User -> Builtin. */
-  getHelperPath(id: string, relativePath: string, options: { workspacePath?: string } = {}): string | undefined {
-    if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) return undefined;
-    if (!/^(?:[a-z0-9][a-z0-9._-]*\/)*[a-z0-9][a-z0-9._-]*$/.test(relativePath)) return undefined;
-    const workspacePath = options.workspacePath ? resolve(options.workspacePath) : this.defaultWorkspacePath;
+  listHelperPaths(id: string, options: { workspacePath?: string } = {}): string[] {
+    const skill = this.get(id, options);
+    if (!skill) return [];
+    const helpers: string[] = [];
+    const regex = /(?:scripts|helpers)\/[a-zA-Z0-9_\-\.\/]+/g;
+    let m;
+    while ((m = regex.exec(skill.content)) !== null) {
+      helpers.push(m[0]);
+    }
+    return Array.from(new Set(helpers));
+  }
 
+  getHelperPath(id: string, relativePath: string, options: { workspacePath?: string } = {}): string | undefined {
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(id) || !/^[a-zA-Z0-9_\-\.\/]+$/.test(relativePath)) {
+      return undefined;
+    }
+    const workspacePath = options.workspacePath ? resolve(options.workspacePath) : this.defaultWorkspacePath;
     const candidates: string[] = [];
     if (workspacePath) {
       candidates.push(join(workspacePath, '.agentdock', 'skills'));
+      candidates.push(join(workspacePath, '.agents', 'skills'));
+      candidates.push(join(workspacePath, '.agents'));
     }
     candidates.push(this.userSkillsDir);
     candidates.push(this.rootDir);
@@ -205,7 +227,7 @@ export class ManagedSkillCatalog {
       if (!existsSync(dir)) continue;
       const skillRoot = resolve(dir, id);
       const path = resolve(skillRoot, relativePath);
-      if (path.startsWith(`${skillRoot}/`) && existsSync(path)) {
+      if (path.startsWith(`${skillRoot}${sep}`) && existsSync(path)) {
         return path;
       }
     }
@@ -257,6 +279,10 @@ export class ManagedSkillCatalog {
       throw new Error('Cannot delete builtin skills.');
     }
 
+    if (this.store) {
+      this.store.deleteSource(input.id, input.scope, input.workspaceId || '');
+    }
+
     if (existsSync(targetDir)) {
       rmSync(targetDir, { recursive: true, force: true });
       return true;
@@ -264,10 +290,13 @@ export class ManagedSkillCatalog {
     return false;
   }
 
-  async installSkillFromGit(input: InstallSkillInput): Promise<SkillInfo> {
-    const url = input.url.trim();
-    if (!url) throw new Error('Skill Git repository URL is required.');
+  async installSkillFromSource(input: InstallSkillInput): Promise<{ installed: SkillInfo[]; skipped: string[]; source?: SkillSource }> {
+    const rawTarget = (input.repo || input.url || '').trim();
+    if (!rawTarget) {
+      throw new Error('Repository or URL is required to install skill.');
+    }
 
+    const { url, repo, ref } = parseSkillRepoUrl(rawTarget, input.ref);
     let baseDir: string;
     if (input.targetScope === 'workspace') {
       const wsPath = input.workspacePath ? resolve(input.workspacePath) : this.defaultWorkspacePath;
@@ -279,116 +308,165 @@ export class ManagedSkillCatalog {
 
     mkdirSync(baseDir, { recursive: true });
 
-    // Derive skill ID from repo name or URL
-    const repoName = url.split('/').pop()?.replace(/\.git$/, '').toLowerCase().replace(/[^a-z0-9-]/g, '-') || 'skill';
-    const id = repoName.startsWith('agent-skill-') ? repoName.replace('agent-skill-', '') : repoName;
-
-    const targetDir = join(baseDir, id);
-    if (existsSync(targetDir)) {
-      rmSync(targetDir, { recursive: true, force: true });
-    }
-
-    // Use execFile to prevent command injection
-    await execFileAsync('git', ['clone', '--depth', '1', url, targetDir]);
-
-    // Verify SKILL.md exists
-    const skillMdPath = join(targetDir, 'SKILL.md');
-    if (!existsSync(skillMdPath)) {
-      // If SKILL.md does not exist at root, create a default one
-      const defaultContent = `---\nname: ${id}\ndescription: Imported skill from ${url}\n---\n# ${id}\n\nSkill imported from ${url}.\n`;
-      writeFileSync(skillMdPath, defaultContent, 'utf8');
-    }
-
-    const content = readFileSync(skillMdPath, 'utf8');
-    const { metadata } = parseFrontmatter(content);
-
-    return {
-      id,
-      name: (metadata.name as string) || id,
-      description: (metadata.description as string) || '',
-      scope: input.targetScope,
-      path: skillMdPath,
-      enabled: true,
-      overridden: false,
-      metadata,
-    };
-  }
-
-  async installSkillBundleFromGit(input: InstallSkillBundleInput): Promise<InstallSkillBundleResult> {
-    const url = input.url.trim();
-    if (!url) throw new Error('Skill bundle Git repository URL is required.');
-
-    let baseDir: string;
-    if (input.targetScope === 'workspace') {
-      const wsPath = input.workspacePath ? resolve(input.workspacePath) : this.defaultWorkspacePath;
-      if (!wsPath) throw new Error('Workspace path is required for workspace bundle installation.');
-      baseDir = join(wsPath, '.agentdock', 'skills');
-    } else {
-      baseDir = this.userSkillsDir;
-    }
-
-    mkdirSync(baseDir, { recursive: true });
-
-    const staging = mkdtempSync(join(tmpdir(), 'agentdock-skill-bundle-'));
-    let stagedRoot: string;
+    const staging = mkdtempSync(join(tmpdir(), 'agentdock-skill-install-'));
     try {
-      await execFileAsync('git', ['clone', '--depth', '1', url, staging]);
-      const skillsRelDir = (input.skillsDir || 'skills').trim();
-      stagedRoot = resolve(staging, skillsRelDir);
-      if (!stagedRoot.startsWith(`${staging}/`) || !existsSync(stagedRoot)) {
-        throw new Error(`Skills directory "${skillsRelDir}" not found in repository root.`);
+      await cloneGitRepository(url, ref, staging);
+      const repoFallbackId = repo.split('/').pop()?.replace(/\.git$/, '').toLowerCase().replace(/[^a-z0-9-]/g, '-') || 'skill';
+      const { skills, skipped } = discoverSkillsInDirectory(staging, input.skillsDir, repoFallbackId);
+      const targetDiscovered = input.id ? skills.filter((s) => s.id === input.id) : skills;
+
+      if (targetDiscovered.length === 0) {
+        throw new Error(
+          input.skillsDir
+            ? `No skill directories with SKILL.md found under "${input.skillsDir}/" in ${url}.`
+            : (input.id ? `Skill "${input.id}" not found in ${url}.` : `No valid SKILL.md found in ${url}.`),
+        );
       }
 
       const installed: SkillInfo[] = [];
-      const skipped: string[] = [];
-      let entries: { name: string; isDirectory(): boolean }[] = [];
-      try {
-        entries = readdirSync(stagedRoot, { withFileTypes: true }).map((e) => ({ name: e.name.toString(), isDirectory: () => e.isDirectory() }));
-      } catch {
-        entries = [];
-      }
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const id = entry.name;
-        if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
-          skipped.push(id);
-          continue;
-        }
-        const sourceSkillMd = join(stagedRoot, id, 'SKILL.md');
-        if (!existsSync(sourceSkillMd)) {
-          skipped.push(id);
-          continue;
-        }
+      const installedAt = new Date().toISOString();
 
-        const targetDir = join(baseDir, id);
-        if (existsSync(targetDir)) {
-          rmSync(targetDir, { recursive: true, force: true });
+      for (const discovered of targetDiscovered) {
+        const targetSkillDir = join(baseDir, discovered.id);
+        if (existsSync(targetSkillDir)) {
+          rmSync(targetSkillDir, { recursive: true, force: true });
         }
-        mkdirSync(targetDir, { recursive: true });
-        copyTree(stagedRoot, id, baseDir);
+        mkdirSync(targetSkillDir, { recursive: true });
+        copyTree(discovered.sourceDir, '', targetSkillDir);
 
-        const content = readFileSync(join(targetDir, 'SKILL.md'), 'utf8');
-        const { metadata } = parseFrontmatter(content);
-        installed.push({
-          id,
-          name: (metadata.name as string) || id,
-          description: (metadata.description as string) || '',
+        const contentHash = computeSkillContentHash(targetSkillDir);
+        const sourceRecord: SkillSource = {
+          skillId: discovered.id,
           scope: input.targetScope,
-          path: join(targetDir, 'SKILL.md'),
+          workspaceId: input.workspaceId || '',
+          workspacePath: input.workspacePath || '',
+          sourceRepo: repo,
+          sourceRef: ref || undefined,
+          sourceType: 'github',
+          contentHash,
+          installedAt,
+          status: 'clean',
+        };
+
+        if (this.store) {
+          this.store.upsertSource(sourceRecord);
+        }
+
+        installed.push({
+          id: discovered.id,
+          name: (discovered.metadata.name as string) || discovered.id,
+          description: (discovered.metadata.description as string) || '',
+          scope: input.targetScope,
+          path: join(targetSkillDir, 'SKILL.md'),
           enabled: true,
           overridden: false,
-          metadata,
+          metadata: discovered.metadata,
+          source: sourceRecord,
         });
       }
 
-      if (installed.length === 0) {
-        throw new Error(`No skill directories with SKILL.md found under "${skillsRelDir}/" in ${url}.`);
-      }
-
-      return { installed, skipped };
+      return { installed, skipped, source: installed[0]?.source };
     } finally {
       rmSync(staging, { recursive: true, force: true });
     }
+  }
+
+  async installSkillFromGit(input: InstallSkillInput): Promise<SkillInfo> {
+    const res = await this.installSkillFromSource(input);
+    if (!res.installed[0]) {
+      throw new Error(`Failed to install skill from ${input.url || input.repo}`);
+    }
+    return res.installed[0];
+  }
+
+  async installSkillBundleFromGit(input: InstallSkillBundleInput): Promise<InstallSkillBundleResult> {
+    const res = await this.installSkillFromSource({
+      url: input.url,
+      repo: input.repo,
+      ref: input.ref,
+      skillsDir: input.skillsDir,
+      targetScope: input.targetScope,
+      workspacePath: input.workspacePath,
+      workspaceId: input.workspaceId,
+    });
+    return { installed: res.installed, skipped: res.skipped };
+  }
+
+  verifySkills(options: { workspacePath?: string; workspaceId?: string; skillId?: string } = {}): VerifySkillResult {
+    const skills = this.listSkills(options);
+    const results: VerifySkillItem[] = [];
+
+    for (const skill of skills) {
+      if (skill.scope === 'builtin') continue;
+      if (options.skillId && skill.id !== options.skillId) continue;
+      if (!skill.source) continue;
+
+      results.push({
+        id: skill.id,
+        name: skill.name,
+        scope: skill.scope,
+        sourceRepo: skill.source.sourceRepo,
+        sourceRef: skill.source.sourceRef,
+        status: skill.source.status || 'clean',
+        path: skill.path,
+      });
+    }
+
+    return { skills: results };
+  }
+
+  async updateSkill(input: UpdateSkillInput): Promise<UpdateSkillResult> {
+    const workspacePath = input.workspacePath ? resolve(input.workspacePath) : this.defaultWorkspacePath;
+    const skills = this.listSkills({ workspacePath, workspaceId: input.workspaceId });
+    const targetSkills = input.all
+      ? skills.filter((s) => s.scope !== 'builtin' && s.source)
+      : skills.filter((s) => s.id === input.id && s.scope !== 'builtin' && s.source);
+
+    if (targetSkills.length === 0) {
+      throw new Error(input.id ? `Skill "${input.id}" has no recorded source to update.` : 'No installed skills with source found to update.');
+    }
+
+    const updated: SkillInfo[] = [];
+    const unchanged: string[] = [];
+    const conflicts: Array<{ id: string; reason: string }> = [];
+
+    for (const skill of targetSkills) {
+      const source = skill.source!;
+      const status = source.status || 'clean';
+
+      if (status === 'locally-modified' && !input.force) {
+        conflicts.push({
+          id: skill.id,
+          reason: `Skill "${skill.id}" has been modified locally. Use --force to overwrite.`,
+        });
+        continue;
+      }
+
+      try {
+        const res = await this.installSkillFromSource({
+          id: skill.id,
+          repo: source.sourceRepo,
+          ref: source.sourceRef,
+          targetScope: skill.scope as 'user' | 'workspace',
+          workspacePath,
+          workspaceId: input.workspaceId,
+          force: true,
+        });
+        const match = res.installed.find((s) => s.id === skill.id) || res.installed[0];
+        if (match) {
+          updated.push(match);
+        } else {
+          unchanged.push(skill.id);
+        }
+      } catch (err) {
+        conflicts.push({
+          id: skill.id,
+          reason: `Failed to update from ${source.sourceRepo}: ${String(err)}`,
+        });
+      }
+    }
+
+    return { updated, unchanged, conflicts };
   }
 
   toggleSkill(input: ToggleSkillInput): boolean {
@@ -430,63 +508,4 @@ function resolveManagedSkillsRoot() {
 function resolveUserSkillsRoot() {
   const home = process.env.HOME || process.env.USERPROFILE || '';
   return join(home, '.agentdock', 'skills');
-}
-
-function parseFrontmatter(markdownContent: string): { metadata: Record<string, unknown>; body: string } {
-  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(markdownContent);
-  if (!match) {
-    return { metadata: {}, body: markdownContent };
-  }
-  const yamlText = match[1];
-  const body = match[2];
-  const metadata: Record<string, unknown> = {};
-  for (const line of yamlText.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const colonIdx = trimmed.indexOf(':');
-    if (colonIdx > 0) {
-      const key = trimmed.slice(0, colonIdx).trim();
-      let value: unknown = trimmed.slice(colonIdx + 1).trim();
-      if (typeof value === 'string') {
-        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-          value = value.slice(1, -1);
-        } else if (value === 'true') {
-          value = true;
-        } else if (value === 'false') {
-          value = false;
-        } else if (value.startsWith('[') && value.endsWith(']')) {
-          try {
-            value = JSON.parse(value);
-          } catch {
-            // Keep original string if JSON parse fails
-          }
-        }
-      }
-      metadata[key] = value;
-    }
-  }
-  return { metadata, body };
-}
-
-function copyTree(sourceRoot: string, relativeDir: string, destRoot: string): void {
-  const sourceDir = resolve(sourceRoot, relativeDir);
-  const destDir = resolve(destRoot, relativeDir);
-  if (!sourceDir.startsWith(`${sourceRoot}/`) || !destDir.startsWith(`${destRoot}/`)) return;
-  const entries = readdirSync(sourceDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const name = entry.name.toString();
-    const sourceEntry = join(sourceDir, name);
-    const destEntry = join(destDir, name);
-    if (entry.isDirectory()) {
-      mkdirSync(destEntry, { recursive: true });
-      copyTree(sourceRoot, `${relativeDir}/${name}`, destRoot);
-    } else if (entry.isFile() && !entry.isSymbolicLink()) {
-      try {
-        const content = readFileSync(sourceEntry);
-        writeFileSync(destEntry, content);
-      } catch {
-        // Skip files that cannot be read (e.g. sockets, special files)
-      }
-    }
-  }
 }

--- a/services/local-ai-core/src/runtime/server-routes.ts
+++ b/services/local-ai-core/src/runtime/server-routes.ts
@@ -109,6 +109,10 @@ export type LocalAiCoreRoute =
   | { name: 'skills.delete' }
   | { name: 'skills.install' }
   | { name: 'skills.installBundle' }
+  | { name: 'skills.add' }
+  | { name: 'skills.update' }
+  | { name: 'skills.verify' }
+  | { name: 'skills.sources' }
   | { name: 'skills.toggle' }
   | { name: 'capabilities.read' }
   | { name: 'capabilities.snapshot' }
@@ -556,6 +560,10 @@ function parseSkillsRoute(method: string, segments: string[]): LocalAiCoreRoute 
   if (segments.length === 2) {
     if (segments[1] === 'install' && method === 'POST') return { name: 'skills.install' };
     if (segments[1] === 'install-bundle' && method === 'POST') return { name: 'skills.installBundle' };
+    if (segments[1] === 'add' && method === 'POST') return { name: 'skills.add' };
+    if (segments[1] === 'update' && method === 'POST') return { name: 'skills.update' };
+    if (segments[1] === 'verify' && method === 'GET') return { name: 'skills.verify' };
+    if (segments[1] === 'sources' && method === 'GET') return { name: 'skills.sources' };
     if (segments[1] === 'toggle' && method === 'POST') return { name: 'skills.toggle' };
     if (method === 'GET') return { name: 'skills.get', skillId: decodeURIComponent(segments[1]) };
   }

--- a/services/local-ai-core/src/runtime/server.ts
+++ b/services/local-ai-core/src/runtime/server.ts
@@ -185,7 +185,7 @@ export class LocalAiCoreServer {
       });
     }
     registerKnowledgeHandlers(this.handlers, b.knowledgeProvider);
-    registerSkillsHandlers(this.handlers, b.skillCatalog || new ManagedSkillCatalog());
+    registerSkillsHandlers(this.handlers, b.skillCatalog || new ManagedSkillCatalog({ store: b.store }));
     registerTraceHandlers(this.handlers, b.store);
     const costEventBus = b.kernel?.context?.bus || { emit: () => {}, on: () => () => {} };
     const costService = b.costService || new CostService({ store: b.store, eventBus: costEventBus as any });

--- a/services/local-ai-core/src/runtime/skill-distribution-service.ts
+++ b/services/local-ai-core/src/runtime/skill-distribution-service.ts
@@ -1,0 +1,238 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, relative, sep } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { SkillInfo, SkillScope, SkillSource, SkillSourceStatus, UpdateSkillResult, VerifySkillResult } from '@cc/superai-contracts/skills';
+import type { LocalSkillSourceStore } from '../acp/store/skill-source-store.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface DiscoveredSkill {
+  id: string;
+  sourceDir: string;
+  metadata: Record<string, unknown>;
+  content: string;
+}
+
+export function computeSkillContentHash(skillDir: string): string {
+  if (!existsSync(skillDir)) return '';
+  const hash = createHash('sha256');
+  const filePaths: string[] = [];
+
+  function collectFiles(current: string) {
+    try {
+      const entries = readdirSync(current, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = join(current, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === '.git' || entry.name === 'node_modules') continue;
+          collectFiles(fullPath);
+        } else if (entry.isFile() && !entry.isSymbolicLink()) {
+          filePaths.push(fullPath);
+        }
+      }
+    } catch {
+      // Skip directories that cannot be read
+    }
+  }
+
+  collectFiles(skillDir);
+  filePaths.sort();
+
+  for (const filePath of filePaths) {
+    const relPath = relative(skillDir, filePath).replace(/\\/g, '/');
+    try {
+      const content = readFileSync(filePath);
+      hash.update(relPath);
+      hash.update('\0');
+      hash.update(content);
+      hash.update('\0');
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return hash.digest('hex');
+}
+
+export function parseSkillRepoUrl(rawInput: string, explicitRef?: string): { url: string; repo: string; ref: string } {
+  let trimmed = rawInput.trim();
+  let ref = explicitRef?.trim() || '';
+
+  if (!ref && trimmed.includes('@') && !trimmed.startsWith('git@')) {
+    const atIdx = trimmed.lastIndexOf('@');
+    const protoIdx = trimmed.indexOf('://');
+    if (protoIdx === -1 || atIdx > protoIdx + 3) {
+      ref = trimmed.slice(atIdx + 1).trim();
+      trimmed = trimmed.slice(0, atIdx).trim();
+    }
+  }
+
+  if (trimmed.startsWith('file://')) {
+    return { url: trimmed, repo: trimmed, ref };
+  }
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://') || trimmed.startsWith('git@')) {
+    const cleanUrl = trimmed.replace(/\.git$/, '');
+    const parts = cleanUrl.split('/');
+    const repo = parts.length >= 2 ? `${parts[parts.length - 2]}/${parts[parts.length - 1]}` : (parts[parts.length - 1] || 'skill');
+    return { url: trimmed.endsWith('.git') ? trimmed : `${trimmed}.git`, repo, ref };
+  }
+
+  const repo = trimmed;
+  const url = `https://github.com/${trimmed}.git`;
+  return { url, repo, ref };
+}
+
+export function parseFrontmatter(markdownContent: string): { metadata: Record<string, unknown>; body: string } {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(markdownContent);
+  if (!match) {
+    return { metadata: {}, body: markdownContent };
+  }
+  const yamlText = match[1];
+  const body = match[2];
+  const metadata: Record<string, unknown> = {};
+  for (const line of yamlText.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx > 0) {
+      const key = trimmed.slice(0, colonIdx).trim();
+      let value: unknown = trimmed.slice(colonIdx + 1).trim();
+      if (typeof value === 'string') {
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        } else if (value === 'true') {
+          value = true;
+        } else if (value === 'false') {
+          value = false;
+        } else if (value.startsWith('[') && value.endsWith(']')) {
+          try {
+            value = JSON.parse(value);
+          } catch {
+            // Keep original string
+          }
+        }
+      }
+      metadata[key] = value;
+    }
+  }
+  return { metadata, body };
+}
+
+export function copyTree(sourceRoot: string, relativeDir: string, destRoot: string): void {
+  const sourceDir = relativeDir ? resolve(sourceRoot, relativeDir) : resolve(sourceRoot);
+  const destDir = relativeDir ? resolve(destRoot, relativeDir) : resolve(destRoot);
+  if (!sourceDir.startsWith(resolve(sourceRoot)) || !destDir.startsWith(resolve(destRoot))) return;
+  const entries = readdirSync(sourceDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const name = entry.name.toString();
+    if (name === '.git') continue;
+    const sourceEntry = join(sourceDir, name);
+    const destEntry = join(destDir, name);
+    if (entry.isDirectory()) {
+      mkdirSync(destEntry, { recursive: true });
+      copyTree(sourceRoot, relativeDir ? `${relativeDir}/${name}` : name, destRoot);
+    } else if (entry.isFile() && !entry.isSymbolicLink()) {
+      try {
+        const content = readFileSync(sourceEntry);
+        writeFileSync(destEntry, content);
+      } catch {
+        // Skip files that cannot be read
+      }
+    }
+  }
+}
+
+export async function cloneGitRepository(url: string, ref: string, targetDir: string): Promise<void> {
+  if (ref) {
+    try {
+      await execFileAsync('git', ['clone', '--depth', '1', '--branch', ref, '--', url, targetDir]);
+      return;
+    } catch {
+      await execFileAsync('git', ['clone', '--', url, targetDir]);
+      await execFileAsync('git', ['checkout', ref], { cwd: targetDir });
+      return;
+    }
+  }
+  await execFileAsync('git', ['clone', '--depth', '1', '--', url, targetDir]);
+}
+
+export function discoverSkillsInDirectory(root: string, requestedSkillsDir?: string, fallbackId?: string): { skills: DiscoveredSkill[]; skipped: string[] } {
+  const discovered: DiscoveredSkill[] = [];
+  const skipped: string[] = [];
+
+  if (requestedSkillsDir) {
+    const targetDir = resolve(root, requestedSkillsDir);
+    if (!targetDir.startsWith(`${root}${sep}`) || !existsSync(targetDir)) {
+      throw new Error(`Skills directory "${requestedSkillsDir}" not found in repository root.`);
+    }
+    scanSubdirsForSkills(targetDir, discovered, skipped);
+    return { skills: discovered, skipped };
+  }
+
+  // 1. Check if root itself is a single-skill repo
+  const rootSkillMd = join(root, 'SKILL.md');
+  if (existsSync(rootSkillMd)) {
+    const content = readFileSync(rootSkillMd, 'utf8');
+    const { metadata } = parseFrontmatter(content);
+    let id = (typeof metadata.name === 'string' && /^[a-z0-9][a-z0-9-]*$/.test(metadata.name) ? metadata.name : '') || fallbackId || 'skill';
+    id = id.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/g, '') || 'skill';
+    discovered.push({ id, sourceDir: root, metadata, content });
+    return { skills: discovered, skipped };
+  }
+
+  // 2. Check skills/ subdirectory
+  const skillsSubdir = join(root, 'skills');
+  if (existsSync(skillsSubdir)) {
+    scanSubdirsForSkills(skillsSubdir, discovered, skipped);
+    if (discovered.length > 0) return { skills: discovered, skipped };
+  }
+
+  // 3. Check .agents/ subdirectory
+  const agentsSubdir = join(root, '.agents');
+  if (existsSync(agentsSubdir)) {
+    const agentsSkillsSubdir = join(agentsSubdir, 'skills');
+    if (existsSync(agentsSkillsSubdir)) {
+      scanSubdirsForSkills(agentsSkillsSubdir, discovered, skipped);
+    }
+    scanSubdirsForSkills(agentsSubdir, discovered, skipped);
+    if (discovered.length > 0) return { skills: discovered, skipped };
+  }
+
+  // 4. Scan 1-level deep subdirectories for SKILL.md
+  scanSubdirsForSkills(root, discovered, skipped);
+  return { skills: discovered, skipped };
+}
+
+function scanSubdirsForSkills(dir: string, discovered: DiscoveredSkill[], skipped: string[]) {
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const id = entry.name;
+      if (id.startsWith('.')) continue;
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+        skipped.push(id);
+        continue;
+      }
+      const skillDir = join(dir, id);
+      const skillMd = join(skillDir, 'SKILL.md');
+      if (!existsSync(skillMd)) {
+        skipped.push(id);
+        continue;
+      }
+      try {
+        const content = readFileSync(skillMd, 'utf8');
+        const { metadata } = parseFrontmatter(content);
+        discovered.push({ id, sourceDir: skillDir, metadata, content });
+      } catch {
+        skipped.push(id);
+      }
+    }
+  } catch {
+    // Ignore read errors
+  }
+}

--- a/src/pages/Skills/SkillsPage.tsx
+++ b/src/pages/Skills/SkillsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Sparkles,
   Search,
@@ -10,532 +10,653 @@ import {
   FolderGit2,
   RefreshCw,
   AlertTriangle,
-  BookOpen,
+  Compass,
+  Layers,
+  Download,
+  ExternalLink,
+  CheckCircle2,
+  GitBranch,
 } from 'lucide-react';
 import { Button, Card, EmptyState, Input, Modal, Textarea, PageHeader } from '@/components/ui';
 import { skills as skillsApi } from '@cc/core-sdk';
-import type { SkillInfo, SkillDetail, SkillScope } from '@cc/superai-contracts/skills';
+import type { SkillInfo, SkillDetail, SkillScope, CuratedSkillPack, SkillSource } from '@cc/superai-contracts/skills';
 import { cn } from '@/lib/utils';
-
-type NoticeTone = 'success' | 'error' | 'warning';
-
-interface NoticeState {
-  tone: NoticeTone;
-  message: string;
-}
+import { useSkillsPageController, type NoticeState } from './useSkillsPageController';
 
 export default function SkillsPage() {
-  const [skills, setSkills] = useState<SkillInfo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [notice, setNotice] = useState<NoticeState | null>(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [scopeFilter, setScopeFilter] = useState<'all' | SkillScope>('all');
+  const ctrl = useSkillsPageController();
 
-  // Modals
-  const [selectedSkill, setSelectedSkill] = useState<SkillDetail | null>(null);
-  const [_isDetailLoading, setIsDetailLoading] = useState(false);
-  const [isEditingContent, setIsEditingContent] = useState(false);
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 p-6">
+      <SkillsPageHeader
+        skillsCount={ctrl.skills.length}
+        activeTab={ctrl.activeTab}
+        setActiveTab={ctrl.setActiveTab}
+        loading={ctrl.loading}
+        verifying={ctrl.verifying}
+        onRefresh={ctrl.fetchSkills}
+        onVerify={ctrl.handleVerifySkills}
+        onOpenInstall={() => ctrl.setShowInstallModal(true)}
+        onOpenNew={() => ctrl.setShowNewModal(true)}
+      />
+
+      {ctrl.notice && <NoticeBanner notice={ctrl.notice} onDismiss={() => ctrl.setNotice(null)} />}
+
+      <SkillsToolbar
+        activeTab={ctrl.activeTab}
+        searchQuery={ctrl.searchQuery}
+        setSearchQuery={ctrl.setSearchQuery}
+        scopeFilter={ctrl.scopeFilter}
+        setScopeFilter={ctrl.setScopeFilter}
+        skillsCount={ctrl.skills.length}
+      />
+
+      {ctrl.activeTab === 'installed' ? (
+        <SkillsInstalledGrid
+          loading={ctrl.loading}
+          skills={ctrl.filteredSkills}
+          searchQuery={ctrl.searchQuery}
+          onToggle={ctrl.handleToggleSkill}
+          onDetail={(skill) =>
+            ctrl.setSelectedSkill({
+              id: skill.id,
+              name: skill.name,
+              description: skill.description,
+              scope: skill.scope,
+              path: skill.path,
+              content: '',
+              enabled: skill.enabled,
+              overridden: skill.overridden,
+            })
+          }
+          onUpdate={ctrl.handleUpdateSkill}
+          onDelete={ctrl.handleDeleteSkill}
+        />
+      ) : (
+        <SkillsBrowseGrid
+          packs={ctrl.filteredPacks}
+          installing={ctrl.installing}
+          onInstall={(pack) => {
+            ctrl.setInstallUrl(pack.repo);
+            ctrl.setInstallRef(pack.defaultRef || '');
+            ctrl.setShowInstallModal(true);
+          }}
+        />
+      )}
+
+      {ctrl.selectedSkill && (
+        <SkillDetailModal
+          skill={ctrl.selectedSkill}
+          onClose={() => ctrl.setSelectedSkill(null)}
+          onSaved={() => {
+            ctrl.setNotice({ tone: 'success', message: 'Skill 保存成功' });
+            ctrl.fetchSkills();
+          }}
+        />
+      )}
+
+      {ctrl.showInstallModal && (
+        <SkillInstallModal
+          open={ctrl.showInstallModal}
+          installUrl={ctrl.installUrl}
+          setInstallUrl={ctrl.setInstallUrl}
+          installRef={ctrl.installRef}
+          setInstallRef={ctrl.setInstallRef}
+          installScope={ctrl.installScope}
+          setInstallScope={ctrl.setInstallScope}
+          installing={ctrl.installing}
+          onClose={() => ctrl.setShowInstallModal(false)}
+          onInstall={ctrl.handleInstallSkill}
+        />
+      )}
+
+      {ctrl.showNewModal && (
+        <SkillNewModal
+          open={ctrl.showNewModal}
+          onClose={() => ctrl.setShowNewModal(false)}
+          onCreated={(id) => {
+            ctrl.setNotice({ tone: 'success', message: `成功创建 Skill "${id}"！` });
+            ctrl.fetchSkills();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function SkillsPageHeader(props: {
+  skillsCount: number;
+  activeTab: 'installed' | 'browse';
+  setActiveTab: (t: 'installed' | 'browse') => void;
+  loading: boolean;
+  verifying: boolean;
+  onRefresh: () => void;
+  onVerify: () => void;
+  onOpenInstall: () => void;
+  onOpenNew: () => void;
+}) {
+  return (
+    <PageHeader
+      title="技能中心 (Agent Skills)"
+      description="统一 Agent Skills（SKILL.md）分发与管理。兼容 .agents/ 根目录与 GitHub 生态，技能自动挂载到 Claude Code、Codex、Gemini CLI 等 Agent 原生目录中。"
+      actions={
+        <div className="flex items-center gap-2">
+          <div className="mr-2 flex items-center rounded-lg border bg-muted/40 p-0.5 text-xs">
+            <button
+              onClick={() => props.setActiveTab('installed')}
+              className={cn(
+                'flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium transition-all',
+                props.activeTab === 'installed'
+                  ? 'bg-background shadow-sm text-foreground'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Layers className="h-3.5 w-3.5" />
+              已安装 ({props.skillsCount})
+            </button>
+            <button
+              onClick={() => props.setActiveTab('browse')}
+              className={cn(
+                'flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium transition-all',
+                props.activeTab === 'browse'
+                  ? 'bg-background shadow-sm text-primary'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Compass className="h-3.5 w-3.5" />
+              发现与推荐
+            </button>
+          </div>
+          <Button variant="outline" size="sm" onClick={props.onRefresh} title="刷新">
+            <RefreshCw className={cn('h-4 w-4', props.loading && 'animate-spin')} />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={props.onVerify}
+            disabled={props.verifying}
+            title="校验本地已安装技能指纹"
+          >
+            <CheckCircle2 className={cn('mr-1.5 h-4 w-4', props.verifying && 'animate-spin')} />
+            {props.verifying ? '校验中…' : '指纹校验'}
+          </Button>
+          <Button variant="outline" size="sm" onClick={props.onOpenInstall}>
+            <FolderGit2 className="mr-1.5 h-4 w-4" />
+            安装 GitHub 技能
+          </Button>
+          <Button size="sm" onClick={props.onOpenNew}>
+            <Plus className="mr-1.5 h-4 w-4" />
+            新建 Skill
+          </Button>
+        </div>
+      }
+    />
+  );
+}
+
+function NoticeBanner({ notice, onDismiss }: { notice: NoticeState; onDismiss: () => void }) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between rounded-lg border p-4 text-sm font-medium transition-all',
+        notice.tone === 'success' && 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+        notice.tone === 'warning' && 'border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-300',
+        notice.tone === 'error' && 'border-rose-500/20 bg-rose-500/10 text-rose-600 dark:text-rose-300',
+      )}
+    >
+      <span>{notice.message}</span>
+      <button onClick={onDismiss} className="ml-4 opacity-70 hover:opacity-100">
+        ×
+      </button>
+    </div>
+  );
+}
+
+function SkillsToolbar(props: {
+  activeTab: 'installed' | 'browse';
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  scopeFilter: 'all' | SkillScope;
+  setScopeFilter: (s: 'all' | SkillScope) => void;
+  skillsCount: number;
+}) {
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="relative flex-1 max-w-md">
+        <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder={props.activeTab === 'installed' ? '搜索已安装 Skill 名称、ID 或描述...' : '搜索推荐技能包与关键词...'}
+          value={props.searchQuery}
+          onChange={(e) => props.setSearchQuery(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+      {props.activeTab === 'installed' && (
+        <div className="flex items-center gap-1 rounded-lg border bg-muted/30 p-1 text-xs">
+          <button
+            onClick={() => props.setScopeFilter('all')}
+            className={cn(
+              'rounded-md px-3 py-1.5 font-medium transition-colors',
+              props.scopeFilter === 'all'
+                ? 'bg-background shadow-sm text-foreground'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            全部 ({props.skillsCount})
+          </button>
+          <button
+            onClick={() => props.setScopeFilter('workspace')}
+            className={cn(
+              'rounded-md px-3 py-1.5 font-medium transition-colors',
+              props.scopeFilter === 'workspace'
+                ? 'bg-background shadow-sm text-emerald-600 dark:text-emerald-400'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            Workspace
+          </button>
+          <button
+            onClick={() => props.setScopeFilter('user')}
+            className={cn(
+              'rounded-md px-3 py-1.5 font-medium transition-colors',
+              props.scopeFilter === 'user'
+                ? 'bg-background shadow-sm text-blue-600 dark:text-blue-400'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            User
+          </button>
+          <button
+            onClick={() => props.setScopeFilter('builtin')}
+            className={cn(
+              'rounded-md px-3 py-1.5 font-medium transition-colors',
+              props.scopeFilter === 'builtin'
+                ? 'bg-background shadow-sm text-purple-600 dark:text-purple-400'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            Builtin
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SkillsInstalledGrid(props: {
+  loading: boolean;
+  skills: SkillInfo[];
+  searchQuery: string;
+  onToggle: (s: SkillInfo) => void;
+  onDetail: (s: SkillInfo) => void;
+  onUpdate: (id?: string) => void;
+  onDelete: (s: SkillInfo) => void;
+}) {
+  if (props.loading) {
+    return <div className="py-16 text-center text-sm text-muted-foreground">正在加载 Skill 目录...</div>;
+  }
+  if (props.skills.length === 0) {
+    return (
+      <EmptyState
+        icon={Sparkles}
+        message={props.searchQuery ? '没有匹配搜索条件的 Skill' : '当前目录下暂无可用 Skill，可点击上方新建或在发现页安装'}
+      />
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {props.skills.map((skill) => (
+        <SkillInstalledCard
+          key={`${skill.scope}:${skill.id}`}
+          skill={skill}
+          onToggle={() => props.onToggle(skill)}
+          onDetail={() => props.onDetail(skill)}
+          onUpdate={() => props.onUpdate(skill.id)}
+          onDelete={() => props.onDelete(skill)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SkillInstalledCard(props: {
+  skill: SkillInfo;
+  onToggle: () => void;
+  onDetail: () => void;
+  onUpdate: () => void;
+  onDelete: () => void;
+}) {
+  const { skill } = props;
+  return (
+    <Card
+      className={cn(
+        'group relative flex flex-col justify-between border p-5 transition-all hover:border-primary/50 hover:shadow-md',
+        !skill.enabled && 'opacity-60 bg-muted/20',
+        skill.overridden && 'border-dashed border-amber-500/40 bg-amber-500/5',
+      )}
+    >
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-semibold text-foreground text-base group-hover:text-primary transition-colors">
+              {skill.name || skill.id}
+            </span>
+            <ScopeBadge scope={skill.scope} />
+            {skill.overridden && (
+              <span className="inline-flex items-center gap-1 rounded bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-600 dark:text-amber-400">
+                <AlertTriangle className="h-3 w-3" /> 被 {skill.overriddenBy} 覆盖
+              </span>
+            )}
+            {skill.source && <SourceStatusBadge source={skill.source} />}
+          </div>
+          <label className="relative inline-flex cursor-pointer items-center">
+            <input type="checkbox" checked={skill.enabled} onChange={props.onToggle} className="peer sr-only" />
+            <div className="peer h-5 w-9 rounded-full bg-muted peer-checked:bg-primary peer-focus:outline-none after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-background after:transition-all after:content-[''] peer-checked:after:translate-x-full" />
+          </label>
+        </div>
+        <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed min-h-[2.25rem]">
+          {skill.description || '无详细描述'}
+        </p>
+        <div className="text-[11px] text-muted-foreground/80 font-mono truncate bg-muted/40 px-2 py-1 rounded">
+          {skill.path}
+        </div>
+      </div>
+      <div className="mt-4 flex items-center justify-between border-t pt-3 text-xs">
+        <Button variant="ghost" size="sm" onClick={props.onDetail} className="h-8 text-xs hover:bg-primary/10 hover:text-primary">
+          <Code2 className="mr-1.5 h-3.5 w-3.5" /> SKILL.md
+        </Button>
+        <div className="flex items-center gap-1">
+          {skill.source && (
+            <Button variant="ghost" size="sm" onClick={props.onUpdate} className="h-8 text-xs hover:bg-primary/10 hover:text-primary" title="从来源更新">
+              <RefreshCw className="mr-1 h-3 w-3" /> 更新
+            </Button>
+          )}
+          {skill.scope !== 'builtin' && (
+            <Button variant="ghost" size="sm" onClick={props.onDelete} className="h-8 text-xs text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:hover:bg-rose-950/30">
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function SkillsBrowseGrid(props: {
+  packs: CuratedSkillPack[];
+  installing: boolean;
+  onInstall: (pack: CuratedSkillPack) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {props.packs.map((pack) => (
+        <Card
+          key={pack.id}
+          className="flex flex-col justify-between border p-5 transition-all hover:border-primary/50 hover:shadow-md"
+        >
+          <div className="space-y-3">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <h3 className="font-semibold text-base text-foreground">{pack.name}</h3>
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5 font-mono">
+                  <GitBranch className="h-3 w-3" /> {pack.repo}
+                </div>
+              </div>
+              <span className="rounded bg-primary/10 px-2 py-0.5 font-semibold text-xs text-primary">{pack.stars}</span>
+            </div>
+            <p className="text-xs text-muted-foreground leading-relaxed min-h-[3rem]">{pack.description}</p>
+            <div className="flex flex-wrap gap-1.5 pt-1">
+              {pack.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded bg-muted/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="mt-5 flex items-center justify-between border-t pt-3 text-xs">
+            <a
+              href={`https://github.com/${pack.repo}`}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-3.5 w-3.5" /> GitHub
+            </a>
+            <Button size="sm" onClick={() => props.onInstall(pack)} disabled={props.installing} className="h-8 text-xs">
+              <Download className="mr-1.5 h-3.5 w-3.5" /> 一键安装
+            </Button>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function SkillDetailModal({
+  skill,
+  onClose,
+  onSaved,
+}: {
+  skill: SkillDetail;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [detail, setDetail] = useState<SkillDetail>(skill);
+  const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState('');
 
-  const [showInstallModal, setShowInstallModal] = useState(false);
-  const [installUrl, setInstallUrl] = useState('');
-  const [installScope, setInstallScope] = useState<'user' | 'workspace'>('user');
-  const [installing, setInstalling] = useState(false);
-  const [installingBundle, setInstallingBundle] = useState(false);
+  useEffect(() => {
+    skillsApi
+      .getSkill(skill.id)
+      .then((d) => {
+        setDetail(d);
+        setEditedContent(d.content);
+      })
+      .catch(() => {});
+  }, [skill.id]);
 
-  const [showNewModal, setShowNewModal] = useState(false);
-  const [newSkillId, setNewSkillId] = useState('');
-  const [newSkillScope, setNewSkillScope] = useState<'user' | 'workspace'>('workspace');
-  const [newSkillContent, setNewSkillContent] = useState(
-    `---\nname: my-custom-skill\ndescription: 描述 Skill 的用途与触发场景\nversion: 1.0.0\n---\n\n# Skill 指令与步骤\n\n当符合条件时执行以下操作...\n`
+  const handleSave = async () => {
+    try {
+      await skillsApi.saveSkill({
+        id: detail.id,
+        scope: detail.scope === 'builtin' ? 'user' : detail.scope,
+        content: editedContent,
+      });
+      setIsEditing(false);
+      onSaved();
+    } catch {}
+  };
+
+  return (
+    <Modal open={true} onClose={onClose} title={`Skill 详情: ${detail.name || detail.id}`} className="max-w-3xl">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between border-b pb-3 text-sm">
+          <div className="flex items-center gap-2 flex-wrap">
+            <ScopeBadge scope={detail.scope} />
+            {detail.source && <SourceStatusBadge source={detail.source} />}
+            <span className="font-mono text-xs text-muted-foreground">{detail.path}</span>
+          </div>
+          <Button
+            size="sm"
+            variant={isEditing ? 'default' : 'outline'}
+            onClick={isEditing ? handleSave : () => setIsEditing(true)}
+          >
+            {isEditing ? (
+              '保存修改'
+            ) : (
+              <>
+                <Pencil className="mr-1.5 h-3.5 w-3.5" /> 编辑 SKILL.md
+              </>
+            )}
+          </Button>
+        </div>
+        {detail.helpers && detail.helpers.length > 0 && (
+          <div className="rounded-md border bg-muted/30 p-3 text-xs">
+            <div className="font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+              <FileCode className="h-3.5 w-3.5 text-primary" /> 关联 Helper 依赖:
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {detail.helpers.map((h) => (
+                <span key={h} className="rounded bg-background px-2 py-0.5 font-mono text-[11px] border">
+                  {h}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+        {isEditing ? (
+          <Textarea
+            value={editedContent}
+            onChange={(e) => setEditedContent(e.target.value)}
+            className="font-mono text-xs min-h-[350px] leading-relaxed"
+          />
+        ) : (
+          <pre className="max-h-[450px] overflow-auto rounded-lg border bg-muted/40 p-4 font-mono text-xs leading-relaxed whitespace-pre-wrap">
+            {detail.content}
+          </pre>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function SkillInstallModal(props: {
+  open: boolean;
+  installUrl: string;
+  setInstallUrl: (v: string) => void;
+  installRef: string;
+  setInstallRef: (v: string) => void;
+  installScope: 'user' | 'workspace';
+  setInstallScope: (v: 'user' | 'workspace') => void;
+  installing: boolean;
+  onClose: () => void;
+  onInstall: () => void;
+}) {
+  return (
+    <Modal open={props.open} onClose={props.onClose} title="安装 GitHub / URL Skill">
+      <div className="space-y-4">
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          输入 GitHub 仓库（例如 <code className="bg-muted px-1 py-0.5 rounded">mattpocock/skills</code> 或{' '}
+          <code className="bg-muted px-1 py-0.5 rounded">owner/repo@ref</code>），系统将自动拉取并解析 SKILL.md。
+        </p>
+        <div className="space-y-2">
+          <label className="text-xs font-medium">GitHub 仓库或 URL</label>
+          <Input
+            placeholder="owner/repo[@ref] 或 https://github.com/..."
+            value={props.installUrl}
+            onChange={(e) => props.setInstallUrl(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-medium">指定版本 Branch / Tag (可选)</label>
+          <Input
+            placeholder="main / v1.0.0"
+            value={props.installRef}
+            onChange={(e) => props.setInstallRef(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-medium">安装作用域 Scope</label>
+          <div className="flex items-center gap-4 text-xs">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                checked={props.installScope === 'user'}
+                onChange={() => props.setInstallScope('user')}
+              />
+              User 全局级 (~/.agentdock/skills/)
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                checked={props.installScope === 'workspace'}
+                onChange={() => props.setInstallScope('workspace')}
+              />
+              Workspace 项目级 (.agentdock/skills/)
+            </label>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={props.onClose}>
+            取消
+          </Button>
+          <Button onClick={props.onInstall} disabled={props.installing || !props.installUrl.trim()}>
+            {props.installing ? '正在安装...' : '开始安装'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function SkillNewModal(props: { open: boolean; onClose: () => void; onCreated: (id: string) => void }) {
+  const [id, setId] = useState('');
+  const [scope, setScope] = useState<'user' | 'workspace'>('workspace');
+  const [content, setContent] = useState(
+    `---\nname: my-custom-skill\ndescription: 描述 Skill 的用途与触发场景\nversion: 1.0.0\n---\n\n# Skill 指令与步骤\n\n当符合条件时执行以下操作...\n`,
   );
   const [creating, setCreating] = useState(false);
 
-  const fetchSkills = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await skillsApi.listSkills();
-      setSkills(res.skills || []);
-    } catch (err) {
-      setNotice({ tone: 'error', message: `获取 Skill 列表失败: ${String(err)}` });
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchSkills();
-  }, [fetchSkills]);
-
-  const showSkillDetail = async (skill: SkillInfo) => {
-    setIsDetailLoading(true);
-    setIsEditingContent(false);
-    try {
-      const detail = await skillsApi.getSkill(skill.id);
-      setSelectedSkill(detail);
-      setEditedContent(detail.content);
-    } catch (err) {
-      setNotice({ tone: 'error', message: `获取 Skill 详情失败: ${String(err)}` });
-    } finally {
-      setIsDetailLoading(false);
-    }
-  };
-
-  const handleToggleSkill = async (skill: SkillInfo) => {
-    try {
-      await skillsApi.toggleSkill({ id: skill.id, enabled: !skill.enabled });
-      setSkills((prev) =>
-        prev.map((s) => (s.id === skill.id && s.scope === skill.scope ? { ...s, enabled: !s.enabled } : s))
-      );
-      setNotice({
-        tone: 'success',
-        message: `已${!skill.enabled ? '启用' : '禁用'} Skill "${skill.name || skill.id}"`,
-      });
-    } catch (err) {
-      setNotice({ tone: 'error', message: `状态切换失败: ${String(err)}` });
-    }
-  };
-
-  const handleSaveSkillContent = async () => {
-    if (!selectedSkill) return;
-    try {
-      await skillsApi.saveSkill({
-        id: selectedSkill.id,
-        scope: selectedSkill.scope === 'builtin' ? 'user' : selectedSkill.scope,
-        content: editedContent,
-      });
-      setNotice({ tone: 'success', message: `Skill "${selectedSkill.name}" 保存成功` });
-      setIsEditingContent(false);
-      setSelectedSkill((prev) => (prev ? { ...prev, content: editedContent } : null));
-      fetchSkills();
-    } catch (err) {
-      setNotice({ tone: 'error', message: `保存失败: ${String(err)}` });
-    }
-  };
-
-  const handleDeleteSkill = async (skill: SkillInfo) => {
-    if (!confirm(`确定要删除 Skill "${skill.name || skill.id}" 吗？此操作无法撤销。`)) return;
-    try {
-      await skillsApi.deleteSkill({ id: skill.id, scope: skill.scope as 'user' | 'workspace' });
-      setNotice({ tone: 'success', message: `Skill "${skill.name || skill.id}" 已成功删除` });
-      if (selectedSkill?.id === skill.id) {
-        setSelectedSkill(null);
-      }
-      fetchSkills();
-    } catch (err) {
-      setNotice({ tone: 'error', message: `删除失败: ${String(err)}` });
-    }
-  };
-
-  const handleInstallSkill = async () => {
-    if (!installUrl.trim()) return;
-    setInstalling(true);
-    try {
-      const installed = await skillsApi.installSkill({ url: installUrl, targetScope: installScope });
-      setNotice({ tone: 'success', message: `成功安装 Skill "${installed.name || installed.id}"！` });
-      setShowInstallModal(false);
-      setInstallUrl('');
-      fetchSkills();
-    } catch (err) {
-      setNotice({ tone: 'error', message: `安装失败: ${String(err)}` });
-    } finally {
-      setInstalling(false);
-    }
-  };
-
-  const handleInstallObsidianBundle = async () => {
-    if (!confirm('将从 github.com/kepano/obsidian-skills 安装 5 个 Obsidian 技能到用户级目录（obsidian-markdown / obsidian-bases / json-canvas / obsidian-cli / defuddle）。继续？')) return;
-    setInstallingBundle(true);
-    try {
-      const result = await skillsApi.installSkillBundle({
-        url: 'https://github.com/kepano/obsidian-skills.git',
-        skillsDir: 'skills',
-        targetScope: 'user',
-      });
-      const count = result.installed.length;
-      const skippedNote = result.skipped.length ? `（跳过 ${result.skipped.length} 个不符合命名规范的目录）` : '';
-      setNotice({ tone: 'success', message: `成功安装 ${count} 个 Obsidian 技能${skippedNote}。` });
-      fetchSkills();
-    } catch (err) {
-      setNotice({ tone: 'error', message: `Obsidian 技能包安装失败: ${String(err)}` });
-    } finally {
-      setInstallingBundle(false);
-    }
-  };
-
-  const handleCreateSkill = async () => {
-    if (!newSkillId.trim()) return;
+  const handleCreate = async () => {
+    if (!id.trim()) return;
     setCreating(true);
     try {
-      await skillsApi.saveSkill({
-        id: newSkillId.trim(),
-        scope: newSkillScope,
-        content: newSkillContent,
-      });
-      setNotice({ tone: 'success', message: `成功创建 Skill "${newSkillId}"！` });
-      setShowNewModal(false);
-      setNewSkillId('');
-      fetchSkills();
-    } catch (err) {
-      setNotice({ tone: 'error', message: `创建失败: ${String(err)}` });
-    } finally {
+      await skillsApi.saveSkill({ id: id.trim(), scope, content });
+      props.onCreated(id.trim());
+      props.onClose();
+    } catch {} finally {
       setCreating(false);
     }
   };
 
-  const filteredSkills = useMemo(() => {
-    return skills.filter((skill) => {
-      if (scopeFilter !== 'all' && skill.scope !== scopeFilter) return false;
-      if (searchQuery.trim()) {
-        const q = searchQuery.toLowerCase();
-        return (
-          skill.id.toLowerCase().includes(q) ||
-          skill.name.toLowerCase().includes(q) ||
-          skill.description.toLowerCase().includes(q)
-        );
-      }
-      return true;
-    });
-  }, [skills, scopeFilter, searchQuery]);
-
   return (
-    <div className="mx-auto max-w-7xl space-y-6 p-6">
-      <PageHeader
-        title="技能中心 (Agent Skills)"
-        description="管理与配置开放 Agent Skills（SKILL.md 格式）。技能自动挂载/软链到 Claude Code、Codex、Gemini CLI、Pi、Hermes 等 Agent 原生目录中。"
-        actions={
-          <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={() => fetchSkills()} title="刷新">
-              <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleInstallObsidianBundle}
-              disabled={installingBundle}
-              title="一键安装 kepano/obsidian-skills 中的 5 个官方 Obsidian 技能"
-            >
-              <BookOpen className={cn('mr-1.5 h-4 w-4', installingBundle && 'animate-pulse')} />
-              {installingBundle ? '安装中…' : '安装 Obsidian 技能包'}
-            </Button>
-            <Button variant="outline" size="sm" onClick={() => setShowInstallModal(true)}>
-              <FolderGit2 className="mr-1.5 h-4 w-4" />
-              Git / URL 安装
-            </Button>
-            <Button size="sm" onClick={() => setShowNewModal(true)}>
-              <Plus className="mr-1.5 h-4 w-4" />
-              新建 Skill
-            </Button>
+    <Modal open={props.open} onClose={props.onClose} title="创建新 Skill" className="max-w-3xl">
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium">Skill 标识 ID</label>
+            <Input
+              placeholder="my-custom-skill"
+              value={id}
+              onChange={(e) => setId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+            />
           </div>
-        }
-      />
-
-      {notice && (
-        <div
-          className={cn(
-            'flex items-center justify-between rounded-lg border p-4 text-sm font-medium transition-all',
-            notice.tone === 'success' && 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
-            notice.tone === 'warning' && 'border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-300',
-            notice.tone === 'error' && 'border-rose-500/20 bg-rose-500/10 text-rose-600 dark:text-rose-300'
-          )}
-        >
-          <span>{notice.message}</span>
-          <button onClick={() => setNotice(null)} className="ml-4 opacity-70 hover:opacity-100">
-            ×
-          </button>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium">保存目录 Scope</label>
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value as 'user' | 'workspace')}
+              className="w-full rounded-md border bg-background px-3 py-2 text-xs"
+            >
+              <option value="workspace">Workspace 项目级 (.agentdock/skills/)</option>
+              <option value="user">User 全局级 (~/.agentdock/skills/)</option>
+            </select>
+          </div>
         </div>
-      )}
-
-      {/* Filter Toolbar */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="relative flex-1 max-w-md">
-          <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="搜索 Skill 名称、ID 或描述..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9"
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium">SKILL.md 内容模板</label>
+          <Textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            className="font-mono text-xs min-h-[260px]"
           />
         </div>
-
-        <div className="flex items-center gap-1 rounded-lg border bg-muted/30 p-1 text-xs">
-          <button
-            onClick={() => setScopeFilter('all')}
-            className={cn('rounded-md px-3 py-1.5 font-medium transition-colors', scopeFilter === 'all' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground')}
-          >
-            全部 ({skills.length})
-          </button>
-          <button
-            onClick={() => setScopeFilter('workspace')}
-            className={cn('rounded-md px-3 py-1.5 font-medium transition-colors', scopeFilter === 'workspace' ? 'bg-background shadow-sm text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground hover:text-foreground')}
-          >
-            Workspace 项目级
-          </button>
-          <button
-            onClick={() => setScopeFilter('user')}
-            className={cn('rounded-md px-3 py-1.5 font-medium transition-colors', scopeFilter === 'user' ? 'bg-background shadow-sm text-blue-600 dark:text-blue-400' : 'text-muted-foreground hover:text-foreground')}
-          >
-            User 全局级
-          </button>
-          <button
-            onClick={() => setScopeFilter('builtin')}
-            className={cn('rounded-md px-3 py-1.5 font-medium transition-colors', scopeFilter === 'builtin' ? 'bg-background shadow-sm text-purple-600 dark:text-purple-400' : 'text-muted-foreground hover:text-foreground')}
-          >
-            Builtin 内置级
-          </button>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={props.onClose}>
+            取消
+          </Button>
+          <Button onClick={handleCreate} disabled={creating || !id.trim()}>
+            {creating ? '正在创建...' : '创建并保存'}
+          </Button>
         </div>
       </div>
-
-      {/* Skills Grid */}
-      {loading ? (
-        <div className="py-16 text-center text-sm text-muted-foreground">正在加载 Skill 目录...</div>
-      ) : filteredSkills.length === 0 ? (
-        <EmptyState
-          icon={Sparkles}
-          message={searchQuery ? '没有匹配搜索条件的 Skill' : '当前工作区与系统目录下暂无可用 Skill，可点击上方新建或安装'}
-        />
-      ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {filteredSkills.map((skill) => (
-            <Card
-              key={`${skill.scope}:${skill.id}`}
-              className={cn(
-                'group relative flex flex-col justify-between border p-5 transition-all hover:border-primary/50 hover:shadow-md',
-                !skill.enabled && 'opacity-60 bg-muted/20',
-                skill.overridden && 'border-dashed border-amber-500/40 bg-amber-500/5'
-              )}
-            >
-              <div className="space-y-3">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-semibold text-foreground text-base group-hover:text-primary transition-colors">
-                      {skill.name || skill.id}
-                    </span>
-                    <ScopeBadge scope={skill.scope} />
-                    {skill.overridden && (
-                      <span className="inline-flex items-center gap-1 rounded bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-600 dark:text-amber-400">
-                        <AlertTriangle className="h-3 w-3" /> 被 {skill.overriddenBy} 覆盖
-                      </span>
-                    )}
-                  </div>
-
-                  <label className="relative inline-flex cursor-pointer items-center">
-                    <input
-                      type="checkbox"
-                      checked={skill.enabled}
-                      onChange={() => handleToggleSkill(skill)}
-                      className="peer sr-only"
-                    />
-                    <div className="peer h-5 w-9 rounded-full bg-muted peer-checked:bg-primary peer-focus:outline-none after:absolute after:left-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:bg-background after:transition-all after:content-[''] peer-checked:after:translate-x-full" />
-                  </label>
-                </div>
-
-                <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed min-h-[2.25rem]">
-                  {skill.description || '无详细描述'}
-                </p>
-
-                <div className="text-[11px] text-muted-foreground/80 font-mono truncate bg-muted/40 px-2 py-1 rounded">
-                  {skill.path}
-                </div>
-              </div>
-
-              <div className="mt-4 flex items-center justify-between border-t pt-3 text-xs">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => showSkillDetail(skill)}
-                  className="h-8 text-xs hover:bg-primary/10 hover:text-primary"
-                >
-                  <Code2 className="mr-1.5 h-3.5 w-3.5" />
-                  查看 / 编辑 SKILL.md
-                </Button>
-
-                {skill.scope !== 'builtin' && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleDeleteSkill(skill)}
-                    className="h-8 text-xs text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:hover:bg-rose-950/30"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                )}
-              </div>
-            </Card>
-          ))}
-        </div>
-      )}
-
-      {/* Skill Detail Modal */}
-      {selectedSkill && (
-        <Modal
-          open={!!selectedSkill}
-          onClose={() => setSelectedSkill(null)}
-          title={`Skill 详情: ${selectedSkill.name || selectedSkill.id}`}
-          className="max-w-3xl"
-        >
-          <div className="space-y-4">
-            <div className="flex items-center justify-between border-b pb-3 text-sm">
-              <div className="flex items-center gap-2">
-                <ScopeBadge scope={selectedSkill.scope} />
-                <span className="font-mono text-xs text-muted-foreground">{selectedSkill.path}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                {!isEditingContent ? (
-                  <Button size="sm" variant="outline" onClick={() => setIsEditingContent(true)}>
-                    <Pencil className="mr-1.5 h-3.5 w-3.5" />
-                    编辑 SKILL.md
-                  </Button>
-                ) : (
-                  <Button size="sm" onClick={handleSaveSkillContent}>
-                    保存修改
-                  </Button>
-                )}
-              </div>
-            </div>
-
-            {selectedSkill.helpers && selectedSkill.helpers.length > 0 && (
-              <div className="rounded-md border bg-muted/30 p-3 text-xs">
-                <div className="font-medium text-foreground mb-1.5 flex items-center gap-1.5">
-                  <FileCode className="h-3.5 w-3.5 text-primary" /> 关联 Helper / Script 依赖:
-                </div>
-                <div className="flex flex-wrap gap-1.5">
-                  {selectedSkill.helpers.map((h) => (
-                    <span key={h} className="rounded bg-background px-2 py-0.5 font-mono text-[11px] border">
-                      {h}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {isEditingContent ? (
-              <div className="space-y-2">
-                <Textarea
-                  value={editedContent}
-                  onChange={(e) => setEditedContent(e.target.value)}
-                  className="font-mono text-xs min-h-[350px] leading-relaxed"
-                />
-              </div>
-            ) : (
-              <pre className="max-h-[450px] overflow-auto rounded-lg border bg-muted/40 p-4 font-mono text-xs leading-relaxed whitespace-pre-wrap">
-                {selectedSkill.content}
-              </pre>
-            )}
-          </div>
-        </Modal>
-      )}
-
-      {/* Install Skill Modal */}
-      {showInstallModal && (
-        <Modal
-          open={showInstallModal}
-          onClose={() => setShowInstallModal(false)}
-          title="从 Git / URL 安装 Skill"
-        >
-          <div className="space-y-4">
-            <p className="text-xs text-muted-foreground leading-relaxed">
-              输入社区或 Git 仓库 URL，系统将自动 clone 并解析包含的 SKILL.md。
-            </p>
-
-            <div className="space-y-2">
-              <label className="text-xs font-medium">Git 仓库 URL</label>
-              <Input
-                placeholder="https://github.com/user/agent-skill-example.git"
-                value={installUrl}
-                onChange={(e) => setInstallUrl(e.target.value)}
-              />
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-xs font-medium">安装目标作用域 Scope</label>
-              <div className="flex items-center gap-4 text-xs">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="scope"
-                    checked={installScope === 'user'}
-                    onChange={() => setInstallScope('user')}
-                  />
-                  User 全局级 (~/.agentdock/skills/)
-                </label>
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="scope"
-                    checked={installScope === 'workspace'}
-                    onChange={() => setInstallScope('workspace')}
-                  />
-                  Workspace 项目级 (.agentdock/skills/)
-                </label>
-              </div>
-            </div>
-
-            <div className="flex justify-end gap-2 pt-2">
-              <Button variant="outline" onClick={() => setShowInstallModal(false)}>
-                取消
-              </Button>
-              <Button onClick={handleInstallSkill} disabled={installing || !installUrl.trim()}>
-                {installing ? '正在安装...' : '开始安装'}
-              </Button>
-            </div>
-          </div>
-        </Modal>
-      )}
-
-      {/* New Skill Modal */}
-      {showNewModal && (
-        <Modal
-          open={showNewModal}
-          onClose={() => setShowNewModal(false)}
-          title="创建新 Skill"
-          className="max-w-3xl"
-        >
-          <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-1.5">
-                <label className="text-xs font-medium">Skill 标识 ID (字母数字短横线)</label>
-                <Input
-                  placeholder="my-custom-skill"
-                  value={newSkillId}
-                  onChange={(e) => setNewSkillId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
-                />
-              </div>
-
-              <div className="space-y-1.5">
-                <label className="text-xs font-medium">保存目录 Scope</label>
-                <select
-                  value={newSkillScope}
-                  onChange={(e) => setNewSkillScope(e.target.value as 'user' | 'workspace')}
-                  className="w-full rounded-md border bg-background px-3 py-2 text-xs"
-                >
-                  <option value="workspace">Workspace 项目级 (.agentdock/skills/)</option>
-                  <option value="user">User 全局级 (~/.agentdock/skills/)</option>
-                </select>
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="text-xs font-medium">SKILL.md 内容模板</label>
-              <Textarea
-                value={newSkillContent}
-                onChange={(e) => setNewSkillContent(e.target.value)}
-                className="font-mono text-xs min-h-[260px]"
-              />
-            </div>
-
-            <div className="flex justify-end gap-2 pt-2">
-              <Button variant="outline" onClick={() => setShowNewModal(false)}>
-                取消
-              </Button>
-              <Button onClick={handleCreateSkill} disabled={creating || !newSkillId.trim()}>
-                {creating ? '正在创建...' : '创建并保存'}
-              </Button>
-            </div>
-          </div>
-        </Modal>
-      )}
-    </div>
+    </Modal>
   );
 }
 
@@ -557,6 +678,28 @@ function ScopeBadge({ scope }: { scope: SkillScope }) {
   return (
     <span className="inline-flex items-center rounded bg-purple-500/10 px-2 py-0.5 text-[11px] font-medium text-purple-600 dark:text-purple-400 border border-purple-500/20">
       Builtin
+    </span>
+  );
+}
+
+function SourceStatusBadge({ source }: { source: SkillSource }) {
+  const label = source.sourceRef ? `${source.sourceRepo}@${source.sourceRef}` : source.sourceRepo;
+  if (source.status === 'locally-modified') {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-600 dark:text-amber-400 border border-amber-500/20 font-mono"
+        title="该技能已在本地被编辑修改"
+      >
+        <AlertTriangle className="h-3 w-3" /> {label} (modified)
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground border font-mono"
+      title={`来源: ${label}`}
+    >
+      <GitBranch className="h-3 w-3" /> {label}
     </span>
   );
 }

--- a/src/pages/Skills/useSkillsPageController.ts
+++ b/src/pages/Skills/useSkillsPageController.ts
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { skills as skillsApi } from '@cc/core-sdk';
+import type { SkillInfo, SkillDetail, SkillScope, CuratedSkillPack } from '@cc/superai-contracts/skills';
+
+export type NoticeTone = 'success' | 'error' | 'warning';
+
+export interface NoticeState {
+  tone: NoticeTone;
+  message: string;
+}
+
+export const CURATED_PACKS: CuratedSkillPack[] = [
+  {
+    id: 'mattpocock-skills',
+    repo: 'mattpocock/skills',
+    name: 'Matt Pocock Engineering Skills',
+    description: '面向工程师的真实软件开发技能集（TDD、to-spec、implement、handoff、grill-me、code-review 等）。',
+    stars: '223k★',
+    skillsCount: 7,
+    tags: ['TDD', 'Spec', 'Engineering', 'Workflow'],
+    defaultRef: 'main',
+  },
+  {
+    id: 'superpowers',
+    repo: 'obra/superpowers',
+    name: 'Superpowers Methodology Pack',
+    description: '面向复杂系统架构与工程规范的技能集，包含系统设计、分解、执行与交接标准。',
+    stars: '274k★',
+    skillsCount: 8,
+    tags: ['Architecture', 'Methodology', 'Planning'],
+    defaultRef: 'main',
+  },
+  {
+    id: 'anthropics-skills',
+    repo: 'anthropics/skills',
+    name: 'Anthropic Official Skills',
+    description: 'Anthropic 官方开源的通用 Agent 技能集合，涵盖代码分析、文档处理与工具集成。',
+    stars: '168k★',
+    skillsCount: 12,
+    tags: ['Official', 'General', 'Analysis'],
+    defaultRef: 'main',
+  },
+  {
+    id: 'obsidian-skills',
+    repo: 'kepano/obsidian-skills',
+    name: 'Obsidian Knowledge Pack',
+    description: 'Obsidian 官方 Markdown、Canvas 可视化白板、Bases 数据库与 CLI 操作增强技能集。',
+    stars: '45k★',
+    skillsCount: 5,
+    tags: ['Knowledge', 'Markdown', 'Canvas', 'Obsidian'],
+    defaultRef: 'main',
+  },
+  {
+    id: 'agent-skills',
+    repo: 'addyosmani/agent-skills',
+    name: 'Addy Osmani Agent Skills',
+    description: '专注于全栈工程优化、Web 性能与前端架构重构的高阶 Agent 技能集合。',
+    stars: '85k★',
+    skillsCount: 6,
+    tags: ['Frontend', 'Performance', 'Refactoring'],
+    defaultRef: 'main',
+  },
+];
+
+export function useSkillsPageController() {
+  const [activeTab, setActiveTab] = useState<'installed' | 'browse'>('installed');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [scopeFilter, setScopeFilter] = useState<'all' | SkillScope>('all');
+  const modals = useSkillModalsState();
+  const ops = useSkillOperations(modals.selectedSkill, modals.setSelectedSkill, modals.setShowInstallModal, modals.setInstallUrl, modals.setInstallRef, modals.installUrl, modals.installRef, modals.installScope);
+
+  const filteredSkills = useMemo(() => {
+    return ops.skills.filter((skill) => {
+      if (scopeFilter !== 'all' && skill.scope !== scopeFilter) return false;
+      if (!searchQuery.trim()) return true;
+      const q = searchQuery.toLowerCase();
+      return skill.id.toLowerCase().includes(q) || skill.name.toLowerCase().includes(q) || skill.description.toLowerCase().includes(q);
+    });
+  }, [ops.skills, scopeFilter, searchQuery]);
+
+  const filteredPacks = useMemo(() => {
+    if (!searchQuery.trim()) return CURATED_PACKS;
+    const q = searchQuery.toLowerCase();
+    return CURATED_PACKS.filter((p) => p.name.toLowerCase().includes(q) || p.repo.toLowerCase().includes(q) || p.tags.some((t) => t.toLowerCase().includes(q)));
+  }, [searchQuery]);
+
+  return {
+    activeTab,
+    setActiveTab,
+    searchQuery,
+    setSearchQuery,
+    scopeFilter,
+    setScopeFilter,
+    filteredSkills,
+    filteredPacks,
+    ...modals,
+    ...ops,
+  };
+}
+
+function useSkillModalsState() {
+  const [selectedSkill, setSelectedSkill] = useState<SkillDetail | null>(null);
+  const [showInstallModal, setShowInstallModal] = useState(false);
+  const [installUrl, setInstallUrl] = useState('');
+  const [installRef, setInstallRef] = useState('');
+  const [installScope, setInstallScope] = useState<'user' | 'workspace'>('user');
+  const [showNewModal, setShowNewModal] = useState(false);
+
+  return {
+    selectedSkill,
+    setSelectedSkill,
+    showInstallModal,
+    setShowInstallModal,
+    installUrl,
+    setInstallUrl,
+    installRef,
+    setInstallRef,
+    installScope,
+    setInstallScope,
+    showNewModal,
+    setShowNewModal,
+  };
+}
+
+function useSkillOperations(
+  selectedSkill: SkillDetail | null,
+  setSelectedSkill: (s: SkillDetail | null) => void,
+  setShowInstallModal: (s: boolean) => void,
+  setInstallUrl: (s: string) => void,
+  setInstallRef: (s: string) => void,
+  installUrl: string,
+  installRef: string,
+  installScope: 'user' | 'workspace',
+) {
+  const [skills, setSkills] = useState<SkillInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [notice, setNotice] = useState<NoticeState | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+
+  const fetchSkills = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await skillsApi.listSkills();
+      setSkills(res.skills || []);
+    } catch (err) {
+      setNotice({ tone: 'error', message: `获取 Skill 列表失败: ${String(err)}` });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchSkills(); }, [fetchSkills]);
+
+  const handleToggleSkill = async (skill: SkillInfo) => {
+    try {
+      await skillsApi.toggleSkill({ id: skill.id, enabled: !skill.enabled });
+      setSkills((prev) => prev.map((s) => (s.id === skill.id && s.scope === skill.scope ? { ...s, enabled: !s.enabled } : s)));
+      setNotice({ tone: 'success', message: `已${!skill.enabled ? '启用' : '禁用'} Skill "${skill.name || skill.id}"` });
+    } catch (err) {
+      setNotice({ tone: 'error', message: `状态切换失败: ${String(err)}` });
+    }
+  };
+
+  const handleDeleteSkill = async (skill: SkillInfo) => {
+    if (!confirm(`确定要删除 Skill "${skill.name || skill.id}" 吗？此操作无法撤销。`)) return;
+    try {
+      await skillsApi.deleteSkill({ id: skill.id, scope: skill.scope as 'user' | 'workspace' });
+      setNotice({ tone: 'success', message: `Skill "${skill.name || skill.id}" 已成功删除` });
+      if (selectedSkill?.id === skill.id) setSelectedSkill(null);
+      fetchSkills();
+    } catch (err) {
+      setNotice({ tone: 'error', message: `删除失败: ${String(err)}` });
+    }
+  };
+
+  const handleInstallSkill = async (customRepo?: string, customRef?: string) => {
+    const targetRepo = customRepo || installUrl;
+    if (!targetRepo.trim()) return;
+    setInstalling(true);
+    try {
+      const result = await skillsApi.addSkill({ repo: targetRepo.trim(), ref: customRef || installRef.trim() || undefined, targetScope: installScope });
+      setNotice({ tone: 'success', message: `成功安装 ${result.installed.length} 个 Skill！` });
+      setShowInstallModal(false);
+      setInstallUrl('');
+      setInstallRef('');
+      fetchSkills();
+    } catch (err) {
+      setNotice({ tone: 'error', message: `安装失败: ${String(err)}` });
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const handleUpdateSkill = async (skillId?: string) => {
+    try {
+      const result = await skillsApi.updateSkill({ id: skillId, all: !skillId });
+      if (result.conflicts.length > 0) {
+        setNotice({ tone: 'warning', message: `存在本地修改冲突: ${result.conflicts.map((c) => c.reason).join('; ')}` });
+      } else {
+        setNotice({ tone: 'success', message: `成功更新 ${result.updated.length} 个 Skill` });
+      }
+      fetchSkills();
+    } catch (err) {
+      setNotice({ tone: 'error', message: `更新失败: ${String(err)}` });
+    }
+  };
+
+  const handleVerifySkills = async () => {
+    setVerifying(true);
+    try {
+      const res = await skillsApi.verifySkills();
+      const modified = res.skills.filter((s) => s.status === 'locally-modified');
+      if (modified.length > 0) {
+        setNotice({ tone: 'warning', message: `检测到 ${modified.length} 个技能已被本地修改（${modified.map((s) => s.id).join(', ')}）。` });
+      } else {
+        setNotice({ tone: 'success', message: '所有已安装技能的来源与指纹校验通过 (Clean)。' });
+      }
+      fetchSkills();
+    } catch (err) {
+      setNotice({ tone: 'error', message: `校验失败: ${String(err)}` });
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  return {
+    skills,
+    loading,
+    notice,
+    setNotice,
+    installing,
+    verifying,
+    fetchSkills,
+    handleToggleSkill,
+    handleDeleteSkill,
+    handleInstallSkill,
+    handleUpdateSkill,
+    handleVerifySkills,
+  };
+}

--- a/tests/contracts/skill-distribution.test.ts
+++ b/tests/contracts/skill-distribution.test.ts
@@ -1,0 +1,197 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import { ManagedSkillCatalog } from '../../services/local-ai-core/src/runtime/managed-skill-catalog.js';
+import { LocalSkillSourceStore } from '../../services/local-ai-core/src/acp/store/skill-source-store.js';
+import { ensureLocalCoreAcpSchema } from '../../services/local-ai-core/src/acp/store/schema.js';
+
+function git(cwd: string, ...args: string[]) {
+  execFileSync('git', args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+}
+
+function createTestDb(): LocalSkillSourceStore {
+  const db = new DatabaseSync(':memory:');
+  ensureLocalCoreAcpSchema(db);
+  return new LocalSkillSourceStore(db);
+}
+
+test('.agents/ and .agents/skills/ directory discovery and priority interop', () => {
+  const testRoot = mkdtempSync(join(tmpdir(), 'agentdock-agents-interop-'));
+  try {
+    const builtinDir = join(testRoot, 'builtin');
+    const userDir = join(testRoot, 'user');
+    const workspaceDir = join(testRoot, 'workspace');
+
+    // 1. Builtin
+    mkdirSync(join(builtinDir, 'base-skill'), { recursive: true });
+    writeFileSync(join(builtinDir, 'base-skill', 'SKILL.md'), '---\nname: Builtin Base\n---\n# Builtin\n');
+
+    // 2. User
+    mkdirSync(join(userDir, 'tdd'), { recursive: true });
+    writeFileSync(join(userDir, 'tdd', 'SKILL.md'), '---\nname: User TDD\n---\n# User TDD\n');
+
+    // 3. Workspace .agents/tdd (should override User TDD)
+    mkdirSync(join(workspaceDir, '.agents', 'tdd'), { recursive: true });
+    writeFileSync(join(workspaceDir, '.agents', 'tdd', 'SKILL.md'), '---\nname: Workspace Agents TDD\n---\n# Workspace Agents TDD\n');
+
+    // 4. Workspace .agents/skills/spec (nested .agents/skills layout)
+    mkdirSync(join(workspaceDir, '.agents', 'skills', 'spec'), { recursive: true });
+    writeFileSync(join(workspaceDir, '.agents', 'skills', 'spec', 'SKILL.md'), '---\nname: Workspace Spec\n---\n# Workspace Spec\n');
+
+    // 5. Workspace .agentdock/skills/tdd (should override .agents/tdd)
+    mkdirSync(join(workspaceDir, '.agentdock', 'skills', 'tdd'), { recursive: true });
+    writeFileSync(join(workspaceDir, '.agentdock', 'skills', 'tdd', 'SKILL.md'), '---\nname: AgentDock Workspace TDD\n---\n# AgentDock Workspace TDD\n');
+
+    const catalog = new ManagedSkillCatalog({
+      rootDir: builtinDir,
+      userSkillsDir: userDir,
+      workspacePath: workspaceDir,
+    });
+
+    const skills = catalog.listSkills({ workspacePath: workspaceDir });
+
+    // TDD should resolve to AgentDock workspace
+    const tdd = skills.find((s) => s.id === 'tdd' && !s.overridden);
+    assert(tdd);
+    assert.equal(tdd.scope, 'workspace');
+    assert.equal(tdd.name, 'AgentDock Workspace TDD');
+
+    // Spec should resolve from .agents/skills
+    const spec = skills.find((s) => s.id === 'spec' && !s.overridden);
+    assert(spec);
+    assert.equal(spec.scope, 'workspace');
+    assert.equal(spec.name, 'Workspace Spec');
+
+    // Base skill should resolve from builtin
+    const base = skills.find((s) => s.id === 'base-skill' && !s.overridden);
+    assert(base);
+    assert.equal(base.scope, 'builtin');
+
+    // catalog.get should resolve from workspace
+    const resolvedTdd = catalog.get('tdd', { workspacePath: workspaceDir });
+    assert(resolvedTdd);
+    assert.equal(resolvedTdd.scope, 'workspace');
+    assert.match(resolvedTdd.content, /# AgentDock Workspace TDD/);
+
+    const resolvedSpec = catalog.get('spec', { workspacePath: workspaceDir });
+    assert(resolvedSpec);
+    assert.equal(resolvedSpec.scope, 'workspace');
+    assert.match(resolvedSpec.content, /# Workspace Spec/);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test('installSkillFromSource, content hash tracking, verifySkills, and safe update with conflict detection', async () => {
+  const staging = mkdtempSync(join(tmpdir(), 'agentdock-dist-source-'));
+  const userDir = mkdtempSync(join(tmpdir(), 'agentdock-dist-user-'));
+  try {
+    // Build a mock git repository with 2 skills
+    mkdirSync(join(staging, 'skills', 'tdd'), { recursive: true });
+    writeFileSync(
+      join(staging, 'skills', 'tdd', 'SKILL.md'),
+      '---\nname: TDD Skill\ndescription: Test Driven Development\n---\n# TDD v1\n',
+    );
+    mkdirSync(join(staging, 'skills', 'implement'), { recursive: true });
+    writeFileSync(
+      join(staging, 'skills', 'implement', 'SKILL.md'),
+      '---\nname: Implement Skill\ndescription: Implementation workflow\n---\n# Implement v1\n',
+    );
+    git(staging, 'init', '--quiet', '--initial-branch=main');
+    git(staging, 'add', '.');
+    git(staging, 'commit', '--quiet', '-m', 'initial skills');
+
+    const store = createTestDb();
+    const catalog = new ManagedSkillCatalog({ userSkillsDir: userDir, store });
+
+    // 1. Install from repository
+    const result = await catalog.installSkillFromSource({
+      url: `file://${staging}`,
+      targetScope: 'user',
+    });
+
+    assert.equal(result.installed.length, 2);
+    const ids = result.installed.map((s) => s.id).sort();
+    assert.deepEqual(ids, ['implement', 'tdd']);
+
+    // 2. Verify sources recorded in SQLite
+    const sources = store.listSources();
+    assert.equal(sources.length, 2);
+    const tddSource = store.getSource('tdd', 'user');
+    assert(tddSource);
+    assert.equal(tddSource.contentHash.length, 64); // SHA-256
+
+    // 3. verifySkills reports clean initially
+    const verifyInitial = catalog.verifySkills();
+    assert.equal(verifyInitial.skills.length, 2);
+    for (const item of verifyInitial.skills) {
+      assert.equal(item.status, 'clean');
+    }
+
+    // 4. Modify a local skill file (e.g. self-refining #64 or user edit)
+    const tddFile = join(userDir, 'tdd', 'SKILL.md');
+    writeFileSync(tddFile, '---\nname: TDD Skill\n---\n# TDD v1 Modified Locally\n');
+
+    // 5. verifySkills detects locally-modified
+    const verifyModified = catalog.verifySkills();
+    const tddVerified = verifyModified.skills.find((s) => s.id === 'tdd');
+    assert(tddVerified);
+    assert.equal(tddVerified.status, 'locally-modified');
+
+    const implementVerified = verifyModified.skills.find((s) => s.id === 'implement');
+    assert(implementVerified);
+    assert.equal(implementVerified.status, 'clean');
+
+    // 6. Update upstream repo
+    writeFileSync(
+      join(staging, 'skills', 'tdd', 'SKILL.md'),
+      '---\nname: TDD Skill\ndescription: Test Driven Development\n---\n# TDD v2 Upstream\n',
+    );
+    writeFileSync(
+      join(staging, 'skills', 'implement', 'SKILL.md'),
+      '---\nname: Implement Skill\ndescription: Implementation workflow\n---\n# Implement v2 Upstream\n',
+    );
+    git(staging, 'add', '.');
+    git(staging, 'commit', '--quiet', '-m', 'v2 update');
+
+    // 7. Update without force: tdd should conflict, implement should update
+    const updateResult = await catalog.updateSkill({ all: true, force: false });
+    assert.equal(updateResult.conflicts.length, 1);
+    assert.equal(updateResult.conflicts[0].id, 'tdd');
+    assert.match(updateResult.conflicts[0].reason, /modified locally/);
+
+    assert(updateResult.updated.some((s) => s.id === 'implement'));
+
+    // Verify local modifications on tdd were preserved!
+    assert.match(readFileSync(tddFile, 'utf8'), /Modified Locally/);
+
+    // 8. Update with force: should overwrite tdd
+    const forceUpdate = await catalog.updateSkill({ id: 'tdd', force: true });
+    assert.equal(forceUpdate.updated.length, 1);
+    assert.equal(forceUpdate.conflicts.length, 0);
+    assert.match(readFileSync(tddFile, 'utf8'), /# TDD v2 Upstream/);
+
+    // 9. Delete skill clears both filesystem and SQLite source
+    const deleted = catalog.deleteSkill({ id: 'tdd', scope: 'user' });
+    assert.equal(deleted, true);
+    assert.equal(existsSync(join(userDir, 'tdd')), false);
+    assert.equal(store.getSource('tdd', 'user'), undefined);
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+    rmSync(userDir, { recursive: true, force: true });
+  }
+});

--- a/tests/electron/lac-cli.test.ts
+++ b/tests/electron/lac-cli.test.ts
@@ -972,3 +972,98 @@ test('lac automation add uses local delivery when channel identifiers are incomp
     assert.deepEqual(body?.delivery, { platform: 'local', route: { type: 'local.thread', channelId: 'workspace-1' } });
   } finally { restore(); }
 });
+
+test('lac skill add, list, verify, update, and remove commands', async () => {
+  const requests: Array<{ url: string; method: string; body?: unknown }> = [];
+  const { restore } = withFetchMock(async (input, init) => {
+    const url = String(input);
+    const method = init?.method || 'GET';
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    requests.push({ url, method, body });
+
+    if (url.includes('/skills/add')) {
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          installed: [{ id: 'tdd', name: 'TDD Skill', scope: 'user', path: '/skills/tdd/SKILL.md' }],
+          skipped: [],
+        },
+      }), { headers: { 'content-type': 'application/json' } });
+    }
+    if (url.includes('/skills/verify')) {
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          skills: [{ id: 'tdd', name: 'TDD Skill', scope: 'user', sourceRepo: 'mattpocock/skills', sourceRef: 'main', status: 'clean', path: '/skills/tdd/SKILL.md' }],
+        },
+      }), { headers: { 'content-type': 'application/json' } });
+    }
+    if (url.includes('/skills/update')) {
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          updated: [{ id: 'tdd', name: 'TDD Skill', scope: 'user', path: '/skills/tdd/SKILL.md' }],
+          unchanged: [],
+          conflicts: [],
+        },
+      }), { headers: { 'content-type': 'application/json' } });
+    }
+    if (url.includes('/skills') && method === 'GET') {
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          skills: [{
+            id: 'tdd',
+            name: 'TDD Skill',
+            scope: 'user',
+            path: '/skills/tdd/SKILL.md',
+            enabled: true,
+            source: { skillId: 'tdd', scope: 'user', sourceRepo: 'mattpocock/skills', sourceRef: 'main', status: 'clean' },
+          }],
+        },
+      }), { headers: { 'content-type': 'application/json' } });
+    }
+    if (url.includes('/skills') && method === 'DELETE') {
+      return new Response(JSON.stringify({ ok: true, data: { success: true } }), { headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({ ok: true, data: {} }), { headers: { 'content-type': 'application/json' } });
+  });
+
+  try {
+    const { io, read } = createIo();
+    const env = { LOCAL_AI_CORE_BASE: 'http://127.0.0.1:9831/api/local/v1' };
+
+    // 1. lac skill add
+    const addCode = await runCli(['skill', 'add', 'mattpocock/skills@main', '--scope', 'user'], env, io);
+    assert.equal(addCode, 0);
+    assert.match(read().stdout, /Installed 1 skill/);
+    assert.deepEqual(requests[0], {
+      url: 'http://127.0.0.1:9831/api/local/v1/skills/add',
+      method: 'POST',
+      body: { repo: 'mattpocock/skills@main', targetScope: 'user', force: false },
+    });
+
+    // 2. lac skill list
+    const listCode = await runCli(['skill', 'list'], env, io);
+    assert.equal(listCode, 0);
+    assert.match(read().stdout, /tdd/);
+
+    // 3. lac skill verify
+    const verifyCode = await runCli(['skill', 'verify'], env, io);
+    assert.equal(verifyCode, 0);
+    assert.match(read().stdout, /clean/);
+
+    // 4. lac skill update
+    const updateCode = await runCli(['skill', 'update', 'tdd'], env, io);
+    assert.equal(updateCode, 0);
+    assert.match(read().stdout, /Updated 1 skill/);
+
+    // 5. lac skill remove
+    const removeCode = await runCli(['skill', 'remove', 'tdd'], env, io);
+    assert.equal(removeCode, 0);
+    assert.match(read().stdout, /Deleted skill "tdd"/);
+  } finally {
+    restore();
+  }
+});
+


### PR DESCRIPTION
## Summary

Implements **Issue #91**: Unified skills distribution layer and ecosystem `.agents/` interop for growing Agent skills ecosystems (Claude Code, Codex, Gemini CLI, Pi, OpenCode, Hermes).

## Key Features

1. **Unified CLI Distribution (`lac skill`)**:
   - `lac skill add <owner/repo>[@ref] [--scope user|workspace] [--skills-dir <dir>] [--force]`
   - `lac skill list [--installed] [--workspace <id>]`
   - `lac skill update <name|all> [--force]`
   - `lac skill remove <name> [--scope user|workspace]`
   - `lac skill verify [<name>]`
   - Supports both single-skill repositories (root `SKILL.md`) and monorepo bundle repositories (`skills/*`, `.agents/skills/*`, `.agents/*`).

2. **`.agents/` Root Directory Ecosystem Interop**:
   - Discovers skills in workspace `.agents/` and `.agents/skills/`.
   - Hierarchical precedence order:
     1. Workspace AgentDock: `.agentdock/skills/` (Priority 5)
     2. Workspace Sub-Skills: `.agents/skills/` (Priority 4)
     3. Workspace Agents Root: `.agents/` (Priority 3)
     4. User Global: `~/.agentdock/skills/` (Priority 2)
     5. Built-in: `<app-bundle>/skills/` (Priority 1)

3. **Provenance Tracking & Self-Refining (#64) Fingerprint Protection**:
   - SQLite `skill_sources` table tracks origin repo, ref, install timestamp, and SHA-256 content hash.
   - Deterministic content hashing across skill directory contents.
   - Detects `locally-modified` status when files are edited by users or self-refining agent workflows (#64), preventing unintended upstream overwrites unless `--force` is explicitly passed.

4. **Skills Center UI Overhaul**:
   - Added **Browse & Discover (发现与推荐)** tab with curated high-star skill packs (`mattpocock/skills`, `obra/superpowers`, `anthropics/skills`, `kepano/obsidian-skills`, `addyosmani/agent-skills`) and one-click install.
   - Installed list displays provenance badges (`github:owner/repo@ref`) and `clean` / `locally-modified` status indicators.
   - Added one-click integrity fingerprint verification and update actions.

## Validation & Quality Gates

- `pnpm typecheck`: 0 errors.
- `pnpm lint:gates`:
  - Circular dependencies: 0 (madge gate passed)
  - Duplicate code rate: 0.00% (jscpd gate passed)
  - Dead code: 165 symbols (within <= 171 gate baseline)
  - File size: 0 files > 1000 lines
  - Function length: 45 functions > 100 lines (within <= 45 gate baseline)
  - ESLint complexity: 108 warnings (within <= 108 gate baseline)
- `pnpm test`: 664/664 unit/integration tests passed + 80/80 BDD scenarios passed.
- `pnpm build`: Renderer Vite build and Electron build passed with zero errors.

Closes #91