### PR TITLE
Add workspace-level MCP server registry via ACP mcpServers passthrough (Issue #98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ flowchart LR
 
 ## New
 
+### 2026-08-22
+
+- 工作区级 MCP Server 注册表（Issue #98，Phase 1）：在工作区设置的「MCP」标签页统一配置 MCP servers（stdio `command`/`args` 或 http/sse `url`，支持启用开关），Local AI Core 会在 ACP `session/new` / `session/load` 时通过协议原生的 `mcpServers` 字段下发给本工作区的所有 agent 会话——一次配置全局生效，无需再为每个 agent CLI 单独维护 MCP 配置。修改 MCP 列表会自动重建 ACP 会话以应用新配置；未配置时行为与此前完全一致。
+
 ### 2026-08-21
 
 - 统一技能分发层与生态目录互操作（Issue #91）：

--- a/packages/plugin-sdk/src/agents.ts
+++ b/packages/plugin-sdk/src/agents.ts
@@ -16,6 +16,20 @@ export interface AgentLaunchConfig {
   model: string;
   execution?: AgentExecutionDescriptor;
   sandbox?: AgentSandboxLaunchConfig;
+  mcpServers?: AgentMcpServerConfig[];
+}
+
+export type AgentMcpTransportType = 'stdio' | 'sse' | 'http';
+
+export interface AgentMcpServerConfig {
+  name: string;
+  type: AgentMcpTransportType;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+  enabled?: boolean;
 }
 
 export type AgentExecutionMode = 'local' | 'sandbox';

--- a/services/local-ai-core/src/acp/local-core-acp-session-coordinator.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-session-coordinator.ts
@@ -7,6 +7,33 @@ import { LocalCoreAcpTransport } from './local-core-acp-transport.js';
 import type { AcpSessionState, LocalCoreProjectConfig } from '../router/workspace-router-types.js';
 import { getChannelPlatformBase, getChannelPlatformInstanceId, routeTypeForPlatform } from '../scheduler/scheduled-job-route.js';
 import { getPathEnv } from '../runtime/env-utils.js';
+import type { AgentMcpServerConfig } from '@cc/plugin-sdk';
+
+type AcpWireMcpServer = {
+  name: string;
+  type: AgentMcpServerConfig['type'];
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+};
+
+// The ACP session/new|load `mcpServers` field takes the wire shape only — the
+// local `enabled` flag is filtered out before the list leaves Local AI Core.
+function toAcpMcpServers(config: LocalCoreProjectConfig): AcpWireMcpServer[] {
+  return (config.mcpServers || [])
+    .filter((server) => server.enabled !== false)
+    .map((server) => {
+      const wire: AcpWireMcpServer = { name: server.name, type: server.type };
+      if (server.command) wire.command = server.command;
+      if (server.args && server.args.length > 0) wire.args = server.args;
+      if (server.env && Object.keys(server.env).length > 0) wire.env = server.env;
+      if (server.url) wire.url = server.url;
+      if (server.headers && Object.keys(server.headers).length > 0) wire.headers = server.headers;
+      return wire;
+    });
+}
 
 type LocalCoreAcpSessionCoordinatorOptions = {
   store: LocalCoreAcpStore;
@@ -113,7 +140,7 @@ export class LocalCoreAcpSessionCoordinator {
         await this.options.transport.request(session, 'session/load', {
           sessionId: row.acp_session_id,
           cwd: acpSessionCwd(config),
-          mcpServers: [],
+          mcpServers: toAcpMcpServers(config),
         }, 30000);
         session.sessionId = row.acp_session_id;
       } catch (error) {
@@ -126,7 +153,7 @@ export class LocalCoreAcpSessionCoordinator {
       try {
         const created = await this.options.transport.request(session, 'session/new', {
           cwd: acpSessionCwd(config),
-          mcpServers: [],
+          mcpServers: toAcpMcpServers(config),
           _meta: this.buildSessionMeta(threadId, permissionMode),
         }, 30000) as { id?: string; sessionId?: string; session_id?: string; session?: { id?: string; sessionId?: string; session_id?: string } };
         session.sessionId = String(created.sessionId || created.session_id || created.id || created.session?.sessionId || created.session?.session_id || created.session?.id || '').trim();
@@ -316,6 +343,7 @@ export class LocalCoreAcpSessionCoordinator {
       model: config.model || '',
       execution: config.execution || null,
       sandbox: config.sandbox || null,
+      mcpServers: toAcpMcpServers(config),
     });
   }
 

--- a/services/local-ai-core/src/router/workspace-route-config.ts
+++ b/services/local-ai-core/src/router/workspace-route-config.ts
@@ -1,6 +1,6 @@
 import { isAbsolute, resolve } from 'node:path';
 import type { DesktopProjectConfig, DesktopProviderConfig, RuntimeConfigState } from '@cc/superai-contracts';
-import type { AgentLaunchConfig } from '@cc/plugin-sdk';
+import type { AgentLaunchConfig, AgentMcpServerConfig } from '@cc/plugin-sdk';
 import {
   LOCALCORE_ACP_AGENT_TYPE,
   normalizeDesktopAgentModel,
@@ -33,6 +33,79 @@ function resolveAgentModel(project: DesktopProjectConfig, providers: DesktopProv
     rawModel,
     normalizedModel,
   }) || normalizedModel;
+}
+
+function toStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([key, entryValue]) => key && entryValue !== undefined && entryValue !== null)
+    .map(([key, entryValue]) => [key, String(entryValue)]);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+const MCP_TRANSPORT_TYPES = new Set(['stdio', 'sse', 'http']);
+
+function buildMcpServerFields(entry: Record<string, unknown>, command: string, url: string) {
+  const args = Array.isArray(entry.args)
+    ? entry.args.map((value) => String(value ?? '')).filter(Boolean)
+    : undefined;
+  const env = toStringRecord(entry.env);
+  const headers = toStringRecord(entry.headers);
+  return {
+    ...(command ? { command } : {}),
+    ...(args && args.length > 0 ? { args } : {}),
+    ...(env ? { env } : {}),
+    ...(url ? { url } : {}),
+    ...(headers ? { headers } : {}),
+  };
+}
+
+function normalizeMcpServerEntry(raw: unknown): AgentMcpServerConfig | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const entry = raw as Record<string, unknown>;
+  const name = String(entry.name || '').trim();
+  if (!name) {
+    return null;
+  }
+  const type = String(entry.type || 'stdio').trim().toLowerCase();
+  if (!MCP_TRANSPORT_TYPES.has(type)) {
+    return null;
+  }
+  const command = String(entry.command || '').trim();
+  const url = String(entry.url || '').trim();
+  if (type === 'stdio' && !command) {
+    return null;
+  }
+  if (type !== 'stdio' && !url) {
+    return null;
+  }
+  return {
+    name,
+    type: type as AgentMcpServerConfig['type'],
+    ...buildMcpServerFields(entry, command, url),
+    enabled: entry.enabled !== false,
+  };
+}
+
+export function normalizeMcpServerOptions(input: unknown): AgentMcpServerConfig[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const servers: AgentMcpServerConfig[] = [];
+  for (const raw of input) {
+    const server = normalizeMcpServerEntry(raw);
+    if (!server || seen.has(server.name)) {
+      continue;
+    }
+    seen.add(server.name);
+    servers.push(server);
+  }
+  return servers;
 }
 
 export function toLocalCoreProjectConfig(configState: RuntimeConfigState, project: DesktopProjectConfig): AgentLaunchConfig {
@@ -81,6 +154,7 @@ export function toLocalCoreProjectConfig(configState: RuntimeConfigState, projec
       ...env,
     },
     model,
+    mcpServers: normalizeMcpServerOptions(project.agent?.options?.mcp_servers),
   };
   return prepareAgentExecutionLaunch({ configState, project, launchConfig });
 }

--- a/shared/desktop.ts
+++ b/shared/desktop.ts
@@ -589,6 +589,20 @@ export interface DesktopSandboxOptions {
   entrypoint?: string[];
 }
 
+export type DesktopMcpTransportType = 'stdio' | 'sse' | 'http';
+
+export interface DesktopMcpServerOptions {
+  /** Unique server name passed through to the agent via ACP mcpServers. */
+  name: string;
+  type?: DesktopMcpTransportType;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+  enabled?: boolean;
+}
+
 export interface DesktopProjectConfig {
   /** Stable Local AI Core identity. Display-name changes must not change this value. */
   workspace_id?: string;
@@ -598,6 +612,7 @@ export interface DesktopProjectConfig {
     options?: Record<string, unknown> & {
       provider_id?: string;
       sandbox?: DesktopSandboxOptions;
+      mcp_servers?: DesktopMcpServerOptions[];
     };
     /** @deprecated Providers are stored independently and projects should reference options.provider_id. */
     providers?: DesktopProviderConfig[];

--- a/src/pages/Desktop/workspace-components.tsx
+++ b/src/pages/Desktop/workspace-components.tsx
@@ -12,7 +12,7 @@ import {
   type DesktopSandboxProviderConfig,
   type DesktopSandboxRuntimeImage,
 } from '@cc/superai-contracts';
-import { BasicProjectSection, PlatformsSection, ProvidersSection, SandboxSection } from './workspace-sections';
+import { BasicProjectSection, McpServersSection, PlatformsSection, ProvidersSection, SandboxSection } from './workspace-sections';
 import {
   CUSTOM_SELECT_VALUE,
   PLATFORM_TYPE_OPTIONS,
@@ -350,6 +350,66 @@ type ProjectDetailsProps = {
   onSaveConfig: () => void;
 };
 
+const PROJECT_TABS: Array<[ProjectTab, string]> = [
+  ['basic', '基本信息'],
+  ['providers', 'Provider'],
+  ['platforms', '平台接入'],
+  ['sandbox', '云端模式'],
+  ['mcp', 'MCP'],
+];
+
+type ProjectTabContentProps = {
+  project: DesktopProjectConfig;
+  projectTab: ProjectTab;
+  modelProviders: DesktopModelProvider[];
+  sandbox: SandboxForm;
+  profile: DesktopDeploymentProfile;
+  sandboxProvider: DesktopSandboxProviderConfig;
+  runtimeImage: DesktopSandboxRuntimeImage;
+  updateProject: (updater: (project: DesktopProjectConfig) => DesktopProjectConfig) => void;
+  updateSandbox: (updater: (sandbox: SandboxForm) => SandboxForm) => void;
+  updateDeploymentProfile: (profileId: string) => void;
+  openPlatformDialog: (index: number | null) => void;
+};
+
+function ProjectTabContent({
+  project,
+  projectTab,
+  modelProviders,
+  sandbox,
+  profile,
+  sandboxProvider,
+  runtimeImage,
+  updateProject,
+  updateSandbox,
+  updateDeploymentProfile,
+  openPlatformDialog,
+}: ProjectTabContentProps) {
+  if (projectTab === 'basic') {
+    return <BasicProjectSection project={project} updateProject={updateProject} />;
+  }
+  if (projectTab === 'providers') {
+    return <ProvidersSection project={project} modelProviders={modelProviders} updateProject={updateProject} />;
+  }
+  if (projectTab === 'platforms') {
+    return <PlatformsSection project={project} updateProject={updateProject} onOpenPlatformDialog={openPlatformDialog} />;
+  }
+  if (projectTab === 'sandbox') {
+    return (
+      <SandboxSection
+        project={project}
+        sandbox={sandbox}
+        profile={profile}
+        sandboxProvider={sandboxProvider}
+        runtimeImage={runtimeImage}
+        updateSandbox={updateSandbox}
+        updateDeploymentProfile={updateDeploymentProfile}
+      />
+    );
+  }
+  return <McpServersSection project={project} updateProject={updateProject} />;
+}
+
 export function ProjectDetails({
   project,
   sandbox,
@@ -384,16 +444,11 @@ export function ProjectDetails({
           <ProjectOverviewCards project={project} sandbox={sandbox} />
 
           <div className="flex gap-2 overflow-x-auto border-b border-black/10 pb-4 [scrollbar-width:none] dark:border-white/[0.08] [&::-webkit-scrollbar]:hidden sm:flex-wrap">
-            {[
-              ['basic', '基本信息'],
-              ['providers', 'Provider'],
-              ['platforms', '平台接入'],
-              ['sandbox', '云端模式'],
-            ].map(([key, label]) => (
+            {PROJECT_TABS.map(([key, label]) => (
               <button
                 key={key}
                 type="button"
-                onClick={() => setProjectTab(key as ProjectTab)}
+                onClick={() => setProjectTab(key)}
                 className={`app-segment ${
                   projectTab === key
                     ? 'app-segment-active'
@@ -405,37 +460,19 @@ export function ProjectDetails({
             ))}
           </div>
 
-          {projectTab === 'basic' ? (
-            <BasicProjectSection project={project} updateProject={updateProject} />
-          ) : null}
-
-          {projectTab === 'providers' ? (
-            <ProvidersSection
-              project={project}
-              modelProviders={modelProviders}
-              updateProject={updateProject}
-            />
-          ) : null}
-
-          {projectTab === 'platforms' ? (
-            <PlatformsSection
-              project={project}
-              updateProject={updateProject}
-              onOpenPlatformDialog={openPlatformDialog}
-            />
-          ) : null}
-
-          {projectTab === 'sandbox' ? (
-            <SandboxSection
-              project={project}
-              sandbox={sandbox}
-              profile={profile}
-              sandboxProvider={sandboxProvider}
-              runtimeImage={runtimeImage}
-              updateSandbox={updateSandbox}
-              updateDeploymentProfile={updateDeploymentProfile}
-            />
-          ) : null}
+          <ProjectTabContent
+            project={project}
+            projectTab={projectTab}
+            modelProviders={modelProviders}
+            sandbox={sandbox}
+            profile={profile}
+            sandboxProvider={sandboxProvider}
+            runtimeImage={runtimeImage}
+            updateProject={updateProject}
+            updateSandbox={updateSandbox}
+            updateDeploymentProfile={updateDeploymentProfile}
+            openPlatformDialog={openPlatformDialog}
+          />
 
           <div className="flex flex-wrap gap-2 border-t border-black/10 pt-5 dark:border-white/[0.08]">
             <Button className="w-full sm:w-auto" onClick={onSaveConfig} loading={pending === 'config'} disabled={!configDirty && pending !== 'config'}>

--- a/src/pages/Desktop/workspace-model.ts
+++ b/src/pages/Desktop/workspace-model.ts
@@ -6,6 +6,7 @@ import {
 } from '@cc/superai-contracts';
 import type {
   DesktopConnectConfig,
+  DesktopMcpServerOptions,
   DesktopModelProvider,
   DesktopModelProviderInput,
   DesktopPlatformConfig,
@@ -26,7 +27,7 @@ export type Notice = {
   message: string;
 };
 
-export type ProjectTab = 'basic' | 'providers' | 'platforms' | 'sandbox';
+export type ProjectTab = 'basic' | 'providers' | 'platforms' | 'sandbox' | 'mcp';
 
 export type PlatformDialogState = {
   index: number | null;
@@ -218,6 +219,20 @@ export function normalizePlatformDraft(platform: DesktopPlatformConfig): Desktop
     };
   }
   return { type, options };
+}
+
+export const MCP_TYPE_OPTIONS = ['stdio', 'sse', 'http'] as const;
+
+export function createMcpServerDraft(): DesktopMcpServerOptions {
+  return { name: '', type: 'stdio', command: '', args: [], enabled: true };
+}
+
+export function formatMcpArgs(args?: string[]) {
+  return (args || []).join(' ');
+}
+
+export function parseMcpArgs(value: string): string[] {
+  return value.split(/\s+/).map((part) => part.trim()).filter(Boolean);
 }
 
 export function platformSummary(platform: DesktopPlatformConfig) {

--- a/src/pages/Desktop/workspace-sections.tsx
+++ b/src/pages/Desktop/workspace-sections.tsx
@@ -9,6 +9,7 @@ import {
   getDefaultDesktopAgentModel,
   normalizeDesktopAgentModel,
   type DesktopDeploymentProfile,
+  type DesktopMcpServerOptions,
   type DesktopModelProvider,
   type DesktopProjectConfig,
   type DesktopSandboxProviderConfig,
@@ -16,7 +17,11 @@ import {
 } from '@cc/superai-contracts';
 import {
   CUSTOM_SELECT_VALUE,
+  MCP_TYPE_OPTIONS,
+  createMcpServerDraft,
+  formatMcpArgs,
   getSelectValue,
+  parseMcpArgs,
   platformSummary,
   type SandboxForm,
 } from './workspace-model';
@@ -201,6 +206,140 @@ export function PlatformsSection({ project, updateProject, onOpenPlatformDialog 
                 </Button>
               </div>
             </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+type McpServersSectionProps = {
+  project: DesktopProjectConfig;
+  updateProject: ProjectUpdater;
+};
+
+type McpServerCardProps = {
+  server: DesktopMcpServerOptions;
+  index: number;
+  onChange: (patch: Partial<DesktopMcpServerOptions>) => void;
+  onRemove: () => void;
+};
+
+function McpServerCard({ server, index, onChange, onRemove }: McpServerCardProps) {
+  return (
+    <div className="space-y-3 rounded-xl border border-black/10 p-4 dark:border-white/[0.08]">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <Input
+          label="Name"
+          value={server.name}
+          placeholder="unique-server-name"
+          onChange={(event) => onChange({ name: event.target.value })}
+        />
+        <Select
+          label="Transport"
+          value={server.type || 'stdio'}
+          onChange={(event) => onChange({ type: event.target.value as DesktopMcpServerOptions['type'] })}
+        >
+          {MCP_TYPE_OPTIONS.map((type) => <option key={type} value={type}>{type}</option>)}
+        </Select>
+        {server.type === 'stdio' ? (
+          <>
+            <Input
+              label="Command"
+              value={server.command || ''}
+              placeholder="npx"
+              onChange={(event) => onChange({ command: event.target.value })}
+            />
+            <Input
+              label="Args"
+              value={formatMcpArgs(server.args)}
+              placeholder="-y fs-mcp"
+              onChange={(event) => onChange({ args: parseMcpArgs(event.target.value) })}
+            />
+          </>
+        ) : (
+          <Input
+            label="URL"
+            value={server.url || ''}
+            placeholder="https://mcp.example.com/sse"
+            onChange={(event) => onChange({ url: event.target.value })}
+          />
+        )}
+      </div>
+      <div className="flex items-center justify-between">
+        <label className="flex items-center gap-2 text-sm text-slate-950 dark:text-white">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-black/20 dark:border-white/20"
+            checked={server.enabled !== false}
+            onChange={(event) => onChange({ enabled: event.target.checked })}
+          />
+          Enabled
+        </label>
+        <Button
+          variant="danger"
+          size="sm"
+          className="app-icon-button"
+          aria-label={`Remove ${server.name || `server ${index + 1}`}`}
+          onClick={onRemove}
+        >
+          <Trash2 size={14} />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function McpServersSection({ project, updateProject }: McpServersSectionProps) {
+  const servers: DesktopMcpServerOptions[] = Array.isArray(project.agent?.options?.mcp_servers)
+    ? project.agent.options.mcp_servers
+    : [];
+
+  const updateServers = (updater: (current: DesktopMcpServerOptions[]) => DesktopMcpServerOptions[]) => {
+    updateProject((current) => ({
+      ...current,
+      agent: {
+        ...current.agent,
+        options: {
+          ...(current.agent.options || {}),
+          mcp_servers: updater(
+            Array.isArray(current.agent?.options?.mcp_servers) ? current.agent.options.mcp_servers : [],
+          ),
+        },
+      },
+    }));
+  };
+
+  const updateServer = (index: number, patch: Partial<DesktopMcpServerOptions>) => {
+    updateServers((current) => current.map((server, i) => (i === index ? { ...server, ...patch } : server)));
+  };
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-950 dark:text-white">MCP Servers</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            通过 ACP mcpServers 透传给本工作区的所有 Agent 会话，一次配置全局生效。
+          </p>
+        </div>
+        <Button size="sm" variant="secondary" onClick={() => updateServers((current) => [...current, createMcpServerDraft()])}>
+          <Plus size={14} /> Server
+        </Button>
+      </div>
+
+      {servers.length === 0 ? (
+        <EmptyState message="No MCP servers configured." />
+      ) : (
+        <div className="space-y-3">
+          {servers.map((server, index) => (
+            <McpServerCard
+              key={index}
+              server={server}
+              index={index}
+              onChange={(patch) => updateServer(index, patch)}
+              onRemove={() => updateServers((current) => current.filter((_, i) => i !== index))}
+            />
           ))}
         </div>
       )}

--- a/tests/integration/workspace-mcp-servers.test.ts
+++ b/tests/integration/workspace-mcp-servers.test.ts
@@ -1,0 +1,251 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AgentLaunchConfig } from '../../packages/plugin-sdk/src/index.js';
+import type { DesktopProjectConfig, RuntimeConfigState } from '../../packages/contracts/src/index.js';
+import {
+  normalizeMcpServerOptions,
+  toLocalCoreProjectConfig,
+} from '../../services/local-ai-core/src/router/workspace-route-config.js';
+import { LocalCoreAcpSessionCoordinator } from '../../services/local-ai-core/src/acp/local-core-acp-session-coordinator.js';
+import { LocalCoreAcpStore } from '../../services/local-ai-core/src/acp/local-core-acp-store.js';
+import type { LocalCoreAcpTransport } from '../../services/local-ai-core/src/acp/local-core-acp-transport.js';
+
+function configState(path: string): RuntimeConfigState {
+  return {
+    storage: 'sqlite',
+    databasePath: path,
+    baseDir: tmpdir(),
+    config: { projects: [] },
+  };
+}
+
+function mcpProject(mcpServers: unknown): DesktopProjectConfig {
+  return {
+    name: 'mcp-project',
+    agent: {
+      type: '',
+      options: {
+        work_dir: '.',
+        command: process.execPath,
+        mcp_servers: mcpServers as any,
+      },
+      providers: [],
+    },
+    platforms: [],
+  };
+}
+
+test('normalizeMcpServerOptions keeps valid stdio and http entries', () => {
+  const normalized = normalizeMcpServerOptions([
+    { name: ' fs ', command: 'npx', args: ['-y', 1], env: { KEY: 'value' } },
+    { name: 'remote', type: 'http', url: 'https://mcp.example.com/sse', headers: { Authorization: 'Bearer token' } },
+    { name: 'disabled-one', type: 'stdio', command: 'uvx', enabled: false },
+  ]);
+
+  assert.deepEqual(normalized, [
+    { name: 'fs', type: 'stdio', command: 'npx', args: ['-y', '1'], env: { KEY: 'value' }, enabled: true },
+    {
+      name: 'remote',
+      type: 'http',
+      url: 'https://mcp.example.com/sse',
+      headers: { Authorization: 'Bearer token' },
+      enabled: true,
+    },
+    { name: 'disabled-one', type: 'stdio', command: 'uvx', enabled: false },
+  ]);
+});
+
+test('normalizeMcpServerOptions drops invalid entries and dedupes names', () => {
+  const normalized = normalizeMcpServerOptions([
+    { command: 'missing-name' },
+    { name: 'no-command' },
+    { name: 'no-url', type: 'http' },
+    { name: 'bad-type', type: 'grpc', command: 'x' },
+    { name: 'dup', command: 'first' },
+    { name: 'dup', command: 'second' },
+  ]);
+
+  assert.deepEqual(normalized, [
+    { name: 'dup', type: 'stdio', command: 'first', enabled: true },
+  ]);
+});
+
+test('normalizeMcpServerOptions returns empty list for non-array input', () => {
+  assert.deepEqual(normalizeMcpServerOptions(undefined), []);
+  assert.deepEqual(normalizeMcpServerOptions('nope'), []);
+  assert.deepEqual(normalizeMcpServerOptions([null, 42]), []);
+});
+
+test('toLocalCoreProjectConfig maps agent options mcp_servers into the launch config', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agentdock-mcp-route-'));
+  try {
+    const config = toLocalCoreProjectConfig(
+      configState(join(dir, 'local-core.db')),
+      mcpProject([{ name: 'fs', command: 'npx', args: ['-y', 'fs-mcp'] }]),
+    );
+
+    assert.deepEqual(config.mcpServers, [
+      { name: 'fs', type: 'stdio', command: 'npx', args: ['-y', 'fs-mcp'], enabled: true },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+type CoordinatorHarness = {
+  coordinator: LocalCoreAcpSessionCoordinator;
+  store: LocalCoreAcpStore;
+  requests: Array<{ method: string; params: any }>;
+  spawned: any[];
+  closed: any[];
+  dir: string;
+};
+
+function createCoordinatorHarness(): CoordinatorHarness {
+  const dir = mkdtempSync(join(tmpdir(), 'agentdock-mcp-acp-'));
+  const store = new LocalCoreAcpStore(dir);
+  const requests: Array<{ method: string; params: any }> = [];
+  const spawned: any[] = [];
+  const closed: any[] = [];
+  let spawnCount = 0;
+  const transport = {
+    spawnSession: (input: any) => {
+      spawnCount += 1;
+      const session = {
+        child: { kill: () => {}, stdout: { on: () => {} }, stderr: { on: () => {} } },
+        requestId: 0,
+        stdoutBuffer: '',
+        pending: new Map(),
+        sessionId: '',
+        supportsLoad: true,
+        workspaceId: input.config.workspaceId,
+        threadId: input.threadId,
+        bridgeSessionKey: input.bridgeSessionKey,
+        currentRunId: null,
+        currentTurn: null,
+        loadReplayMode: false,
+        pendingPermissionByRun: new Map(),
+        schedulerJobCreatedByRun: new Map(),
+        closed: false,
+        closeReason: null,
+        promptPromise: null,
+        launchPermissionMode: '',
+      };
+      spawned.push(session);
+      return session;
+    },
+    initializeSession: async () => {},
+    request: async (_session: any, method: string, params: any) => {
+      requests.push({ method, params });
+      if (method === 'session/new') {
+        return { sessionId: `acp-new-${spawnCount}` };
+      }
+      return {};
+    },
+    closeSession: (session: any) => {
+      session.closed = true;
+      closed.push(session);
+    },
+  } as unknown as LocalCoreAcpTransport;
+  const coordinator = new LocalCoreAcpSessionCoordinator({
+    store,
+    transport,
+    runThreadMap: new Map<string, string>(),
+    emitBridge: () => {},
+    log: () => {},
+  });
+  return { coordinator, store, requests, spawned, closed, dir };
+}
+
+function launchConfig(mcpServers?: AgentLaunchConfig['mcpServers']): AgentLaunchConfig {
+  return {
+    workspaceId: 'mcp-workspace',
+    agentType: 'pi',
+    workDir: tmpdir(),
+    command: process.execPath,
+    args: [],
+    env: {},
+    model: '',
+    ...(mcpServers ? { mcpServers } : {}),
+  };
+}
+
+test('ensureSession passes enabled MCP servers to session/new', async () => {
+  const harness = createCoordinatorHarness();
+  try {
+    const thread = harness.store.createThread('mcp-workspace', 'MCP thread', 'pi');
+    await harness.coordinator.ensureSession(thread.id, `session:${thread.id}`, launchConfig([
+      { name: 'fs', type: 'stdio', command: 'npx', args: ['-y', 'fs-mcp'], env: { KEY: 'v' }, enabled: true },
+      { name: 'off', type: 'http', url: 'https://mcp.example.com', enabled: false },
+    ]));
+
+    const newRequest = harness.requests.find((request) => request.method === 'session/new');
+    assert.ok(newRequest, 'session/new should be requested');
+    assert.deepEqual(newRequest.params.mcpServers, [
+      { name: 'fs', type: 'stdio', command: 'npx', args: ['-y', 'fs-mcp'], env: { KEY: 'v' } },
+    ]);
+  } finally {
+    rmSync(harness.dir, { recursive: true, force: true });
+  }
+});
+
+test('ensureSession keeps mcpServers empty when none are configured', async () => {
+  const harness = createCoordinatorHarness();
+  try {
+    const thread = harness.store.createThread('mcp-workspace', 'MCP thread', 'pi');
+    await harness.coordinator.ensureSession(thread.id, `session:${thread.id}`, launchConfig());
+
+    const newRequest = harness.requests.find((request) => request.method === 'session/new');
+    assert.deepEqual(newRequest?.params.mcpServers, []);
+  } finally {
+    rmSync(harness.dir, { recursive: true, force: true });
+  }
+});
+
+test('ensureSession passes enabled MCP servers to session/load for resumable threads', async () => {
+  const harness = createCoordinatorHarness();
+  try {
+    const thread = harness.store.createThread('mcp-workspace', 'MCP thread', 'pi');
+    harness.store.updateThreadSession(thread.id, 'acp-existing', true);
+    await harness.coordinator.ensureSession(thread.id, `session:${thread.id}`, launchConfig([
+      { name: 'remote', type: 'http', url: 'https://mcp.example.com', enabled: true },
+    ]));
+
+    const loadRequest = harness.requests.find((request) => request.method === 'session/load');
+    assert.ok(loadRequest, 'session/load should be requested');
+    assert.deepEqual(loadRequest.params.mcpServers, [
+      { name: 'remote', type: 'http', url: 'https://mcp.example.com' },
+    ]);
+    assert.equal(harness.requests.some((request) => request.method === 'session/new'), false);
+  } finally {
+    rmSync(harness.dir, { recursive: true, force: true });
+  }
+});
+
+test('changing the MCP server list rebuilds the session', async () => {
+  const harness = createCoordinatorHarness();
+  try {
+    const thread = harness.store.createThread('mcp-workspace', 'MCP thread', 'pi');
+    const bridgeKey = `session:${thread.id}`;
+    await harness.coordinator.ensureSession(thread.id, bridgeKey, launchConfig());
+    assert.equal(harness.spawned.length, 1);
+
+    await harness.coordinator.ensureSession(thread.id, bridgeKey, launchConfig([
+      { name: 'fs', type: 'stdio', command: 'npx', enabled: true },
+    ]));
+
+    assert.equal(harness.spawned.length, 2, 'a changed MCP list must rebuild the session');
+    assert.equal(harness.closed.length, 1, 'the previous session must be closed');
+    // The rebuilt session resumes the persisted ACP session via session/load,
+    // which must carry the updated server list.
+    const loadRequest = harness.requests.find((request) => request.method === 'session/load');
+    assert.deepEqual(loadRequest?.params.mcpServers, [
+      { name: 'fs', type: 'stdio', command: 'npx' },
+    ]);
+  } finally {
+    rmSync(harness.dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

AgentDock had zero MCP support: the ACP `session/new` / `session/load` calls hardcoded `mcpServers: []`, and users had to configure the same MCP server separately for every agent CLI. This implements Issue #98's Phase 1: a workspace-level MCP server registry that Local AI Core injects into every managed agent session through the protocol-native `mcpServers` field — configure once, applies to all agents in the workspace.

## Changes

- `shared/desktop.ts`: `DesktopMcpServerOptions` / `DesktopMcpTransportType` types; `agent.options.mcp_servers` persisted config field.
- `packages/plugin-sdk/src/agents.ts`: `AgentMcpServerConfig` + `AgentLaunchConfig.mcpServers`.
- `workspace-route-config.ts`: `normalizeMcpServerOptions` — trims/validates entries (required unique name; stdio requires `command`, http/sse requires `url`; unknown transports dropped; args/env/headers coerced to strings; `enabled !== false`).
- `local-core-acp-session-coordinator.ts`: `toAcpMcpServers` filters disabled servers and strips the local `enabled` flag before passing the wire shape to `session/new` and `session/load` (replacing both `mcpServers: []` placeholders).
- Workspace UI: new「MCP」project tab — server cards with name/transport/command+args (stdio) or URL (http/sse), enable toggle, add/remove; saved through the existing config save flow.
- README "New" entry for 2026-08-22.

## Implementation

The config flows through the existing launch pipeline: `agent.options.mcp_servers` → `toLocalCoreProjectConfig` → `AgentLaunchConfig.mcpServers` → coordinator. `buildLaunchConfigKey` now includes the wire-form server list, so editing the MCP list no longer reuses the existing ACP session — it rebuilds, and the new session receives the updated servers (`session/load` for resumable threads, `session/new` otherwise). Two component extractions (`ProjectTabContent`, `McpServerCard`) keep the ESLint complexity cap and function-length gate at their baselines.

## Testing

- `node --import tsx --test tests/integration/workspace-mcp-servers.test.ts` — 8 new tests: normalization (valid stdio/http, invalid dropped, dedupe, non-array input), `toLocalCoreProjectConfig` mapping, `session/new` passthrough (disabled excluded), empty-list backwards compatibility (`mcpServers: []`), `session/load` passthrough, and MCP-list-change forcing a session rebuild. All pass.
- `pnpm test` — full suite 672 pass / 0 fail; BDD 80 scenarios pass.
- `pnpm typecheck` clean; `lint:circular` 0 cycles; `lint:duplicate` 0.00%; `lint:function-length` at baseline 45; `lint:complexity:gate` at baseline 108 warnings. (`lint-dead-code`/knip cannot run in this sandbox due to the known oxc-parser 2GiB raw-transfer crash; CI is authoritative — no new unused exports are introduced, all new symbols are consumed.)
- Renderer UI follows the existing workspace section patterns and compiles via `build:renderer`; interactive browser verification of the new tab was not possible in this environment.

## Compatibility

No breaking changes. `mcp_servers` is optional and absent by default — behavior is byte-identical to before (empty `mcpServers` array on the wire). No API, CLI, or migration changes.

## Risk

Low. Invalid config entries are dropped silently rather than failing session creation; agents that ignore the ACP `mcpServers` field are unaffected. Secrets in `env`/`headers` live in the existing config file with the same protection as agent env vars today.

## Issue

Closes #98