### PR TITLE
Cache skill content hash behind stat signature

### DIFF
--- a/services/local-ai-core/src/runtime/managed-skill-catalog.ts
+++ b/services/local-ai-core/src/runtime/managed-skill-catalog.ts
@@ -166,7 +166,10 @@ export class ManagedSkillCatalog {
    * locally-modified check must never read a stale "clean".
    */
   private computeSkillHashCached(skillDir: string): string {
-    if (!existsSync(skillDir)) return '';
+    if (!existsSync(skillDir)) {
+      this.skillHashCache.delete(skillDir);
+      return '';
+    }
     let signature = '';
     for (const file of collectFilesRecursive(skillDir)) {
       let stats;
@@ -176,7 +179,7 @@ export class ManagedSkillCatalog {
         // A file vanished mid-walk: hash fresh and skip caching this pass.
         return computeSkillContentHash(skillDir);
       }
-      signature += `${relative(skillDir, file).replace(/\\/g, '/')}:${stats.mtimeMs}:${stats.size}\n`;
+      signature += `${relative(skillDir, file).replace(/\\/g, '/')}:${stats.mtimeMs}:${stats.ctimeMs}:${stats.size}\n`;
     }
     const cached = this.skillHashCache.get(skillDir);
     if (cached && cached.signature === signature) return cached.hash;

--- a/services/local-ai-core/src/runtime/managed-skill-catalog.ts
+++ b/services/local-ai-core/src/runtime/managed-skill-catalog.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs';
-import { resolve, join, sep } from 'node:path';
+import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, rmSync, mkdtempSync, statSync } from 'node:fs';
+import { resolve, join, sep, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import type {
   SkillInfo,
@@ -21,6 +21,7 @@ import type {
   SkillSecurityAuditResult,
 } from '@cc/superai-contracts/skills';
 import { LocalSkillSourceStore } from '../acp/store/skill-source-store.js';
+import { collectFilesRecursive } from '../kernel/fs-walk.js';
 import {
   computeSkillContentHash,
   parseSkillRepoUrl,
@@ -53,6 +54,7 @@ export class ManagedSkillCatalog {
   private readonly rootDir: string;
   private readonly userSkillsDir: string;
   private readonly defaultWorkspacePath?: string;
+  private readonly skillHashCache = new Map<string, { signature: string; hash: string }>();
   readonly store?: LocalSkillSourceStore;
 
   constructor(options: ManagedSkillCatalogOptions = {}) {
@@ -146,7 +148,7 @@ export class ManagedSkillCatalog {
       const source = this.store.getSource(skill.id, skill.scope, workspaceId);
       if (source) {
         const skillDir = resolve(skill.path, '..');
-        const currentHash = computeSkillContentHash(skillDir);
+        const currentHash = this.computeSkillHashCached(skillDir);
         const status: SkillSourceStatus = !existsSync(skillDir)
           ? 'missing'
           : currentHash === source.contentHash
@@ -155,6 +157,32 @@ export class ManagedSkillCatalog {
         skill.source = { ...source, status };
       }
     }
+  }
+
+  /**
+   * listSkills runs on every skills REST call, so the per-file content hash is
+   * reused while every file's path/mtime/size is unchanged. Any edit, add, or
+   * removal changes the signature and forces a fresh hash — the
+   * locally-modified check must never read a stale "clean".
+   */
+  private computeSkillHashCached(skillDir: string): string {
+    if (!existsSync(skillDir)) return '';
+    let signature = '';
+    for (const file of collectFilesRecursive(skillDir)) {
+      let stats;
+      try {
+        stats = statSync(file);
+      } catch {
+        // A file vanished mid-walk: hash fresh and skip caching this pass.
+        return computeSkillContentHash(skillDir);
+      }
+      signature += `${relative(skillDir, file).replace(/\\/g, '/')}:${stats.mtimeMs}:${stats.size}\n`;
+    }
+    const cached = this.skillHashCache.get(skillDir);
+    if (cached && cached.signature === signature) return cached.hash;
+    const hash = computeSkillContentHash(skillDir);
+    this.skillHashCache.set(skillDir, { signature, hash });
+    return hash;
   }
 
   get(id: string, options: { workspacePath?: string } = {}): ManagedSkill | undefined {

--- a/tests/contracts/skill-security-scan.test.ts
+++ b/tests/contracts/skill-security-scan.test.ts
@@ -435,3 +435,37 @@ test('ManagedSkillCatalog.updateSkill blocks malicious updates without force', a
   }
 });
 
+test('listSkills reports stable clean status and detects nested-file edits', () => {
+  const root = mkdtempSync(join(tmpdir(), 'skill-hash-cache-test-'));
+  try {
+    const userDir = join(root, 'user-skills');
+    mkdirSync(join(userDir, 'demo-skill', 'scripts'), { recursive: true });
+    writeFileSync(join(userDir, 'demo-skill', 'SKILL.md'), '---\nname: demo-skill\n---\n# Demo\n');
+    writeFileSync(join(userDir, 'demo-skill', 'scripts', 'helper.sh'), 'echo hello\n');
+
+    const store = createTestDb();
+    const catalog = new ManagedSkillCatalog({ rootDir: join(root, 'builtin'), userSkillsDir: userDir, store });
+    store.upsertSource({
+      skillId: 'demo-skill',
+      scope: 'user',
+      sourceRepo: 'owner/demo',
+      sourceRef: 'v1.0.0',
+      installedAt: new Date().toISOString(),
+      contentHash: computeSkillContentHash(join(userDir, 'demo-skill')),
+    });
+
+    const statusOf = () => {
+      const skill = catalog.listSkills().find((s) => s.id === 'demo-skill');
+      return skill?.source?.status;
+    };
+
+    assert.equal(statusOf(), 'clean');
+    assert.equal(statusOf(), 'clean');
+
+    writeFileSync(join(userDir, 'demo-skill', 'scripts', 'helper.sh'), 'echo tampered\n');
+    assert.equal(statusOf(), 'locally-modified');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+


### PR DESCRIPTION
## Summary
- `ManagedSkillCatalog.listSkills()` runs on every skills REST request and after every skill mutation (7 mount call sites), and `attachSourceMetadataToSkills` re-ran `computeSkillContentHash` — a full recursive walk + `readFileSync` of every file — for every sourced skill on each call, all synchronously on the event loop
- Adds a per-catalog cache: a per-file stat signature (`relPath:mtimeMs:ctimeMs:size`, built with the shared `kernel/fs-walk.ts` walker) is compared first; only when it changes is the full content hash recomputed. Cache hits replace per-file reads with per-file stats
- Soundness matters: the resulting `clean`/`locally-modified` status feeds `updateSkill`'s overwrite-protection gate, so a directory-mtime scheme was rejected (nested-file edits don't bump the parent dir mtime); the per-file signature catches any edit, add, removal, or symlink swap. A `statSync` mid-walk failure falls back to a fresh uncached hash, and a missing skill dir evicts its cache entry
- New contract test pins the observable contract: consecutive `listSkills` report `clean` (stable), and editing a nested file flips the status to `locally-modified`

Category: **c) performance** — this hotspot was flagged by the efficiency reviewer in PR #105 as "the only genuine hotspot in these flows".

## Review
Three parallel review passes (reuse / quality / efficiency) over `git diff main...HEAD`:
- **Reuse: clean** — no existing stat-signature/cache utility duplicated; keeping the cache private to the catalog judged correct under CLAUDE.md's "real second use" rule; the other `computeSkillContentHash` caller (install path, cold) correctly stays uncached
- **Quality: clean after round 2** — confirmed statSync-failure fallback and symlink-swap handling sound, doc comment explains WHY; round-2 hardening applied from its notes: added `ctimeMs` to the signature (closes the touch-back/same-ms-same-size stale-clean window) and cache eviction when a skill dir goes missing
- **Efficiency: clean** — "solid, honest win"; hit path = walk + stats instead of walk + reads + sha256; frontmatter caching in `scanSkillsRoot` noted as a possible future follow-up (low payoff)

Rounds: 2 (round 2 = verbatim application of reviewer-prescribed hardening; full suite re-verified after).

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test`: fail = 0 (684 pass / 1 skipped); BDD 80 scenarios / 286 steps — verified after round 1 and after round 2
- [x] New contract test covers cache-hit stability and nested-edit invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)