### PR TITLE
Add cron schedule windows to automation monitors (Closes #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ flowchart LR
 
 ## New
 
+### 2026-08-28
+
+- 事件监控支持 cron 时间窗（Issue #115 Phase 1）：
+  - **定时评估窗口**：`lac monitor add/edit` 新增 `--cron "<expr>"` 与 `--timezone <tz>`（默认 `Asia/Shanghai`），监控仅在匹配的时间窗内轮询评估（如每交易日 11 点检查、`edit --cron off` 清除窗口），窗口外不再空转轮询，降低行情源限流风险。
+  - **向后兼容**：未配置时间窗的监控保持 24×7 轮询行为不变；`monitor info` 输出新增 Schedule 行；交易日历门控留待后续阶段。
+
 ### 2026-08-27
 
 - 发布 AgentDock 0.1.80：内置股票与量化盯盘 Skill (`stock-monitor`)：

--- a/packages/contracts/src/automation.ts
+++ b/packages/contracts/src/automation.ts
@@ -4,6 +4,7 @@ import {
   ScheduledJobExecutionMode,
   ScheduledJobRoute,
 } from './scheduler.js';
+import type { AutomationMonitorSchedule } from './automations.js';
 
 export type ScheduledJobTriggerType = 'cron' | 'once' | (string & {});
 
@@ -140,6 +141,7 @@ export interface AutomationMonitor {
   enabled: boolean;
   cooldownMs: number;
   concurrencyPolicy: 'skip_if_running';
+  schedule?: AutomationMonitorSchedule;
   lastState?: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -178,6 +180,7 @@ export interface AutomationMonitorCreateInput {
   executionMode?: ScheduledJobExecutionMode;
   enabled?: boolean;
   cooldownMs?: number;
+  schedule?: AutomationMonitorSchedule;
 }
 
 export interface AutomationMonitorUpdateInput {
@@ -189,6 +192,7 @@ export interface AutomationMonitorUpdateInput {
   executionMode?: ScheduledJobExecutionMode;
   enabled?: boolean;
   cooldownMs?: number;
+  schedule?: AutomationMonitorSchedule | null;
 }
 
 export function normalizeAutomationMonitorStatus(value: unknown, fallback: AutomationMonitorStatus = 'queued'): AutomationMonitorStatus {

--- a/packages/contracts/src/automations.ts
+++ b/packages/contracts/src/automations.ts
@@ -7,7 +7,12 @@ export type AutomationActivation =
   | { kind: 'cron'; expression: string; timezone: string }
   | { kind: 'once'; runAt: string }
   | { kind: 'interval'; intervalMs: number }
-  | { kind: 'provider-event'; sourceType: string; sourceConfig: Record<string, unknown> };
+  | { kind: 'provider-event'; sourceType: string; sourceConfig: Record<string, unknown>; schedule?: AutomationMonitorSchedule };
+
+export interface AutomationMonitorSchedule {
+  cron: string;
+  timezone: string;
+}
 
 export type AutomationCondition =
   | { kind: 'always' }
@@ -305,6 +310,15 @@ function normalizeRoute(value: unknown): ScheduledJobRoute {
   return normalized;
 }
 
+export function normalizeAutomationMonitorSchedule(value: unknown, label = 'Automation monitor schedule'): AutomationMonitorSchedule | undefined {
+  if (value === undefined || value === null) return undefined;
+  const input = asRecord(value, label);
+  return {
+    cron: requiredString(input.cron, `${label} cron`),
+    timezone: requiredString(input.timezone, `${label} timezone`),
+  };
+}
+
 export function normalizeAutomationActivation(value: unknown): AutomationActivation {
   const input = asRecord(value, 'Automation activation');
   switch (input.kind) {
@@ -321,12 +335,16 @@ export function normalizeAutomationActivation(value: unknown): AutomationActivat
       if (intervalMs === 0) throw new Error('Automation intervalMs must be greater than zero.');
       return { kind: 'interval', intervalMs };
     }
-    case 'provider-event':
-      return {
+    case 'provider-event': {
+      const activation: AutomationActivation = {
         kind: 'provider-event',
         sourceType: requiredString(input.sourceType, 'Automation provider sourceType'),
         sourceConfig: asRecord(input.sourceConfig, 'Automation provider sourceConfig'),
       };
+      const schedule = normalizeAutomationMonitorSchedule(input.schedule, 'Automation provider-event schedule');
+      if (schedule) activation.schedule = schedule;
+      return activation;
+    }
     default:
       throw new Error('Automation activation kind must be cron, once, interval, or provider-event.');
   }

--- a/services/local-ai-core/src/automation/automation-monitor-service.ts
+++ b/services/local-ai-core/src/automation/automation-monitor-service.ts
@@ -2,12 +2,19 @@ import type {
   AutomationMonitor,
   AutomationMonitorCreateInput,
   AutomationMonitorEventSnapshot,
+  AutomationMonitorSchedule,
   AutomationMonitorUpdateInput,
   ScheduledJobRoute,
 } from '@cc/superai-contracts';
 import type { ChannelRuntime, EventBus, MonitorProviderRuntime } from '@cc/plugin-sdk';
 import type { LocalCoreAcpStore } from '../acp/local-core-acp-store.js';
 import type { WorkspaceRouter } from '../router/workspace-router.js';
+import {
+  assertSupportedTimezone,
+  compileCronExpression,
+  cronMatchesFields,
+  extractFieldsInTimezone,
+} from '../scheduler/cron.js';
 import {
   routeFromPlatformThreadBinding,
   routeWithPlatformInstance,
@@ -35,6 +42,20 @@ type ResolvedAutomationMonitorCreateInput = AutomationMonitorCreateInput & {
   platform: NonNullable<AutomationMonitorCreateInput['platform']>;
   route: NonNullable<AutomationMonitorCreateInput['route']>;
 };
+
+// A monitor with a schedule only polls when the current wall clock (in the schedule's
+// timezone) matches the cron expression. Stored schedules are validated on create/update,
+// so fail-open here would only trigger on corrupted state — degrading to always-poll is
+// safer for a monitoring tool than silently dropping evaluations.
+export function isMonitorWithinSchedule(schedule: AutomationMonitorSchedule | undefined, now: Date): boolean {
+  if (!schedule) return true;
+  try {
+    const compiled = compileCronExpression(schedule.cron);
+    return cronMatchesFields(compiled, extractFieldsInTimezone(now, schedule.timezone));
+  } catch {
+    return true;
+  }
+}
 
 type AutomationMonitorServiceOptions = {
   store: LocalCoreAcpStore;
@@ -202,6 +223,7 @@ export class AutomationMonitorService {
 
   async createMonitor(input: AutomationMonitorCreateInput): Promise<AutomationMonitor> {
     const resolved = this.resolveCreateInput(input);
+    this.assertValidMonitorSchedule(resolved.schedule);
     this.providers.get(resolved.sourceType)?.validateConfig?.(resolved.sourceConfig || {});
     const mapped = monitorToAutomationInput(resolved);
     let monitor: AutomationMonitor | undefined;
@@ -230,6 +252,7 @@ export class AutomationMonitorService {
     this.options.automations.assertLegacyFacadesAvailable();
     const existing = this.getRequiredMonitor(monitorId);
     if (input.sourceConfig) this.providers.get(existing.sourceType)?.validateConfig?.(input.sourceConfig);
+    this.assertValidMonitorSchedule(input.schedule === null ? undefined : input.schedule);
     const resolved = this.resolveCreateInput({
       workspaceId: existing.workspaceId,
       title: input.title ?? existing.title,
@@ -242,6 +265,7 @@ export class AutomationMonitorService {
       executionMode: input.executionMode ?? existing.executionMode,
       enabled: input.enabled ?? existing.enabled,
       cooldownMs: input.cooldownMs ?? existing.cooldownMs,
+      schedule: input.schedule === undefined ? existing.schedule : input.schedule || undefined,
     });
     const mapped = monitorToAutomationInput(resolved);
     const { workspaceId: _workspaceId, originKind: _originKind, ...update } = mapped;
@@ -348,7 +372,9 @@ export class AutomationMonitorService {
       if (refreshSubscriptions) await this.refreshSubscriptions(generation);
       if (generation !== undefined && !this.isCurrentLifecycle(generation, 'running')) return;
       const monitors = this.listMonitors().filter((candidate) =>
-        candidate.enabled && !this.providers.get(candidate.sourceType)?.startMonitor
+        candidate.enabled
+        && !this.providers.get(candidate.sourceType)?.startMonitor
+        && isMonitorWithinSchedule(candidate.schedule, new Date())
       );
       let index = 0;
       const worker = async () => {
@@ -812,6 +838,17 @@ export class AutomationMonitorService {
   private async settleInFlight(): Promise<void> {
     while (this.inFlight.size > 0) {
       await Promise.allSettled([...this.inFlight]);
+    }
+  }
+
+  private assertValidMonitorSchedule(schedule: AutomationMonitorSchedule | undefined): void {
+    if (!schedule) return;
+    try {
+      compileCronExpression(schedule.cron);
+      assertSupportedTimezone(schedule.timezone);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Monitor schedule is invalid: ${message}`);
     }
   }
 

--- a/services/local-ai-core/src/automation/legacy-automation-mappers.ts
+++ b/services/local-ai-core/src/automation/legacy-automation-mappers.ts
@@ -119,6 +119,7 @@ export function monitorToAutomationInput(input: ResolvedMonitorInput): LegacyAut
       kind: 'provider-event',
       sourceType: requireText(input.sourceType, 'Automation monitor sourceType'),
       sourceConfig: input.sourceConfig || {},
+      ...(input.schedule ? { schedule: input.schedule } : {}),
     },
     condition: { kind: 'expression', expression: monitorConditionExpression(input.condition) },
     action: {
@@ -164,6 +165,7 @@ export function automationToMonitor(
     enabled: automation.enabled,
     cooldownMs: automation.policies.cooldownMs,
     concurrencyPolicy: 'skip_if_running',
+    ...(automation.activation.schedule ? { schedule: automation.activation.schedule } : {}),
     ...(lastState ? { lastState } : {}),
     createdAt: automation.createdAt,
     updatedAt: automation.updatedAt,

--- a/services/local-ai-core/src/cli/lac.ts
+++ b/services/local-ai-core/src/cli/lac.ts
@@ -14,7 +14,7 @@ import { toPublicScheduledJobId } from '../scheduler/job-id.js';
 import { getChannelPlatformBase, getChannelPlatformInstanceId, scheduledJobMatchesCliContext } from '../scheduler/scheduled-job-route.js';
 import { toPublicAutomationMonitorId } from '../automation/monitor-id.js';
 import { automationMonitorToScheduledJob } from '../automation/automation-schedule-utils.js';
-import { parseDurationMs, parseMonitorCondition } from './monitor-cli-parsers.js';
+import { parseDurationMs, parseMonitorCondition, parseMonitorSchedule } from './monitor-cli-parsers.js';
 import { formatSafeError } from '../kernel/local-core-errors.js';
 import { runSkillDomain } from './skill-cli-handlers.js';
 import type { StdIo, ParsedFlags, CliContext } from './cli-helpers.js';
@@ -315,6 +315,9 @@ async function handleMonitorAdd(flags: Map<string, string[]>, env: NodeJS.Proces
   const promptTemplate = getRequiredFlag(flags, 'message');
   const condition = parseMonitorCondition(getRequiredFlag(flags, 'condition'));
   const sourceConfig = buildSourceConfig(sourceType, flags);
+  const cronFlag = getFlag(flags, 'cron');
+  const timezoneFlag = getFlag(flags, 'timezone');
+  if (timezoneFlag && !cronFlag) throw new Error('--timezone requires --cron.');
   const monitor = await request<AutomationMonitor>(context.baseUrl, 'POST', '/automation/monitors', {
     workspaceId: context.workspaceId,
     ...(context.threadId ? { threadId: context.threadId } : {}),
@@ -325,6 +328,7 @@ async function handleMonitorAdd(flags: Map<string, string[]>, env: NodeJS.Proces
     promptTemplate,
     executionMode: getMonitorExecutionMode(flags),
     cooldownMs: parseDurationMs(getFlag(flags, 'cooldown') || '15m'),
+    ...(cronFlag ? { schedule: parseMonitorSchedule(cronFlag, timezoneFlag) } : {}),
     enabled: true,
   });
   print(json, io.stdout, presentMonitor(monitor), [
@@ -374,12 +378,17 @@ async function handleMonitorEdit(monitorId: string, flags: Map<string, string[]>
   const enabled = getOptionalBooleanFlag(flags, 'enabled');
   const executionMode = getFlag(flags, 'execution-mode');
   const cooldown = getFlag(flags, 'cooldown');
+  const cronFlag = getFlag(flags, 'cron');
+  const timezoneFlag = getFlag(flags, 'timezone');
+  if (timezoneFlag && !cronFlag) throw new Error('--timezone requires --cron.');
   if (title) input.title = title;
   if (typeof promptTemplate === 'string' && promptTemplate) input.promptTemplate = promptTemplate;
   if (condition) input.condition = parseMonitorCondition(condition);
   if (typeof enabled === 'boolean') input.enabled = enabled;
   if (executionMode) input.executionMode = normalizeScheduledJobExecutionMode(executionMode);
   if (cooldown) input.cooldownMs = parseDurationMs(cooldown);
+  if (cronFlag === 'off') input.schedule = null;
+  else if (cronFlag) input.schedule = parseMonitorSchedule(cronFlag, timezoneFlag);
   if (Object.keys(input).length === 0) {
     throw new Error('monitor edit requires at least one editable field.');
   }
@@ -623,10 +632,10 @@ function printUsage(output: Pick<NodeJS.WriteStream, 'write'>) {
     '  lac scheduler edit <job-id> [--cron "<expr>"] [--message "<text>"] [--desc "<label>"] [--enabled true|false] [--execution-mode same-thread|side-thread] [--json]',
     '  lac scheduler del <job-id> [--json]',
     '  lac scheduler run <job-id> [--json]',
-    '  lac monitor add --title "<title>" --source stock.quote --symbol <symbol> --condition "change_percent >= 3" --message "<text>" [--cooldown 15m] [--execution-mode same-thread|side-thread] [--json]',
+    '  lac monitor add --title "<title>" --source stock.quote --symbol <symbol> --condition "change_percent >= 3" --message "<text>" [--cooldown 15m] [--cron "<expr>"] [--timezone <tz>] [--execution-mode same-thread|side-thread] [--json]',
     '  lac monitor list [--workspace <id>] [--thread [<id>]] [--json]',
     '  lac monitor info <monitor-id> [--json]',
-    '  lac monitor edit <monitor-id> [--title "<title>"] [--condition "<expr>"] [--message "<text>"] [--enabled true|false] [--cooldown 15m] [--execution-mode same-thread|side-thread] [--json]',
+    '  lac monitor edit <monitor-id> [--title "<title>"] [--condition "<expr>"] [--message "<text>"] [--enabled true|false] [--cooldown 15m] [--cron "<expr>"|off] [--timezone <tz>] [--execution-mode same-thread|side-thread] [--json]',
     '  lac monitor del <monitor-id> [--json]',
     '  lac monitor run <monitor-id> [--json]',
     '  lac automation add --title "<title>" --script-id <script-id> --script-version <approved-version-id> --interval <duration> --message "<prompt>" [--json]',
@@ -680,6 +689,7 @@ function formatMonitorDetails(monitor: AutomationMonitor, latestRun?: Automation
     `Source: ${monitor.sourceType}`,
     `Condition: ${formatCondition(monitor.condition)}`,
     `Cooldown: ${monitor.cooldownMs}ms`,
+    ...(monitor.schedule ? [`Schedule: ${monitor.schedule.cron} (${monitor.schedule.timezone})`] : []),
     `Enabled: ${monitor.enabled ? 'true' : 'false'}`,
     `Message: ${monitor.promptTemplate}`,
     latestRun ? `Latest run: ${latestRun.status} @ ${latestRun.triggeredAt}` : 'Latest run: none',

--- a/services/local-ai-core/src/cli/monitor-cli-parsers.ts
+++ b/services/local-ai-core/src/cli/monitor-cli-parsers.ts
@@ -1,4 +1,4 @@
-import type { AutomationMonitorCondition } from '@cc/superai-contracts';
+import type { AutomationMonitorCondition, AutomationMonitorSchedule } from '@cc/superai-contracts';
 import { normalizeAutomationMonitorConditionOperator } from '@cc/superai-contracts';
 
 export function parseMonitorCondition(value: string): AutomationMonitorCondition {
@@ -33,5 +33,16 @@ export function parseDurationMs(value: string) {
   const unit = String(match[2] || 'ms').toLowerCase();
   const multiplier = unit === 'h' ? 60 * 60 * 1000 : unit === 'm' ? 60 * 1000 : unit === 's' ? 1000 : 1;
   return Math.round(amount * multiplier);
+}
+
+export function parseMonitorSchedule(cron: string, timezone: string | undefined): AutomationMonitorSchedule {
+  const expression = String(cron || '').trim();
+  if (!expression) {
+    throw new Error('Monitor schedule cron expression must not be empty. Use "off" in monitor edit to clear it.');
+  }
+  return {
+    cron: expression,
+    timezone: String(timezone || 'Asia/Shanghai').trim() || 'Asia/Shanghai',
+  };
 }
 

--- a/tests/contracts/automation-contracts.test.ts
+++ b/tests/contracts/automation-contracts.test.ts
@@ -212,7 +212,7 @@ test('provider-event activation preserves a valid evaluation schedule', () => {
     sourceConfig: {},
     schedule: { cron: '0 11 * * 1-5', timezone: 'Asia/Shanghai' },
   });
-  assert.deepEqual(activation.schedule, { cron: '0 11 * * 1-5', timezone: 'Asia/Shanghai' });
+  assert.deepEqual(activation.kind === 'provider-event' ? activation.schedule : undefined, { cron: '0 11 * * 1-5', timezone: 'Asia/Shanghai' });
 
   const withoutSchedule = normalizeAutomationActivation({
     kind: 'provider-event',

--- a/tests/contracts/automation-contracts.test.ts
+++ b/tests/contracts/automation-contracts.test.ts
@@ -204,3 +204,36 @@ test('validates canonical timestamps', () => {
     /timestamp/,
   );
 });
+
+test('provider-event activation preserves a valid evaluation schedule', () => {
+  const activation = normalizeAutomationActivation({
+    kind: 'provider-event',
+    sourceType: 'stock.quote',
+    sourceConfig: {},
+    schedule: { cron: '0 11 * * 1-5', timezone: 'Asia/Shanghai' },
+  });
+  assert.deepEqual(activation.schedule, { cron: '0 11 * * 1-5', timezone: 'Asia/Shanghai' });
+
+  const withoutSchedule = normalizeAutomationActivation({
+    kind: 'provider-event',
+    sourceType: 'stock.quote',
+    sourceConfig: {},
+  });
+  assert.equal(withoutSchedule.kind === 'provider-event' ? withoutSchedule.schedule : undefined, undefined);
+});
+
+test('provider-event schedule requires both cron and timezone', () => {
+  const base = { kind: 'provider-event', sourceType: 'stock.quote', sourceConfig: {} };
+  assert.throws(
+    () => normalizeAutomationActivation({ ...base, schedule: { timezone: 'UTC' } }),
+    /schedule cron/,
+  );
+  assert.throws(
+    () => normalizeAutomationActivation({ ...base, schedule: { cron: '* * * * *' } }),
+    /schedule timezone/,
+  );
+  assert.throws(
+    () => normalizeAutomationActivation({ ...base, schedule: 'weekdays' }),
+    /schedule must be an object/,
+  );
+});

--- a/tests/electron/automation-monitor.test.ts
+++ b/tests/electron/automation-monitor.test.ts
@@ -8,6 +8,7 @@ import {
   validateRestrictedExpression,
 } from '../../services/local-ai-core/src/automation/condition-evaluator.js';
 import { AutomationMonitorService } from '../../services/local-ai-core/src/automation/automation-monitor-service.js';
+import { isMonitorWithinSchedule } from '../../services/local-ai-core/src/automation/automation-monitor-service.js';
 import { AutomationService } from '../../services/local-ai-core/src/automation/automation-service.js';
 import { monitorToAutomationInput } from '../../services/local-ai-core/src/automation/legacy-automation-mappers.js';
 import { LocalCoreAcpStore } from '../../services/local-ai-core/src/acp/local-core-acp-store.js';
@@ -1255,5 +1256,100 @@ test('unified monitor evaluation preserves nested legacy metrics and trusted sta
       subject: { market: 'NASDAQ' }, sourceType: { vendor: 'IEX' },
       lastEventId: 'spoofed', lastEventAt: 'spoofed', payload: { spoofed: true },
     });
+  } finally { await monitors.stop(); context.close(); }
+});
+
+test('schedule gate matches wall clock in the schedule timezone and fails open on corrupt state', () => {
+  const weekdayCron = { cron: '0 11 * * 1-5', timezone: 'Asia/Shanghai' };
+  // 11:00 Monday Asia/Shanghai (2026-08-24) is 03:00Z.
+  assert.equal(isMonitorWithinSchedule(weekdayCron, new Date('2026-08-24T03:00:00Z')), true);
+  assert.equal(isMonitorWithinSchedule(weekdayCron, new Date('2026-08-24T03:00:59Z')), true);
+  assert.equal(isMonitorWithinSchedule(weekdayCron, new Date('2026-08-24T04:01:00Z')), false);
+  assert.equal(isMonitorWithinSchedule(weekdayCron, new Date('2026-08-22T03:00:00Z')), false);
+  assert.equal(isMonitorWithinSchedule(undefined, new Date('2026-08-22T03:00:00Z')), true);
+  assert.equal(isMonitorWithinSchedule({ cron: 'not a cron', timezone: 'UTC' }, new Date()), true);
+  assert.equal(isMonitorWithinSchedule({ cron: '* * * * *', timezone: 'Mars/Phobos' }, new Date()), true);
+});
+
+test('monitor create persists a validated schedule and rejects invalid windows', async () => {
+  const context = monitorFixture();
+  const monitors = new AutomationMonitorService({
+    store: context.store, automations: context.automations, eventBus: context.eventBus, providers: [],
+  });
+  try {
+    await monitors.createMonitor({
+      workspaceId: 'workspace', title: 'Quote', sourceType: 'stock.quote',
+      condition: { metric: 'latestPrice', operator: '>', value: 1 }, promptTemplate: 'quote',
+      schedule: { cron: '0 11 * * 1-5', timezone: 'Asia/Shanghai' },
+    });
+    assert.deepEqual(monitors.listMonitors()[0]?.schedule, { cron: '0 11 * * 1-5', timezone: 'Asia/Shanghai' });
+
+    await assert.rejects(() => monitors.createMonitor({
+      workspaceId: 'workspace', title: 'Bad cron', sourceType: 'stock.quote',
+      condition: { metric: 'latestPrice', operator: '>', value: 1 }, promptTemplate: 'quote',
+      schedule: { cron: '0 11', timezone: 'Asia/Shanghai' },
+    }), /Monitor schedule is invalid/);
+    await assert.rejects(() => monitors.createMonitor({
+      workspaceId: 'workspace', title: 'Bad timezone', sourceType: 'stock.quote',
+      condition: { metric: 'latestPrice', operator: '>', value: 1 }, promptTemplate: 'quote',
+      schedule: { cron: '* * * * *', timezone: 'Mars/Phobos' },
+    }), /Monitor schedule is invalid/);
+    assert.equal(context.automations.list().length, 1);
+  } finally { await monitors.stop(); context.close(); }
+});
+
+test('monitor edit can set and clear the schedule window', async () => {
+  const context = monitorFixture();
+  const monitors = new AutomationMonitorService({
+    store: context.store, automations: context.automations, eventBus: context.eventBus, providers: [],
+  });
+  try {
+    const monitor = await monitors.createMonitor({
+      workspaceId: 'workspace', title: 'Quote', sourceType: 'stock.quote',
+      condition: { metric: 'latestPrice', operator: '>', value: 1 }, promptTemplate: 'quote',
+    });
+    assert.equal(monitors.listMonitors()[0]?.schedule, undefined);
+
+    await monitors.updateMonitor(monitor.id, { schedule: { cron: '30 9 * * 1-5', timezone: 'Asia/Shanghai' } });
+    assert.deepEqual(monitors.listMonitors()[0]?.schedule, { cron: '30 9 * * 1-5', timezone: 'Asia/Shanghai' });
+
+    await assert.rejects(() => monitors.updateMonitor(monitor.id, { schedule: { cron: 'nope', timezone: 'UTC' } }), /Monitor schedule is invalid/);
+
+    await monitors.updateMonitor(monitor.id, { schedule: null });
+    assert.equal(monitors.listMonitors()[0]?.schedule, undefined);
+  } finally { await monitors.stop(); context.close(); }
+});
+
+test('runTick skips out-of-window monitors while manual runs still poll', async () => {
+  const context = monitorFixture();
+  const polled: string[] = [];
+  const laterMinute = (new Date().getUTCMinutes() + 30) % 60;
+  const inWindow = context.automations.createFromLegacy(monitorToAutomationInput({
+    workspaceId: 'workspace', title: 'Always', sourceType: 'stock.quote', sourceConfig: { symbol: 'IN' },
+    condition: { metric: 'latestPrice', operator: '>', value: 1 }, promptTemplate: 'quote',
+    platform: 'local', route: { type: 'local.thread', channelId: 'workspace' },
+  }));
+  const outWindow = context.automations.createFromLegacy(monitorToAutomationInput({
+    workspaceId: 'workspace', title: 'Windowed', sourceType: 'stock.quote', sourceConfig: { symbol: 'OUT' },
+    condition: { metric: 'latestPrice', operator: '>', value: 1 }, promptTemplate: 'quote',
+    platform: 'local', route: { type: 'local.thread', channelId: 'workspace' },
+    schedule: { cron: `${laterMinute} * * * *`, timezone: 'UTC' },
+  }));
+  const monitors = new AutomationMonitorService({
+    store: context.store, automations: context.automations, eventBus: context.eventBus,
+    providers: [{ sourceType: 'stock.quote', modes: ['poll'], async poll({ sourceConfig }) {
+      polled.push(String(sourceConfig.symbol));
+      return null;
+    } }],
+  });
+  try {
+    await monitors.start();
+    assert.ok(polled.includes('IN'));
+    assert.equal(polled.includes('OUT'), false);
+
+    await monitors.runMonitorNow(outWindow.id);
+    assert.ok(polled.includes('OUT'));
+    assert.ok(monitors.listMonitors().find((candidate) => candidate.id === outWindow.id)?.schedule);
+    assert.equal(inWindow.id === outWindow.id, false);
   } finally { await monitors.stop(); context.close(); }
 });


### PR DESCRIPTION
## Summary
Closes #115 (Phase 1). Event monitors previously polled every enabled monitor unconditionally every 30s — weekends, nights, and non-trading hours included. This adds an optional cron schedule window so monitors only poll/evaluate when the current wall clock matches, covering "every trading day at 11:00" style workflows while keeping condition-triggered semantics and reducing upstream quote-API rate-limit pressure.

## Changes
- **Contracts** (`packages/contracts/src/automations.ts`, `automation.ts`): new `AutomationMonitorSchedule { cron, timezone }`; optional `schedule` on the `provider-event` activation variant, `AutomationMonitor`, and its create/update inputs (`null` on update clears the window); `normalizeAutomationMonitorSchedule` + preservation in `normalizeAutomationActivation`.
- **Engine** (`automation-monitor-service.ts`): timezone-aware cron gate (`isMonitorWithinSchedule`, reusing the scheduler's cron matcher) filters the polling tick; cron/timezone validated on create/edit with a clear error; manual `runMonitorNow` bypasses the gate.
- **Mappers** (`legacy-automation-mappers.ts`): schedule carried both directions between monitor inputs and the persisted provider-event activation (activation is stored as JSON — no schema migration needed).
- **CLI** (`lac.ts`, `monitor-cli-parsers.ts`): `monitor add --cron "<expr>" [--timezone <tz>]` (default `Asia/Shanghai`), `monitor edit --cron "<expr>"|off` (`off` clears); `monitor info` shows a `Schedule:` line; help text updated.
- **README**: `New` section entry.

## Implementation
Cron matching reuses `compileCronExpression` / `extractFieldsInTimezone` / `cronMatchesFields` from the existing scheduler (same primitive the `cron` activation uses), so timezone and DST handling stay in one place. The tick's 30s granularity naturally covers each matching minute. The gate fails open on invalid stored state as a last-resort (schedules are validated at the boundary, so this only guards corrupted data) — silently dropping evaluations would be worse for a monitoring tool.

## Testing
- `tests/electron/automation-monitor.test.ts` (+4): gate purity (timezone match, minute bounds, weekend exclusion, fail-open), create persists valid schedule / rejects bad cron and bad timezone, edit set + clear + reject, runTick polls in-window monitor and skips out-of-window monitor while `runMonitorNow` still polls — 43/43 pass.
- `tests/contracts/automation-contracts.test.ts` (+2): schedule normalization preservation and required-field errors — 10/10 pass.
- `pnpm test` full suite (typecheck + renderer/electron builds + node tests + BDD): pass.
- Lint gates: circular 0, duplicate (CI thresholds) pass, complexity 107 ≤ 108 baseline, function-length 45 = baseline, file-size clean.

## Compatibility
No breaking changes. Additive optional field: monitors without a schedule keep the exact 24×7 polling behavior; existing persisted activations normalize unchanged; no API/CLI removals, no config or data migration.

## Risk
Low. Scope is limited to polling monitors in the tick loop; subscription-style providers (startMonitor) are unaffected — schedule windows for push-style sources are left for a later phase, as is trading-calendar gating (issue Phase 2). Cron windows express per-minute matches, so a continuous trading-session window is approximated with cron ranges until a calendar/window-range phase lands.

## Issue
Closes #115