### PR TITLE
Cap skill scan budget and fail closed on oversized bundles

### DIFF
--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -36,7 +36,8 @@ export type SkillScanCategory =
   | 'T06_PERSISTENCE'
   | 'T07_TOOL_HIJACK'
   | 'T08_INSECURE_DEPENDENCIES'
-  | 'T09_INSECURE_PRACTICES';
+  | 'T09_INSECURE_PRACTICES'
+  | 'SCAN_LIMIT_EXCEEDED';
 
 export interface SkillScanFinding {
   id: string;

--- a/services/local-ai-core/src/security/skill-content-scan.ts
+++ b/services/local-ai-core/src/security/skill-content-scan.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
 import { collectFilesRecursive } from '../kernel/fs-walk.js';
 import type {
@@ -348,20 +348,21 @@ export function scanSkillDirectory(skillDir: string, skillId: string = 'skill', 
     let scannedBytes = 0;
     for (const file of filesToScan) {
       try {
-        const content = readFileSync(file, 'utf8');
-        scannedBytes += content.length;
+        const rel = relative(resolvedDir, file).replace(/\\/g, '/');
+        // Size-check before reading so a single huge file is never fully
+        // loaded just to discover it exceeds the budget.
+        scannedBytes += statSync(file).size;
         if (scannedBytes > MAX_SCAN_BYTES) {
-          const rel = relative(resolvedDir, file).replace(/\\/g, '/');
           findings.push({
             id: 'SCAN-LIMIT-BYTES',
             category: 'SCAN_LIMIT_EXCEEDED',
             severity: 'high',
-            message: `Scan budget exceeded: over ${MAX_SCAN_BYTES} bytes of scannable content read.`,
+            message: `Scan budget exceeded: scannable content exceeds ${MAX_SCAN_BYTES} bytes.`,
             file: rel,
           });
           break;
         }
-        const rel = relative(resolvedDir, file).replace(/\\/g, '/');
+        const content = readFileSync(file, 'utf8');
         const fileFindings = scanSkillContent(content, rel);
         findings.push(...fileFindings);
       } catch {

--- a/services/local-ai-core/src/security/skill-content-scan.ts
+++ b/services/local-ai-core/src/security/skill-content-scan.ts
@@ -321,6 +321,12 @@ export function scanSkillContent(content: string, relativePath: string = 'SKILL.
   return findings;
 }
 
+// The scanner reads untrusted skill bundles synchronously on the event loop;
+// without a budget a malicious tree could stall the server. Any skill that
+// trips a limit fails the gate (high severity) instead of being trusted.
+const MAX_SCAN_FILES = 2000;
+const MAX_SCAN_BYTES = 20 * 1024 * 1024;
+
 export function scanSkillDirectory(skillDir: string, skillId: string = 'skill', scope?: SkillScope): SkillScanReport {
   const findings: SkillScanFinding[] = [];
   const resolvedDir = resolve(skillDir);
@@ -328,9 +334,33 @@ export function scanSkillDirectory(skillDir: string, skillId: string = 'skill', 
   if (existsSync(resolvedDir)) {
     const filesToScan = collectFilesRecursive(resolvedDir, isScannableFile);
 
+    if (filesToScan.length > MAX_SCAN_FILES) {
+      findings.push({
+        id: 'SCAN-LIMIT-FILES',
+        category: 'SCAN_LIMIT_EXCEEDED',
+        severity: 'high',
+        message: `Scan budget exceeded: ${filesToScan.length} scannable files (limit ${MAX_SCAN_FILES}).`,
+        file: relative(resolvedDir, filesToScan[MAX_SCAN_FILES]).replace(/\\/g, '/'),
+      });
+      filesToScan.length = MAX_SCAN_FILES;
+    }
+
+    let scannedBytes = 0;
     for (const file of filesToScan) {
       try {
         const content = readFileSync(file, 'utf8');
+        scannedBytes += content.length;
+        if (scannedBytes > MAX_SCAN_BYTES) {
+          const rel = relative(resolvedDir, file).replace(/\\/g, '/');
+          findings.push({
+            id: 'SCAN-LIMIT-BYTES',
+            category: 'SCAN_LIMIT_EXCEEDED',
+            severity: 'high',
+            message: `Scan budget exceeded: over ${MAX_SCAN_BYTES} bytes of scannable content read.`,
+            file: rel,
+          });
+          break;
+        }
         const rel = relative(resolvedDir, file).replace(/\\/g, '/');
         const fileFindings = scanSkillContent(content, rel);
         findings.push(...fileFindings);

--- a/tests/contracts/skill-security-scan.test.ts
+++ b/tests/contracts/skill-security-scan.test.ts
@@ -195,6 +195,42 @@ test('scanSkillDirectory analyzes multi-file skill folder', () => {
   }
 });
 
+test('scanSkillDirectory enforces scan budget on oversized skill trees', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agentdock-scan-budget-'));
+  try {
+    // File-count cap: 2001 scannable files exceeds the 2000-file budget.
+    mkdirSync(join(dir, 'file-cap-skill'), { recursive: true });
+    for (let i = 0; i <= 2000; i++) {
+      writeFileSync(join(dir, 'file-cap-skill', `f${String(i).padStart(4, '0')}.md`), 'x\n');
+    }
+
+    const fileCapReport = scanSkillDirectory(join(dir, 'file-cap-skill'), 'file-cap-skill', 'user');
+    assert.equal(fileCapReport.passed, false);
+    const filesFinding = fileCapReport.findings.find((f) => f.id === 'SCAN-LIMIT-FILES');
+    assert(filesFinding);
+    assert.equal(filesFinding.category, 'SCAN_LIMIT_EXCEEDED');
+    assert.equal(filesFinding.severity, 'high');
+    assert(filesFinding.file);
+
+    // Byte cap: 5 x 5MB files exceeds the 20MB read budget.
+    mkdirSync(join(dir, 'byte-cap-skill'), { recursive: true });
+    const big = 'x'.repeat(5 * 1024 * 1024);
+    for (let i = 0; i < 5; i++) {
+      writeFileSync(join(dir, 'byte-cap-skill', `f${String(i).padStart(4, '0')}.md`), big);
+    }
+
+    const byteCapReport = scanSkillDirectory(join(dir, 'byte-cap-skill'), 'byte-cap-skill', 'user');
+    assert.equal(byteCapReport.passed, false);
+    const bytesFinding = byteCapReport.findings.find((f) => f.id === 'SCAN-LIMIT-BYTES');
+    assert(bytesFinding);
+    assert.equal(bytesFinding.category, 'SCAN_LIMIT_EXCEEDED');
+    assert.equal(bytesFinding.severity, 'high');
+    assert(bytesFinding.file);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('ManagedSkillCatalog.installSkillFromSource blocks malicious skills by default and allows with force', async () => {
   const staging = mkdtempSync(join(tmpdir(), 'agentdock-sec-git-'));
   const userDir = mkdtempSync(join(tmpdir(), 'agentdock-sec-user-'));

--- a/tests/contracts/skill-security-scan.test.ts
+++ b/tests/contracts/skill-security-scan.test.ts
@@ -231,6 +231,34 @@ test('scanSkillDirectory enforces scan budget on oversized skill trees', () => {
   }
 });
 
+test('scanSkillDirectory allows trees exactly at the scan budget boundary', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agentdock-scan-boundary-'));
+  try {
+    // Exactly 2000 scannable files stays within the file budget.
+    mkdirSync(join(dir, 'file-boundary-skill'), { recursive: true });
+    for (let i = 0; i < 2000; i++) {
+      writeFileSync(join(dir, 'file-boundary-skill', `f${String(i).padStart(4, '0')}.md`), 'x\n');
+    }
+
+    const fileBoundaryReport = scanSkillDirectory(join(dir, 'file-boundary-skill'), 'file-boundary-skill', 'user');
+    assert.equal(fileBoundaryReport.passed, true);
+    assert(!fileBoundaryReport.findings.some((f) => f.id === 'SCAN-LIMIT-FILES'));
+
+    // Exactly 20MB of scannable content stays within the byte budget.
+    mkdirSync(join(dir, 'byte-boundary-skill'), { recursive: true });
+    const exact = 'x'.repeat(5 * 1024 * 1024);
+    for (let i = 0; i < 4; i++) {
+      writeFileSync(join(dir, 'byte-boundary-skill', `f${String(i).padStart(4, '0')}.md`), exact);
+    }
+
+    const byteBoundaryReport = scanSkillDirectory(join(dir, 'byte-boundary-skill'), 'byte-boundary-skill', 'user');
+    assert.equal(byteBoundaryReport.passed, true);
+    assert(!byteBoundaryReport.findings.some((f) => f.id === 'SCAN-LIMIT-BYTES'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('ManagedSkillCatalog.installSkillFromSource blocks malicious skills by default and allows with force', async () => {
   const staging = mkdtempSync(join(tmpdir(), 'agentdock-sec-git-'));
   const userDir = mkdtempSync(join(tmpdir(), 'agentdock-sec-user-'));


### PR DESCRIPTION
## Summary
- The skill security scanner reads untrusted bundle trees synchronously on the event loop; a hostile tree with millions of files or one huge file could stall the server before any gate ran.
- `scanSkillDirectory` now enforces a scan budget: max 2000 scannable files and 20MB of scannable content. Exceeding either emits a high-severity `SCAN_LIMIT_EXCEEDED` finding (new contract category value), so the install/update gate (`passed = critical==0 && high==0`) fails closed.
- The byte budget is checked via `statSync` size *before* reading, so a single huge file is never loaded into memory just to discover it exceeds the cap.

## Motivation
Follow-up from the #105 review (efficiency finding): untrusted skill bundles had no bounds on scan work. Logs show no new code bugs today (only known external provider-auth signatures), so this lands as the daily optimization/hardening pick — security robustness with a performance rationale.

## Review
- 3 parallel reviewers (code reuse / code quality / efficiency) over `main...HEAD`.
- Round 1: reuse clean; quality + efficiency both flagged the post-read byte check. Fixed verbatim (pre-read `statSync`) and added boundary tests pinning both `>` off-by-one semantics. fs-walk `maxEntries` idea declined as accepted residual risk (walk is per-entry cheap; reads are the expensive part and are now bounded).
- No further review round needed — fixes applied prescriptions exactly.

## Validation
- `pnpm typecheck` — clean
- `pnpm test` — 688 tests, 0 fail (1 pre-existing skip), BDD 80 scenarios / 286 steps passed
- New contract tests: over-budget file count (2001 files), over-budget bytes (5×5MB), and exactly-at-boundary (2000 files / exactly 20MB) both pass the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)