### PR TITLE
Dedupe provider contract fields and shared row action buttons

### DIFF
--- a/shared/desktop.ts
+++ b/shared/desktop.ts
@@ -414,18 +414,8 @@ export interface DesktopModelProvider extends DesktopProviderConfig {
   updatedAt: string;
 }
 
-export interface DesktopModelProviderInput {
+export interface DesktopModelProviderInput extends DesktopProviderConfig {
   id?: string;
-  name: string;
-  api_key?: string;
-  base_url?: string;
-  model?: string;
-  models?: DesktopProviderModelConfig[];
-  thinking?: string;
-  env?: Record<string, string>;
-  unit_price_in?: number;
-  unit_price_out?: number;
-  unit_price_cache?: number;
 }
 
 export interface DesktopModelProviderListResponse {

--- a/src/components/ui/RowActions.tsx
+++ b/src/components/ui/RowActions.tsx
@@ -1,0 +1,33 @@
+import { Pencil, Play, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from './Button';
+
+interface RowActionLabels {
+  run: string;
+  edit: string;
+  delete: string;
+}
+
+interface RowActionsProps {
+  labels: RowActionLabels;
+  onRun: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  className?: string;
+}
+
+export function RowActions({ labels, onRun, onEdit, onDelete, className }: RowActionsProps) {
+  return (
+    <div className={cn('flex shrink-0 gap-2', className)}>
+      <Button variant="secondary" size="sm" className="app-icon-button" onClick={onRun} title={labels.run} aria-label={labels.run}>
+        <Play size={14} />
+      </Button>
+      <Button variant="secondary" size="sm" className="app-icon-button" onClick={onEdit} title={labels.edit} aria-label={labels.edit}>
+        <Pencil size={14} />
+      </Button>
+      <Button variant="danger" size="sm" className="app-icon-button" onClick={onDelete} title={labels.delete} aria-label={labels.delete}>
+        <Trash2 size={14} />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -13,4 +13,5 @@ export { Modal } from './Modal';
 export { Input, Textarea } from './Input';
 export { Select } from './Select';
 export { EmptyState } from './EmptyState';
+export { RowActions } from './RowActions';
 export { AdvancedDrawer, PageHeader, SectionCard, StatusPill } from './Page';

--- a/src/pages/Automation/MonitorList.tsx
+++ b/src/pages/Automation/MonitorList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Bell, Pencil, Play, Plus, Trash2 } from 'lucide-react';
+import { Bell, Plus } from 'lucide-react';
 import { subscribeEvents } from '@cc/core-sdk/runtime';
 import {
   createAutomationMonitor as createMonitor,
@@ -11,7 +11,7 @@ import {
 } from '@cc/core-sdk/automation';
 import { listWorkspaces } from '@cc/core-sdk/threads';
 import type { AutomationMonitor as Monitor, AutomationMonitorCreateInput as MonitorCreateInput } from '@cc/superai-contracts';
-import { Badge, Button, Card, EmptyState, Input, Modal, PageHeader, Select, Textarea } from '@/components/ui';
+import { Badge, Button, Card, EmptyState, Input, Modal, PageHeader, RowActions, Select, Textarea } from '@/components/ui';
 import { formatTime } from '@/lib/utils';
 
 type MonitorFormState = {
@@ -224,17 +224,12 @@ export default function MonitorList() {
                   <p className="mt-3 line-clamp-3 rounded-[16px] bg-black/[0.035] px-3 py-2 text-sm leading-6 text-gray-700 dark:bg-white/[0.05] dark:text-gray-300">{monitor.promptTemplate}</p>
                   {monitor.lastError && <p className="mt-2 text-xs text-red-500">{monitor.lastError}</p>}
                 </div>
-                <div className="flex shrink-0 gap-2">
-                  <Button variant="secondary" size="sm" className="app-icon-button" onClick={() => handleRun(monitor.id)} title={t('monitors.run')} aria-label={t('monitors.run')}>
-                    <Play size={14} />
-                  </Button>
-                  <Button variant="secondary" size="sm" className="app-icon-button" onClick={() => openEdit(monitor)} title={t('common.save')} aria-label={t('common.save')}>
-                    <Pencil size={14} />
-                  </Button>
-                  <Button variant="danger" size="sm" className="app-icon-button" onClick={() => handleDelete(monitor.id)} title={t('common.delete')} aria-label={t('common.delete')}>
-                    <Trash2 size={14} />
-                  </Button>
-                </div>
+                <RowActions
+                  labels={{ run: t('monitors.run'), edit: t('common.save'), delete: t('common.delete') }}
+                  onRun={() => handleRun(monitor.id)}
+                  onEdit={() => openEdit(monitor)}
+                  onDelete={() => handleDelete(monitor.id)}
+                />
               </div>
             </Card>
           ))}

--- a/src/pages/Automation/MonitorList.tsx
+++ b/src/pages/Automation/MonitorList.tsx
@@ -225,7 +225,7 @@ export default function MonitorList() {
                   {monitor.lastError && <p className="mt-2 text-xs text-red-500">{monitor.lastError}</p>}
                 </div>
                 <RowActions
-                  labels={{ run: t('monitors.run'), edit: t('common.save'), delete: t('common.delete') }}
+                  labels={{ run: t('monitors.run'), edit: t('monitors.edit'), delete: t('common.delete') }}
                   onRun={() => handleRun(monitor.id)}
                   onEdit={() => openEdit(monitor)}
                   onDelete={() => handleDelete(monitor.id)}

--- a/src/pages/Cron/CronList.tsx
+++ b/src/pages/Cron/CronList.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Clock, Pencil, Play, Plus, Trash2 } from 'lucide-react';
+import { Clock, Plus } from 'lucide-react';
 import { subscribeEvents } from '@cc/core-sdk/runtime';
 import {
   createScheduledJob as createCronJob,
@@ -11,7 +11,7 @@ import {
 } from '@cc/core-sdk/scheduler';
 import { listWorkspaces } from '@cc/core-sdk/threads';
 import type { ScheduledJob as CronJob, ScheduledJobCreateInput as CronJobCreateInput } from '@cc/superai-contracts';
-import { Badge, Button, Card, EmptyState, Input, Modal, PageHeader, Select, Textarea } from '@/components/ui';
+import { Badge, Button, Card, EmptyState, Input, Modal, PageHeader, RowActions, Select, Textarea } from '@/components/ui';
 import { formatTime } from '@/lib/utils';
 
 type SchedulerFormState = {
@@ -280,17 +280,13 @@ export default function CronList() {
                   <p className="mt-3 line-clamp-3 rounded-[16px] bg-black/[0.035] px-3 py-2 text-sm leading-6 text-gray-700 dark:bg-white/[0.05] dark:text-gray-300">{job.promptTemplate}</p>
                   {job.lastError && <p className="text-xs text-red-500 mt-2">{job.lastError}</p>}
                 </div>
-                <div className="flex shrink-0 gap-2 lg:pt-0">
-                  <Button size="sm" variant="secondary" className="app-icon-button" onClick={() => void handleRun(job.id)} aria-label="Run now">
-                    <Play size={14} />
-                  </Button>
-                  <Button size="sm" variant="secondary" className="app-icon-button" onClick={() => openEdit(job)} aria-label="Edit job">
-                    <Pencil size={14} />
-                  </Button>
-                  <Button size="sm" variant="danger" className="app-icon-button" onClick={() => void handleDelete(job.id)} aria-label="Delete job">
-                    <Trash2 size={14} />
-                  </Button>
-                </div>
+                <RowActions
+                  className="lg:pt-0"
+                  labels={{ run: 'Run now', edit: 'Edit job', delete: 'Delete job' }}
+                  onRun={() => void handleRun(job.id)}
+                  onEdit={() => openEdit(job)}
+                  onDelete={() => void handleDelete(job.id)}
+                />
               </div>
             </Card>
           ))}


### PR DESCRIPTION
## Summary
- `shared/desktop.ts`: `DesktopModelProviderInput` re-declared all 10 fields of `DesktopProviderConfig`; it now `extends DesktopProviderConfig` (adding only `id?`), mirroring `DesktopModelProvider` and removing drift risk in the shared contract that both renderer and backend compilations consume (type-only, no runtime change)
- Extract the duplicated Play/Edit/Delete icon-button row from `MonitorList` and `CronList` into a new presentation-only `RowActions` component (`src/components/ui/RowActions.tsx`), exported via the ui barrel
- Fix the monitor edit pencil label: was `t('common.save')` ("Save"), now `t('monitors.edit')` ("Edit monitor"/"编辑监控"; locales without a `monitors` block already fall back to en on this page)
- Cron action buttons gain `title` tooltips (they previously had aria-labels only)

Part of the ongoing `lint:duplicate` de-dup series (#75, #78, #82, #85, #87, #90, #94, #97). Category: refactor/code-reuse.

## Review
Three parallel review passes (code reuse / code quality / efficiency) over `git diff main...HEAD`:
- Reuse: extraction layer and interface direction confirmed correct; no other genuine Play/Edit/Delete icon rows found to adopt `RowActions` yet; flagged the mislabeled edit button (fixed in round 2)
- Quality: verified all 20 `DesktopModelProviderInput` consumers are structural — no breakage; a11y unchanged or improved
- Efficiency: no meaningful render/bundle impact; memoization correctly rejected as premature

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test`: 664 pass / 0 fail / 1 skipped; BDD 80 scenarios / 286 steps
- [x] `lint:gates`: circular, duplicate, file-size, function-length, complexity all pass (dead-code gate fails only locally due to oxc-parser memory limits on this 3.6GB box — environmental, CI unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)