### PR TITLE
Share recursive skill file walker via kernel fs-walk module

### DIFF
--- a/services/local-ai-core/src/kernel/fs-walk.ts
+++ b/services/local-ai-core/src/kernel/fs-walk.ts
@@ -1,0 +1,27 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SKILL_TREE_SKIP_DIRS = new Set(['.git', 'node_modules']);
+
+export function collectFilesRecursive(root: string, includeFile?: (name: string) => boolean): string[] {
+  const files: string[] = [];
+  walkFiles(root, includeFile, files);
+  files.sort();
+  return files;
+}
+
+function walkFiles(current: string, includeFile: ((name: string) => boolean) | undefined, files: string[]): void {
+  try {
+    const entries = readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (SKILL_TREE_SKIP_DIRS.has(entry.name)) continue;
+        walkFiles(join(current, entry.name), includeFile, files);
+      } else if (entry.isFile() && !entry.isSymbolicLink() && (!includeFile || includeFile(entry.name))) {
+        files.push(join(current, entry.name));
+      }
+    }
+  } catch {
+    // Skip directories that cannot be read
+  }
+}

--- a/services/local-ai-core/src/runtime/skill-distribution-service.ts
+++ b/services/local-ai-core/src/runtime/skill-distribution-service.ts
@@ -16,30 +16,35 @@ export interface DiscoveredSkill {
   content: string;
 }
 
+const SKILL_TREE_SKIP_DIRS = new Set(['.git', 'node_modules']);
+
+export function collectFilesRecursive(root: string, includeFile?: (name: string) => boolean): string[] {
+  const files: string[] = [];
+  walkFiles(root, includeFile, files);
+  files.sort();
+  return files;
+}
+
+function walkFiles(current: string, includeFile: ((name: string) => boolean) | undefined, files: string[]): void {
+  try {
+    const entries = readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (SKILL_TREE_SKIP_DIRS.has(entry.name)) continue;
+        walkFiles(join(current, entry.name), includeFile, files);
+      } else if (entry.isFile() && !entry.isSymbolicLink() && (!includeFile || includeFile(entry.name))) {
+        files.push(join(current, entry.name));
+      }
+    }
+  } catch {
+    // Skip directories that cannot be read
+  }
+}
+
 export function computeSkillContentHash(skillDir: string): string {
   if (!existsSync(skillDir)) return '';
   const hash = createHash('sha256');
-  const filePaths: string[] = [];
-
-  function collectFiles(current: string) {
-    try {
-      const entries = readdirSync(current, { withFileTypes: true });
-      for (const entry of entries) {
-        const fullPath = join(current, entry.name);
-        if (entry.isDirectory()) {
-          if (entry.name === '.git' || entry.name === 'node_modules') continue;
-          collectFiles(fullPath);
-        } else if (entry.isFile() && !entry.isSymbolicLink()) {
-          filePaths.push(fullPath);
-        }
-      }
-    } catch {
-      // Skip directories that cannot be read
-    }
-  }
-
-  collectFiles(skillDir);
-  filePaths.sort();
+  const filePaths = collectFilesRecursive(skillDir);
 
   for (const filePath of filePaths) {
     const relPath = relative(skillDir, filePath).replace(/\\/g, '/');

--- a/services/local-ai-core/src/runtime/skill-distribution-service.ts
+++ b/services/local-ai-core/src/runtime/skill-distribution-service.ts
@@ -6,6 +6,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { SkillInfo, SkillScope, SkillSource, SkillSourceStatus, UpdateSkillResult, VerifySkillResult } from '@cc/superai-contracts/skills';
 import type { LocalSkillSourceStore } from '../acp/store/skill-source-store.js';
+import { collectFilesRecursive } from '../kernel/fs-walk.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -14,31 +15,6 @@ export interface DiscoveredSkill {
   sourceDir: string;
   metadata: Record<string, unknown>;
   content: string;
-}
-
-const SKILL_TREE_SKIP_DIRS = new Set(['.git', 'node_modules']);
-
-export function collectFilesRecursive(root: string, includeFile?: (name: string) => boolean): string[] {
-  const files: string[] = [];
-  walkFiles(root, includeFile, files);
-  files.sort();
-  return files;
-}
-
-function walkFiles(current: string, includeFile: ((name: string) => boolean) | undefined, files: string[]): void {
-  try {
-    const entries = readdirSync(current, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        if (SKILL_TREE_SKIP_DIRS.has(entry.name)) continue;
-        walkFiles(join(current, entry.name), includeFile, files);
-      } else if (entry.isFile() && !entry.isSymbolicLink() && (!includeFile || includeFile(entry.name))) {
-        files.push(join(current, entry.name));
-      }
-    }
-  } catch {
-    // Skip directories that cannot be read
-  }
 }
 
 export function computeSkillContentHash(skillDir: string): string {

--- a/services/local-ai-core/src/security/skill-content-scan.ts
+++ b/services/local-ai-core/src/security/skill-content-scan.ts
@@ -1,5 +1,6 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { collectFilesRecursive } from '../runtime/skill-distribution-service.js';
 import type {
   SkillScanCategory,
   SkillScanFinding,
@@ -325,9 +326,7 @@ export function scanSkillDirectory(skillDir: string, skillId: string = 'skill', 
   const resolvedDir = resolve(skillDir);
 
   if (existsSync(resolvedDir)) {
-    const filesToScan: string[] = [];
-    collectScannableFiles(resolvedDir, filesToScan);
-    filesToScan.sort();
+    const filesToScan = collectFilesRecursive(resolvedDir, isScannableFile);
 
     for (const file of filesToScan) {
       try {
@@ -367,23 +366,6 @@ function isScannableFile(name: string): boolean {
   const dotIdx = lower.lastIndexOf('.');
   if (dotIdx === -1) return false;
   return SCANNABLE_EXTENSIONS.has(lower.slice(dotIdx));
-}
-
-function collectScannableFiles(current: string, result: string[]): void {
-  try {
-    const entries = readdirSync(current, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.name === '.git' || entry.name === 'node_modules') continue;
-      const full = join(current, entry.name);
-      if (entry.isDirectory()) {
-        collectScannableFiles(full, result);
-      } else if (entry.isFile() && !entry.isSymbolicLink() && isScannableFile(entry.name)) {
-        result.push(full);
-      }
-    }
-  } catch {
-    // Ignore directory traversal errors
-  }
 }
 
 export function summarizeFindings(findings: SkillScanFinding[]): SkillScanSummary {

--- a/services/local-ai-core/src/security/skill-content-scan.ts
+++ b/services/local-ai-core/src/security/skill-content-scan.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
-import { collectFilesRecursive } from '../runtime/skill-distribution-service.js';
+import { collectFilesRecursive } from '../kernel/fs-walk.js';
 import type {
   SkillScanCategory,
   SkillScanFinding,


### PR DESCRIPTION
## Summary
- Two modules had private recursive directory walkers with identical semantics (skip `.git`/`node_modules`, recurse dirs, collect non-symlink regular files, sort, swallow per-dir read errors): `computeSkillContentHash`'s inner `collectFiles` in `runtime/skill-distribution-service.ts` and `collectScannableFiles` in `security/skill-content-scan.ts` (added yesterday with the T01-T09 scanner, duplicating the PR #96 walker)
- Extract one shared `collectFilesRecursive(root, includeFile?)` into a new neutral leaf module `services/local-ai-core/src/kernel/fs-walk.ts`; both the distribution service (no filter) and the security scanner (extension predicate) now import downward from kernel, avoiding a security↔runtime mutual import direction

Category: **b) code reuse**, continuing the lint:duplicate de-dup series (#75, #78, #82, #85, #87, #90, #94, #97, #101).

## Review
Three parallel review passes (reuse / quality / efficiency) over `git diff main...HEAD`:
- **Quality: clean** — proved no constructible name diverges between old pre-branch skip and new in-branch skip (`node_modules` has no dot; `.git` → ext 'git' not scannable), sort comparator and error-swallowing structure unchanged
- **Efficiency: clean** — same syscalls/allocations; module-level skip Set marginally better; confirmed the consolidation has no perf impact. Flagged two pre-existing follow-ups (not this PR): `attachSourceMetadataToSkills` re-hashes every skill tree on each `listSkills()` call (real recurring cost — worth an mtime-keyed cache), and the untrusted-input scan has no file-count/byte cap
- **Reuse: placement** — all other walker candidates (script-package hardened traversal, skill-mounter flat list, managed-skill-catalog priority scan, automation-script-store chmod walk) verified as intentionally different; one actionable finding: the walker belonged in a neutral kernel module rather than the runtime service (arbitrary security↔runtime direction, future cycle risk). **Fixed in round 2** as a pure code move; typecheck, lint:circular (0 cycles), and the full suite re-verified after the move

Rounds: 2 (round 2 was a verbatim application of the reviewer's placement prescription — no behavior change).

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test`: 684 pass / 0 fail / 1 skipped; BDD 80 scenarios / 286 steps (baseline and after each round)
- [x] `lint:circular` 0 cycles; `lint:duplicate` CI thresholds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)