### PR TITLE
Dedupe default budget form literal in CostDashboard

### DIFF
--- a/src/pages/Cost/CostDashboard.tsx
+++ b/src/pages/Cost/CostDashboard.tsx
@@ -501,6 +501,19 @@ function DeleteConfirmModal({
   );
 }
 
+const DEFAULT_BUDGET_FORM: BudgetCreateInput = {
+  workspaceId: 'default',
+  name: '',
+  scopeKind: 'workspace',
+  scopeId: '',
+  periodKind: 'daily',
+  limitUsd: 5.0,
+  softThreshold: 0.8,
+  hardThreshold: 1.0,
+  action: 'alert_and_skip',
+  enabled: true,
+};
+
 function useCostDashboardData() {
   const [summary, setSummary] = useState<CostSummary | null>(null);
   const [budgets, setBudgets] = useState<Budget[]>([]);
@@ -509,18 +522,7 @@ function useCostDashboardData() {
   const [budgetModalOpen, setBudgetModalOpen] = useState(false);
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null);
   const [deletingBudget, setDeletingBudget] = useState<Budget | null>(null);
-  const [modalForm, setModalForm] = useState<BudgetCreateInput>({
-    workspaceId: 'default',
-    name: '',
-    scopeKind: 'workspace',
-    scopeId: '',
-    periodKind: 'daily',
-    limitUsd: 5.0,
-    softThreshold: 0.8,
-    hardThreshold: 1.0,
-    action: 'alert_and_skip',
-    enabled: true,
-  });
+  const [modalForm, setModalForm] = useState<BudgetCreateInput>(DEFAULT_BUDGET_FORM);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -546,18 +548,7 @@ function useCostDashboardData() {
 
   const openCreateModal = () => {
     setEditingBudget(null);
-    setModalForm({
-      workspaceId: 'default',
-      name: '',
-      scopeKind: 'workspace',
-      scopeId: '',
-      periodKind: 'daily',
-      limitUsd: 5.0,
-      softThreshold: 0.8,
-      hardThreshold: 1.0,
-      action: 'alert_and_skip',
-      enabled: true,
-    });
+    setModalForm(DEFAULT_BUDGET_FORM);
     setBudgetModalOpen(true);
   };
 


### PR DESCRIPTION
## Summary
- Category: **b — code reuse** (daily optimization pass; logs clean — zero new errors in ~20h, one external agent warn)
- `src/pages/Cost/CostDashboard.tsx`: the 11-field default budget-create form literal was duplicated in `useCostDashboardData`'s `useState` initializer and in `openCreateModal`. Extracted a module-level `DEFAULT_BUDGET_FORM: BudgetCreateInput` used by both, matching the existing `DEFAULT_FORM` pattern in `CronList.tsx` and `MonitorList.tsx`.
- Safe by construction: every form edit uses functional spreads (`(prev) => ({ ...prev, ... })`), so the shared reference is never mutated.

## Motivation
jscpd top-10 clone from the freshly merged Cost & Budgets feature (PR #96/#97 area). Continues the de-dup series (#75, #78, #85, #87, #90).

Scanned and declined today: thread-chat hook clones (field-list mirrors between composed hooks — structural, high-risk churn), lark/weixin scheduler plugins (deliberately parallel), core-sdk/knowledge-api header clones (parallel type-import lists), facade forwarding in local-core-acp-store (structural), budget preflight path (single check per run, efficient).

## Review
3 parallel reviewers (reuse / quality / efficiency), 1 round, **all clean**:
- Reuse: no existing default-form factory; literal appeared exactly twice repo-wide, both replaced; follows the established same-file `DEFAULT_FORM` convention.
- Quality: verified every `setModalForm` mutation path immutable; type-checked against `BudgetScopeKind`/`BudgetPeriodKind`/`BudgetAction` unions; no comment needed.
- Efficiency: no render-identity or memoization pitfalls; reset-to-create now reuses a stable reference.

## Validation
- `pnpm test`: 664 pass / 0 fail / 1 skipped; BDD 80 scenarios, 286 steps passed
- Diff: 1 file, +15/−24

🤖 Generated with [Claude Code](https://claude.com/claude-code)