### PR TITLE
Honor workspace skill overrides in agent message composition

### DIFF
--- a/services/local-ai-core/src/router/workspace-router.ts
+++ b/services/local-ai-core/src/router/workspace-router.ts
@@ -34,6 +34,7 @@ import type { ProbeCollector, WorkspaceRoute, WorkspaceRouterOptions, WorkspaceT
 import { isLocalCoreNativeAcpProject, normalizePlatformTypes, toLocalCoreProjectConfig } from './workspace-route-config.js';
 import { projectWorkspaceId } from '../runtime/workspace-project-registry.js';
 import { composeAgentMessage } from '../thread/agent-message-policy.js';
+import { ManagedSkillCatalog } from '../runtime/managed-skill-catalog.js';
 import { createChannelThreadMessageInput } from '../channel/shared/content.js';
 import { WorkspaceBridgeEventStream } from './workspace-bridge-event-stream.js';
 
@@ -263,7 +264,7 @@ export class WorkspaceRouter {
     const route = isLocalSlashCommand(content)
       ? await this.getWorkspaceRoute(workspaceId)
       : await this.getThreadWorkspaceRoute(threadId, workspaceId);
-    const preparedContent = await this.prepareAgentMessage(threadId, content);
+    const preparedContent = await this.prepareAgentMessage(threadId, content, route.config.workDir);
     return this.localCoreAcp.sendThreadMessage(threadId, preparedContent, route.config, options);
   }
 
@@ -327,7 +328,7 @@ export class WorkspaceRouter {
     };
   }
 
-  private async prepareAgentMessage(threadId: string, content: string | ChannelInboundMessageContent) {
+  private async prepareAgentMessage(threadId: string, content: string | ChannelInboundMessageContent, workspacePath = '') {
     const displayText = typeof content === 'string' ? content : content.displayText;
     if (displayText.trim().startsWith('/')) {
       return content;
@@ -338,7 +339,10 @@ export class WorkspaceRouter {
           .filter((base) => selectedIds.has(base.id))
           .map(({ id, name }) => ({ id, name }))
       : [];
-    const wrapped = composeAgentMessage(displayText, knowledgeBases);
+    // Honor workspace > user > builtin skill precedence so workspace-scoped
+    // overrides of condition-trigger / stock-monitor are the ones injected.
+    const catalog = workspacePath ? new ManagedSkillCatalog({ workspacePath }) : new ManagedSkillCatalog();
+    const wrapped = composeAgentMessage(displayText, knowledgeBases, catalog);
     return typeof content === 'string'
       ? wrapped
       : createChannelThreadMessageInput(wrapped, content.contentParts);

--- a/services/local-ai-core/src/router/workspace-router.ts
+++ b/services/local-ai-core/src/router/workspace-router.ts
@@ -328,7 +328,7 @@ export class WorkspaceRouter {
     };
   }
 
-  private async prepareAgentMessage(threadId: string, content: string | ChannelInboundMessageContent, workspacePath = '') {
+  private async prepareAgentMessage(threadId: string, content: string | ChannelInboundMessageContent, workspacePath: string) {
     const displayText = typeof content === 'string' ? content : content.displayText;
     if (displayText.trim().startsWith('/')) {
       return content;
@@ -341,8 +341,7 @@ export class WorkspaceRouter {
       : [];
     // Honor workspace > user > builtin skill precedence so workspace-scoped
     // overrides of condition-trigger / stock-monitor are the ones injected.
-    const catalog = workspacePath ? new ManagedSkillCatalog({ workspacePath }) : new ManagedSkillCatalog();
-    const wrapped = composeAgentMessage(displayText, knowledgeBases, catalog);
+    const wrapped = composeAgentMessage(displayText, knowledgeBases, new ManagedSkillCatalog({ workspacePath }));
     return typeof content === 'string'
       ? wrapped
       : createChannelThreadMessageInput(wrapped, content.contentParts);

--- a/services/local-ai-core/src/thread/agent-message-policy.ts
+++ b/services/local-ai-core/src/thread/agent-message-policy.ts
@@ -1,3 +1,5 @@
+import { ManagedSkillCatalog } from '../runtime/managed-skill-catalog.js';
+
 const SCHEDULER_INSTRUCTION = [
   '[Scheduler Tools]',
   'If the user asks to create, view, edit, delete, or manually run a scheduled task for this conversation, use the Bash tool to run the local scheduler CLI.',
@@ -124,5 +126,5 @@ function isConditionAutomationRequest(content: string) {
   const chineseNegation = /(?:不要|不需要|无需|别|仅|只是|不想).{0,8}(?:创建|新建|设置|添加|建立|配置|制作|实现)/.test(content);
   return (englishCondition && englishAutomation && englishRequest && !englishNegation) || (chineseCondition && chineseRequest && !chineseNegation);
 }
-import { ManagedSkillCatalog } from '../runtime/managed-skill-catalog.js';
+
 

--- a/tests/integration/workspace-router-skill-composition.test.ts
+++ b/tests/integration/workspace-router-skill-composition.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { LocalCoreAcpStore } from '../../services/local-ai-core/src/acp/local-core-acp-store.js';
+import { LocalCoreEventBus } from '../../services/local-ai-core/src/kernel/event-bus.js';
+import { WorkspaceRouter } from '../../services/local-ai-core/src/router/workspace-router.js';
+
+const OVERRIDE_MARKER = 'WORKSPACE-STOCK-OVERRIDE-MARKER';
+
+test('sendThreadMessage composes skill blocks from workspace-scoped skill overrides', async () => {
+  const userData = mkdtempSync(join(tmpdir(), 'ws-router-skill-user-'));
+  const workspaceDir = mkdtempSync(join(tmpdir(), 'ws-router-skill-ws-'));
+  const skillDir = join(workspaceDir, '.agentdock', 'skills', 'stock-monitor');
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, 'SKILL.md'), [
+    '---',
+    'name: stock-monitor',
+    'description: workspace override',
+    '---',
+    '',
+    OVERRIDE_MARKER,
+    '',
+  ].join('\n'), 'utf8');
+
+  const store = new LocalCoreAcpStore(userData);
+  const router = new WorkspaceRouter({
+    store,
+    eventBus: new LocalCoreEventBus(),
+    readRuntimeConfig: async () => ({
+      storage: 'sqlite',
+      databasePath: join(userData, 'runtime.db'),
+      baseDir: userData,
+      config: {
+        projects: [{
+          name: 'fixture-ws',
+          platforms: [],
+          agent: {
+            type: 'localcore-acp',
+            options: { command: 'true', work_dir: workspaceDir },
+          },
+        }],
+      },
+    }),
+    getCapabilities: () => ({ snapshot: { agents: [] } }) as any,
+    knowledgeProvider: { listKnowledgeBases: async () => [] } as any,
+    knowledgeAttachments: { listThreadKnowledgeBaseIds: async () => [] } as any,
+  });
+
+  try {
+    const thread = store.createThread('fixture-ws', 'skill composition');
+    await router.sendThreadMessage(thread.id, '帮我监控股票价格');
+
+    const detail = store.getThread(thread.id, []);
+    const userMessage = detail.messages.find((message) => message.role === 'user');
+    assert(userMessage, 'expected a composed user message');
+    assert.match(userMessage.content, /\[Stock Monitor Skill\]/);
+    assert.match(userMessage.content, new RegExp(OVERRIDE_MARKER));
+  } finally {
+    router.close();
+    rmSync(userData, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/workspace-router-skill-composition.test.ts
+++ b/tests/integration/workspace-router-skill-composition.test.ts
@@ -25,31 +25,31 @@ test('sendThreadMessage composes skill blocks from workspace-scoped skill overri
     '',
   ].join('\n'), 'utf8');
 
-  const store = new LocalCoreAcpStore(userData);
-  const router = new WorkspaceRouter({
-    store,
-    eventBus: new LocalCoreEventBus(),
-    readRuntimeConfig: async () => ({
-      storage: 'sqlite',
-      databasePath: join(userData, 'runtime.db'),
-      baseDir: userData,
-      config: {
-        projects: [{
-          name: 'fixture-ws',
-          platforms: [],
-          agent: {
-            type: 'localcore-acp',
-            options: { command: 'true', work_dir: workspaceDir },
-          },
-        }],
-      },
-    }),
-    getCapabilities: () => ({ snapshot: { agents: [] } }) as any,
-    knowledgeProvider: { listKnowledgeBases: async () => [] } as any,
-    knowledgeAttachments: { listThreadKnowledgeBaseIds: async () => [] } as any,
-  });
-
+  let router: WorkspaceRouter | undefined;
   try {
+    const store = new LocalCoreAcpStore(userData);
+    router = new WorkspaceRouter({
+      store,
+      eventBus: new LocalCoreEventBus(),
+      readRuntimeConfig: async () => ({
+        storage: 'sqlite',
+        databasePath: join(userData, 'runtime.db'),
+        baseDir: userData,
+        config: {
+          projects: [{
+            name: 'fixture-ws',
+            platforms: [],
+            agent: {
+              type: 'localcore-acp',
+              options: { command: 'true', work_dir: workspaceDir },
+            },
+          }],
+        },
+      }),
+      getCapabilities: () => ({ snapshot: { agents: [] } }) as any,
+      knowledgeProvider: { listKnowledgeBases: async () => [] } as any,
+      knowledgeAttachments: { listThreadKnowledgeBaseIds: async () => [] } as any,
+    });
     const thread = store.createThread('fixture-ws', 'skill composition');
     await router.sendThreadMessage(thread.id, '帮我监控股票价格');
 
@@ -59,7 +59,7 @@ test('sendThreadMessage composes skill blocks from workspace-scoped skill overri
     assert.match(userMessage.content, /\[Stock Monitor Skill\]/);
     assert.match(userMessage.content, new RegExp(OVERRIDE_MARKER));
   } finally {
-    router.close();
+    router?.close();
     rmSync(userData, { recursive: true, force: true });
     rmSync(workspaceDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Category

a) Architecture consistency (optimization mode — no bugs found in service logs)

## Motivation

`composeAgentMessage` accepts an injected `ManagedSkillCatalog`, and the catalog is explicitly designed around workspace > user > builtin precedence (`get()` checks `.agentdock/skills` and `.agents/skills` in the workspace first). But the only production call site — `WorkspaceRouter.prepareAgentMessage`, the path every inbound chat message takes — built a default catalog with **no workspace path**, so workspace-scoped installs/overrides of `condition-trigger` and `stock-monitor` were silently ignored in favor of the user/builtin copies. The skills UI lets users install workspace-scoped skills; message composition never saw them.

Fix: pass the resolved `route.config.workDir` into a workspace-aware catalog. Also moves `agent-message-policy.ts`'s import from the bottom of the file to the top (behavior-neutral hygiene).

## TDD

A new router-level integration test (`tests/integration/workspace-router-skill-composition.test.ts`) was written **first** and failed against unmodified code: a fixture workspace with a marker-bearing `.agentdock/skills/stock-monitor/SKILL.md` received the **builtin** skill content instead of the override. It passes after the one-line plumb, and it is the first test in the repo that exercises the real `WorkspaceRouter` → `composeAgentMessage` composition path end to end (real SQLite store, stubbed config/knowledge options).

## Review

1 round, 3 parallel agents (code reuse / code quality / efficiency) over `git diff main...HEAD`.

Applied verbatim:
- Made `prepareAgentMessage`'s `workspacePath` required and dropped the redundant ternary (route workDir is always non-empty; the catalog constructor already guards falsy values).
- Moved test store/router construction inside `try` so a constructor failure can't leak the SQLite handle or temp dirs.

Declined, with reasons:
- Reuse agent's suggestion to hold a long-lived shared catalog and thread `workspacePath` through `composeAgentMessage` → `catalog.get(...)` per call: the efficiency agent confirmed the change is cost-neutral (the old code already constructed a default catalog per send; the constructor's only IO is one `existsSync`), so the restructure adds signature and wiring surface for negligible gain.
- Precise-type casts on the test's router-option stubs: repo-wide convention is `as any` for these stubs (all gateway/router tests); full interface stubs would be noise.

Round 2 not needed — accepted fixes applied prescriptions verbatim.

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 700 tests: 699 pass, 1 skipped (pre-existing), 0 fail; BDD 80 scenarios / 286 steps passed