### PR TITLE
Support workspace and channel provider resolution with session fingerprinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ flowchart LR
 
 ## New
 
+### 2026-09-02
+
+- 定时任务与渠道会话 LLM Provider 动态继承与会话指纹隔离：
+  - **Workspace + Channel Provider 层次继承模型**：定时任务与渠道消息严格跟随当前工作区与渠道绑定的 Provider 配置；支持渠道级独立覆写（`preferred_provider_id`），未单独覆写时严格继承工作区默认配置，确保提供商切换实时生效。
+  - **Session 强指纹防污染**：ACP 会话管理器建立模型提供商启动指纹（`buildSessionProviderKey`）；当提供商凭证、Base URL 或 Model 变更时，自动失效并拒绝载入旧 Session，避免跨提供商旧端点残留导致的 401 认证异常。
+  - **渠道交互式 `/provider` 指令**：支持在飞书/微信等渠道直接使用 `/provider current`、`/provider list`、`/provider use <id>` 与 `/provider reset` 进行渠道级 Provider 查询、切换与重置。
+
 ### 2026-08-28
 
 - 事件监控支持 cron 时间窗（Issue #115 Phase 1）：

--- a/services/local-ai-core/src/acp/local-core-acp-backend.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-backend.ts
@@ -171,6 +171,21 @@ export class LocalCoreAcpBackend {
         setThreadMode: (threadId, mode) => this.sessionCoordinator.setThreadMode(threadId, mode),
         closeThreadSession: (threadId) => this.sessionCoordinator.closeThreadSession(threadId),
         interruptRun: (runId) => this.sessionCoordinator.interruptRun(runId),
+        listModelProviders: () => this.options.store.listModelProviders(),
+        getModelProvider: (providerId) => this.options.store.getModelProvider(providerId),
+        getWorkspaceDefaultProviderId: (workspaceId) => {
+          const config = this.options.store.readRuntimeConfig().config;
+          const project = config?.projects?.find((p: any) => p.name === workspaceId || p.workspace_id === workspaceId);
+          return String(project?.agent?.options?.provider_id || '').trim();
+        },
+        getChannelBinding: (workspaceId, chatId, platformUserId, platform) => this.options.store.getPlatformThreadBinding(workspaceId, chatId, platformUserId, platform),
+        setChannelPreferredProvider: (input) => this.options.store.updatePlatformThreadPreferredProvider(
+          input.workspaceId,
+          input.chatId,
+          input.platformUserId,
+          input.providerId,
+          input.platform,
+        ),
         log: options.log,
       },
     });

--- a/services/local-ai-core/src/acp/local-core-acp-session-coordinator.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-session-coordinator.ts
@@ -134,7 +134,17 @@ export class LocalCoreAcpSessionCoordinator {
     await this.options.transport.initializeSession(session);
     this.options.log?.(`[acp.session:${threadId}] initialize done in ${Date.now() - startedAt}ms`);
     const row = this.options.store.getThreadRow(threadId);
-    if (row?.acp_session_id && row.acp_supports_load && session.supportsLoad) {
+    const providerKey = this.buildSessionProviderKey(config);
+    const hasProviderMismatch = Boolean(
+      row?.acp_launch_config_key && row.acp_launch_config_key !== providerKey,
+    );
+    if (hasProviderMismatch && row?.acp_session_id) {
+      this.options.log?.(
+        `[acp.session:${threadId}] provider configuration mismatch (stored=${row.acp_launch_config_key} current=${providerKey}); ` +
+        `discarding stale session ${row.acp_session_id} to prevent provider/model pollution`,
+      );
+    }
+    if (row?.acp_session_id && row.acp_supports_load && session.supportsLoad && !hasProviderMismatch) {
       try {
         session.loadReplayMode = true;
         await this.options.transport.request(session, 'session/load', {
@@ -160,12 +170,14 @@ export class LocalCoreAcpSessionCoordinator {
         if (!session.sessionId) {
           throw new Error('ACP session/new did not return a sessionId');
         }
-        this.options.store.updateThreadSession(threadId, session.sessionId, session.supportsLoad);
+        this.options.store.updateThreadSession(threadId, session.sessionId, session.supportsLoad, providerKey);
         this.options.log?.(`[acp.session:${threadId}] session/new done in ${Date.now() - startedAt}ms`);
       } catch (error) {
         this.closeThreadSession(threadId);
         throw error;
       }
+    } else if (!row?.acp_launch_config_key) {
+      this.options.store.updateThreadSession(threadId, session.sessionId, session.supportsLoad, providerKey);
     }
     this.options.log?.(`[acp.session:${threadId}] ready in ${Date.now() - startedAt}ms`);
     return session;
@@ -344,6 +356,16 @@ export class LocalCoreAcpSessionCoordinator {
       execution: config.execution || null,
       sandbox: config.sandbox || null,
       mcpServers: toAcpMcpServers(config),
+    });
+  }
+
+  private buildSessionProviderKey(config: LocalCoreProjectConfig) {
+    const env = config.env || {};
+    return JSON.stringify({
+      agentType: config.agentType,
+      model: config.model || '',
+      baseUrl: env.OPENAI_BASE_URL || env.HERMES_BASE_URL || env.ANTHROPIC_BASE_URL || '',
+      apiKey: env.OPENAI_API_KEY || env.HERMES_API_KEY || env.ANTHROPIC_API_KEY || '',
     });
   }
 

--- a/services/local-ai-core/src/acp/local-core-acp-session-coordinator.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-session-coordinator.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { delimiter, win32 } from 'node:path';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -140,7 +141,7 @@ export class LocalCoreAcpSessionCoordinator {
     );
     if (hasProviderMismatch && row?.acp_session_id) {
       this.options.log?.(
-        `[acp.session:${threadId}] provider configuration mismatch (stored=${row.acp_launch_config_key} current=${providerKey}); ` +
+        `[acp.session:${threadId}] provider configuration mismatch (stored=${this.sanitizeProviderKeyForLog(row.acp_launch_config_key)} current=${this.sanitizeProviderKeyForLog(providerKey)}); ` +
         `discarding stale session ${row.acp_session_id} to prevent provider/model pollution`,
       );
     }
@@ -361,12 +362,28 @@ export class LocalCoreAcpSessionCoordinator {
 
   private buildSessionProviderKey(config: LocalCoreProjectConfig) {
     const env = config.env || {};
+    const rawApiKey = env.OPENAI_API_KEY || env.HERMES_API_KEY || env.ANTHROPIC_API_KEY || '';
+    const keyHash = rawApiKey ? createHash('sha256').update(rawApiKey).digest('hex').slice(0, 16) : '';
     return JSON.stringify({
       agentType: config.agentType,
       model: config.model || '',
       baseUrl: env.OPENAI_BASE_URL || env.HERMES_BASE_URL || env.ANTHROPIC_BASE_URL || '',
-      apiKey: env.OPENAI_API_KEY || env.HERMES_API_KEY || env.ANTHROPIC_API_KEY || '',
+      keyHash,
     });
+  }
+
+  private sanitizeProviderKeyForLog(key?: string | null) {
+    if (!key) return 'none';
+    try {
+      const parsed = JSON.parse(key);
+      if (parsed && typeof parsed === 'object') {
+        const { apiKey: _removed, ...rest } = parsed as Record<string, unknown>;
+        return JSON.stringify(rest);
+      }
+    } catch {
+      // ignore
+    }
+    return 'fingerprint';
   }
 
   private resolveLaunchPermissionMode(threadId: string, permissionModeOverride = '') {

--- a/services/local-ai-core/src/acp/store/acp-store-types.ts
+++ b/services/local-ai-core/src/acp/store/acp-store-types.ts
@@ -14,6 +14,7 @@ export type LocalThreadRow = {
   acp_session_id: string | null;
   acp_supports_load: number;
   agent_mode: string;
+  acp_launch_config_key?: string | null;
 };
 
 export type LocalMessageRow = {
@@ -301,6 +302,7 @@ export type LocalPlatformThreadBindingRow = {
   thread_id: string;
   last_platform_message_id: string | null;
   preferred_agent_type?: string | null;
+  preferred_provider_id?: string | null;
   created_at: string;
   updated_at: string;
 };

--- a/services/local-ai-core/src/acp/store/local-core-acp-store.ts
+++ b/services/local-ai-core/src/acp/store/local-core-acp-store.ts
@@ -228,10 +228,20 @@ export class LocalCoreAcpStore {
   }
 
   upsertModelProvider(input: DesktopModelProviderInput): DesktopModelProvider {
-    return this.modelProviders.upsert(input);
+    const existing = input.id ? this.modelProviders.get(input.id) : undefined;
+    const result = this.modelProviders.upsert(input);
+    if (existing && (existing.base_url !== result.base_url || existing.api_key !== result.api_key)) {
+      this.threads.clearAllSessions();
+    }
+    return result;
+  }
+
+  clearAllThreadSessions() {
+    this.threads.clearAllSessions();
   }
 
   deleteModelProvider(providerId: string) {
+    this.threads.clearAllSessions();
     return this.modelProviders.delete(providerId);
   }
 
@@ -676,8 +686,16 @@ export class LocalCoreAcpStore {
     this.threads.updateAgentType(threadId, agentType);
   }
 
-  updateThreadSession(threadId: string, sessionId: string, supportsLoad: boolean) {
-    this.threads.updateSession(threadId, sessionId, supportsLoad);
+  updateThreadSession(threadId: string, sessionId: string, supportsLoad: boolean, launchConfigKey?: string | null) {
+    this.threads.updateSession(threadId, sessionId, supportsLoad, launchConfigKey);
+  }
+
+  clearThreadSession(threadId: string) {
+    this.threads.clearSession(threadId);
+  }
+
+  clearWorkspaceThreadSessions(workspaceId: string) {
+    this.threads.clearWorkspaceSessions(workspaceId);
   }
 
   createPairingRequest(input: Omit<LocalPlatformPairingRow, 'platform'> & { platform?: string }) {
@@ -744,6 +762,16 @@ export class LocalCoreAcpStore {
     platform = 'lark',
   ) {
     this.platform.updatePlatformThreadPreferredAgent(workspaceId, chatId, platformUserId, agentType, platform);
+  }
+
+  updatePlatformThreadPreferredProvider(
+    workspaceId: string,
+    chatId: string,
+    platformUserId: string,
+    providerId: string | null,
+    platform = 'lark',
+  ) {
+    this.platform.updatePlatformThreadPreferredProvider(workspaceId, chatId, platformUserId, providerId, platform);
   }
 
   updatePlatformThreadMessageId(workspaceId: string, chatId: string, platformUserId: string, messageId: string, platform = 'lark') {

--- a/services/local-ai-core/src/acp/store/platform-store.ts
+++ b/services/local-ai-core/src/acp/store/platform-store.ts
@@ -140,7 +140,7 @@ export class LocalPlatformStore {
 
   getPlatformThreadBinding(workspaceId: string, chatId: string, platformUserId: string, platform = 'lark') {
     return this.db.prepare(`
-      SELECT workspace_id, platform, chat_id, platform_user_id, thread_id, last_platform_message_id, preferred_agent_type, created_at, updated_at
+      SELECT workspace_id, platform, chat_id, platform_user_id, thread_id, last_platform_message_id, preferred_agent_type, preferred_provider_id, created_at, updated_at
       FROM platform_thread_bindings
       WHERE workspace_id = ? AND platform = ? AND chat_id = ? AND platform_user_id = ?
     `).get(workspaceId, platform, chatId, platformUserId) as LocalPlatformThreadBindingRow | undefined;
@@ -148,7 +148,7 @@ export class LocalPlatformStore {
 
   getPlatformThreadBindingByThreadId(threadId: string) {
     return this.db.prepare(`
-      SELECT workspace_id, platform, chat_id, platform_user_id, thread_id, last_platform_message_id, preferred_agent_type, created_at, updated_at
+      SELECT workspace_id, platform, chat_id, platform_user_id, thread_id, last_platform_message_id, preferred_agent_type, preferred_provider_id, created_at, updated_at
       FROM platform_thread_bindings
       WHERE thread_id = ?
       ORDER BY updated_at DESC
@@ -163,12 +163,13 @@ export class LocalPlatformStore {
   upsertPlatformThreadBinding(input: Omit<LocalPlatformThreadBindingRow, 'platform'> & { platform?: string }) {
     this.db.prepare(`
       INSERT INTO platform_thread_bindings
-      (workspace_id, platform, chat_id, platform_user_id, thread_id, last_platform_message_id, preferred_agent_type, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (workspace_id, platform, chat_id, platform_user_id, thread_id, last_platform_message_id, preferred_agent_type, preferred_provider_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(workspace_id, platform, chat_id, platform_user_id) DO UPDATE SET
         thread_id = excluded.thread_id,
         last_platform_message_id = COALESCE(excluded.last_platform_message_id, platform_thread_bindings.last_platform_message_id),
         preferred_agent_type = COALESCE(excluded.preferred_agent_type, platform_thread_bindings.preferred_agent_type),
+        preferred_provider_id = COALESCE(excluded.preferred_provider_id, platform_thread_bindings.preferred_provider_id),
         updated_at = excluded.updated_at
     `).run(
       input.workspace_id,
@@ -178,6 +179,7 @@ export class LocalPlatformStore {
       input.thread_id,
       input.last_platform_message_id,
       input.preferred_agent_type ?? null,
+      input.preferred_provider_id ?? null,
       input.created_at,
       input.updated_at,
     );
@@ -195,6 +197,20 @@ export class LocalPlatformStore {
       SET preferred_agent_type = ?, updated_at = ?
       WHERE workspace_id = ? AND platform = ? AND chat_id = ? AND platform_user_id = ?
     `).run(agentType, new Date().toISOString(), workspaceId, platform, chatId, platformUserId);
+  }
+
+  updatePlatformThreadPreferredProvider(
+    workspaceId: string,
+    chatId: string,
+    platformUserId: string,
+    providerId: string | null,
+    platform = 'lark',
+  ) {
+    this.db.prepare(`
+      UPDATE platform_thread_bindings
+      SET preferred_provider_id = ?, updated_at = ?
+      WHERE workspace_id = ? AND platform = ? AND chat_id = ? AND platform_user_id = ?
+    `).run(providerId, new Date().toISOString(), workspaceId, platform, chatId, platformUserId);
   }
 
   updatePlatformThreadMessageId(workspaceId: string, chatId: string, platformUserId: string, messageId: string, platform = 'lark') {

--- a/services/local-ai-core/src/acp/store/schema.ts
+++ b/services/local-ai-core/src/acp/store/schema.ts
@@ -29,7 +29,8 @@ export function ensureLocalCoreAcpSchema(db: DatabaseSync) {
       excerpt TEXT NOT NULL DEFAULT '',
       acp_session_id TEXT,
       acp_supports_load INTEGER NOT NULL DEFAULT 0,
-      agent_mode TEXT NOT NULL DEFAULT 'default'
+      agent_mode TEXT NOT NULL DEFAULT 'default',
+      acp_launch_config_key TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_threads_workspace_updated ON threads (workspace_id, updated_at DESC);
     CREATE TABLE IF NOT EXISTS messages (
@@ -102,6 +103,8 @@ export function ensureLocalCoreAcpSchema(db: DatabaseSync) {
       platform_user_id TEXT NOT NULL,
       thread_id TEXT NOT NULL,
       last_platform_message_id TEXT,
+      preferred_agent_type TEXT,
+      preferred_provider_id TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
       PRIMARY KEY (workspace_id, platform, chat_id, platform_user_id)
@@ -474,6 +477,7 @@ export function ensureLocalCoreAcpSchema(db: DatabaseSync) {
   ensureColumn(db, 'messages', 'bridge_kind', 'TEXT');
   ensureColumn(db, 'messages', 'bridge_status', 'TEXT');
   ensureColumn(db, 'platform_thread_bindings', 'preferred_agent_type', 'TEXT');
+  ensureColumn(db, 'platform_thread_bindings', 'preferred_provider_id', 'TEXT');
   ensureColumn(db, 'scheduled_jobs', 'execution_mode', "TEXT NOT NULL DEFAULT 'same-thread'");
   ensureColumn(db, 'scheduled_job_runs', 'platform_message_ids_json', 'TEXT');
   ensureColumn(db, 'scheduled_job_runs', 'delivery_mode', 'TEXT');
@@ -481,6 +485,7 @@ export function ensureLocalCoreAcpSchema(db: DatabaseSync) {
   ensureColumn(db, 'scheduled_job_runs', 'delivery_error', 'TEXT');
   ensureColumn(db, 'scheduled_job_runs', 'last_bridge_event_at', 'TEXT');
   ensureColumn(db, 'threads', 'agent_mode', "TEXT NOT NULL DEFAULT 'default'");
+  ensureColumn(db, 'threads', 'acp_launch_config_key', 'TEXT');
   ensureColumn(db, 'automations', 'legacy_metadata_json', 'TEXT');
   ensureColumn(db, 'model_providers', 'unit_price_in', 'REAL');
   ensureColumn(db, 'model_providers', 'unit_price_out', 'REAL');

--- a/services/local-ai-core/src/acp/store/thread-store.ts
+++ b/services/local-ai-core/src/acp/store/thread-store.ts
@@ -253,7 +253,7 @@ export class LocalThreadStore {
 
   getRow(threadId: string) {
     return this.db.prepare(`
-      SELECT id, workspace_id, session_id, bridge_session_key, title, agent_type, created_at, updated_at, history_count, excerpt, acp_session_id, acp_supports_load, agent_mode
+      SELECT id, workspace_id, session_id, bridge_session_key, title, agent_type, created_at, updated_at, history_count, excerpt, acp_session_id, acp_supports_load, agent_mode, acp_launch_config_key
       FROM threads
       WHERE id = ?
     `).get(threadId) as LocalThreadRow | undefined;
@@ -270,16 +270,39 @@ export class LocalThreadStore {
   updateAgentType(threadId: string, agentType: string) {
     this.db.prepare(`
       UPDATE threads
-      SET agent_type = ?, acp_session_id = NULL, acp_supports_load = 0, updated_at = ?
+      SET agent_type = ?, acp_session_id = NULL, acp_supports_load = 0, acp_launch_config_key = NULL, updated_at = ?
       WHERE id = ?
     `).run(agentType, new Date().toISOString(), threadId);
   }
 
-  updateSession(threadId: string, sessionId: string, supportsLoad: boolean) {
+  updateSession(threadId: string, sessionId: string, supportsLoad: boolean, launchConfigKey?: string | null) {
     this.db.prepare(`
       UPDATE threads
-      SET acp_session_id = ?, acp_supports_load = ?, updated_at = COALESCE(updated_at, ?)
+      SET acp_session_id = ?, acp_supports_load = ?, acp_launch_config_key = ?, updated_at = COALESCE(updated_at, ?)
       WHERE id = ?
-    `).run(sessionId, supportsLoad ? 1 : 0, new Date().toISOString(), threadId);
+    `).run(sessionId, supportsLoad ? 1 : 0, launchConfigKey ?? null, new Date().toISOString(), threadId);
+  }
+
+  clearSession(threadId: string) {
+    this.db.prepare(`
+      UPDATE threads
+      SET acp_session_id = NULL, acp_supports_load = 0, acp_launch_config_key = NULL, updated_at = ?
+      WHERE id = ?
+    `).run(new Date().toISOString(), threadId);
+  }
+
+  clearWorkspaceSessions(workspaceId: string) {
+    this.db.prepare(`
+      UPDATE threads
+      SET acp_session_id = NULL, acp_supports_load = 0, acp_launch_config_key = NULL, updated_at = ?
+      WHERE workspace_id = ?
+    `).run(new Date().toISOString(), workspaceId);
+  }
+
+  clearAllSessions() {
+    this.db.prepare(`
+      UPDATE threads
+      SET acp_session_id = NULL, acp_supports_load = 0, acp_launch_config_key = NULL, updated_at = ?
+    `).run(new Date().toISOString());
   }
 }

--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -498,6 +498,7 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
         type: 'channel.chat',
         channelId: msg.chatId,
         participantId: msg.platformUserId,
+        metadata: { platform: 'lark' },
       },
     });
     return; // { paired: true, threadId };

--- a/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
+++ b/services/local-ai-core/src/channel/lark/local-core-lark-gateway.ts
@@ -493,7 +493,13 @@ export class LocalCoreLarkGateway extends BaseChannelGateway<LarkRuntimeState, L
       return;
     }
     this.options.store.clearPlatformThreadMessageId(msg.workspaceId, msg.chatId, msg.platformUserId);
-    await router.sendThreadMessage(threadId, createChannelThreadMessageInput(msg.text, msg.contentParts));
+    await router.sendThreadMessage(threadId, createChannelThreadMessageInput(msg.text, msg.contentParts), {
+      channelRoute: {
+        type: 'channel.chat',
+        channelId: msg.chatId,
+        participantId: msg.platformUserId,
+      },
+    });
     return; // { paired: true, threadId };
   }
 

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -143,6 +143,21 @@ export abstract class BaseChannelGateway<
           input.agentType,
           input.platform,
         ),
+        listModelProviders: () => options.store.listModelProviders(),
+        getModelProvider: (providerId) => options.store.getModelProvider(providerId),
+        getWorkspaceDefaultProviderId: (workspaceId) => {
+          const config = options.store.readRuntimeConfig().config;
+          const project = config?.projects?.find((p: any) => p.name === workspaceId || p.workspace_id === workspaceId);
+          return String(project?.agent?.options?.provider_id || '').trim();
+        },
+        getChannelBinding: (workspaceId, chatId, platformUserId, platform) => options.store.getPlatformThreadBinding(workspaceId, chatId, platformUserId, platform),
+        setChannelPreferredProvider: (input) => options.store.updatePlatformThreadPreferredProvider(
+          input.workspaceId,
+          input.chatId,
+          input.platformUserId,
+          input.providerId,
+          input.platform,
+        ),
         log: options.log,
       },
     });

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -440,8 +440,14 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
       msg.contextToken || msg.messageId,
       platformKey,
     );
-    await router.sendThreadMessage(threadId, createChannelThreadMessageInput(msg.text, msg.contentParts));
-      return;
+    await router.sendThreadMessage(threadId, createChannelThreadMessageInput(msg.text, msg.contentParts), {
+      channelRoute: {
+        type: 'channel.chat',
+        channelId: msg.chatId,
+        participantId: msg.platformUserId,
+      },
+    });
+    return;
   }
 
 

--- a/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
+++ b/services/local-ai-core/src/channel/weixin/local-core-weixin-gateway.ts
@@ -445,6 +445,7 @@ export class LocalCoreWeixinGateway extends BaseChannelGateway<WeixinRuntimeStat
         type: 'channel.chat',
         channelId: msg.chatId,
         participantId: msg.platformUserId,
+        metadata: { platform: 'weixin' },
       },
     });
     return;

--- a/services/local-ai-core/src/router/workspace-router-types.ts
+++ b/services/local-ai-core/src/router/workspace-router-types.ts
@@ -4,6 +4,7 @@ import type {
   AutomationEvaluation,
   AutomationRun,
   ChannelInboundMessageContent,
+  ChannelRoute,
   RuntimeConfigState,
   LocalCoreCapabilities,
   ThreadDetail,
@@ -173,4 +174,7 @@ export type WorkspaceThreadBackend = {
 export type WorkspaceThreadMessageOptions = {
   permissionMode?: string;
   runtimeEnv?: Record<string, string>;
+  channelRoute?: ChannelRoute;
+  providerIdOverride?: string;
+  agentTypeOverride?: string;
 };

--- a/services/local-ai-core/src/router/workspace-router.ts
+++ b/services/local-ai-core/src/router/workspace-router.ts
@@ -12,6 +12,7 @@ import type {
   AuditEventListQuery,
   AuditEventListResponse,
   ChannelInboundMessageContent,
+  ChannelRoute,
   CommandRiskClassification,
   DesktopBridgeEvent,
   LocalCoreCapabilities,
@@ -263,14 +264,14 @@ export class WorkspaceRouter {
     const { workspaceId } = decodeThreadId(threadId);
     const route = isLocalSlashCommand(content)
       ? await this.getWorkspaceRoute(workspaceId)
-      : await this.getThreadWorkspaceRoute(threadId, workspaceId);
+      : await this.getThreadWorkspaceRoute(threadId, workspaceId, options);
     const preparedContent = await this.prepareAgentMessage(threadId, content, route.config.workDir);
     return this.localCoreAcp.sendThreadMessage(threadId, preparedContent, route.config, options);
   }
 
-  async sendThreadAction(threadId: string, content: string) {
+  async sendThreadAction(threadId: string, content: string, options?: WorkspaceThreadMessageOptions) {
     const { workspaceId } = decodeThreadId(threadId);
-    const route = await this.getThreadWorkspaceRoute(threadId, workspaceId);
+    const route = await this.getThreadWorkspaceRoute(threadId, workspaceId, options);
     return this.localCoreAcp.sendThreadAction(threadId, content, route.config);
   }
 
@@ -552,20 +553,36 @@ export class WorkspaceRouter {
     }
   }
 
-  private async getThreadWorkspaceRoute(threadId: string, workspaceId: string): Promise<WorkspaceRoute> {
-    const defaultRoute = await this.getWorkspaceRoute(workspaceId);
+  private async getThreadWorkspaceRoute(
+    threadId: string,
+    workspaceId: string,
+    options?: WorkspaceThreadMessageOptions,
+  ): Promise<WorkspaceRoute> {
     const row = this.store.getThreadRow(threadId);
     const threadAgentType = String(row?.agent_type || '').trim().toLowerCase();
-    const route = !threadAgentType || threadAgentType === defaultRoute.agentType
-      ? defaultRoute
-      : await this.getWorkspaceRoute(workspaceId, threadAgentType);
+    const binding = this.resolveThreadBinding(workspaceId, threadId, options?.channelRoute);
+    const effectiveAgentType = options?.agentTypeOverride
+      || (binding?.preferred_agent_type && binding.preferred_agent_type !== threadAgentType ? binding.preferred_agent_type : '');
+    const effectiveProviderId = options?.providerIdOverride || binding?.preferred_provider_id || '';
+    const route = await this.getWorkspaceRoute(workspaceId, effectiveAgentType, effectiveProviderId);
     const externalThread = this.store.getExternalThreadByThreadId(threadId);
-    return externalThread
-      ? withThreadWorkspacePath(route, externalThread.workspacePath)
-      : route;
+    return externalThread ? withThreadWorkspacePath(route, externalThread.workspacePath) : route;
   }
 
-  private async getWorkspaceRoute(workspaceId: string, agentTypeOverride = ''): Promise<WorkspaceRoute> {
+  private resolveThreadBinding(workspaceId: string, threadId: string, channelRoute?: ChannelRoute) {
+    if (channelRoute) {
+      const platform = channelRoute.type?.replace(/^channel\./, '') || 'lark';
+      return this.store.getPlatformThreadBinding(
+        workspaceId,
+        channelRoute.channelId,
+        channelRoute.participantId || '',
+        platform,
+      );
+    }
+    return this.store.getPlatformThreadBindingByThreadId(threadId);
+  }
+
+  private async getWorkspaceRoute(workspaceId: string, agentTypeOverride = '', providerIdOverride = ''): Promise<WorkspaceRoute> {
     const configState = await this.options.readRuntimeConfig();
     const projects = this.withWorkspaceIds(
       Array.isArray(configState.config?.projects) ? configState.config.projects : [],
@@ -575,7 +592,13 @@ export class WorkspaceRouter {
       config: { ...configState.config, projects },
     };
     const matched = projects.find((project) => projectWorkspaceId(project) === workspaceId);
-    const project = matched && agentTypeOverride ? withAgentTypeOverride(matched, agentTypeOverride) : matched;
+    let project = matched;
+    if (project && agentTypeOverride) {
+      project = withAgentTypeOverride(project, agentTypeOverride);
+    }
+    if (project && providerIdOverride) {
+      project = withProviderOverride(project, providerIdOverride);
+    }
     const route = project ? this.resolveProjectRoute(projectedConfigState, project) : null;
     if (!matched || !route) {
       throw new Error(`Workspace "${workspaceId}" is not configured as a Local AI Core ACP workspace.`);
@@ -586,6 +609,15 @@ export class WorkspaceRouter {
   async getWorkspaceAgentType(workspaceId: string): Promise<string> {
     const route = await this.getWorkspaceRoute(workspaceId);
     return route.agentType;
+  }
+
+  async getWorkspaceDefaultProviderId(workspaceId: string): Promise<string> {
+    const configState = await this.options.readRuntimeConfig();
+    const projects = this.withWorkspaceIds(
+      Array.isArray(configState.config?.projects) ? configState.config.projects : [],
+    );
+    const matched = projects.find((project) => projectWorkspaceId(project) === workspaceId);
+    return String(matched?.agent?.options?.provider_id || '').trim();
   }
 
   private async listLocalCoreProjects() {
@@ -662,6 +694,22 @@ export function createWorkspaceRouter(options: WorkspaceRouterOptions) {
   return new WorkspaceRouter(options);
 }
 
+function withProviderOverride(project: DesktopProjectConfig, providerId: string): DesktopProjectConfig {
+  const options = project.agent?.options && typeof project.agent.options === 'object'
+    ? { ...(project.agent.options as Record<string, unknown>) }
+    : {};
+  return {
+    ...project,
+    agent: {
+      ...(project.agent || {}),
+      options: {
+        ...options,
+        provider_id: providerId,
+      },
+    },
+  };
+}
+
 function withAgentTypeOverride(project: DesktopProjectConfig, agentType: string): DesktopProjectConfig {
   const options = project.agent?.options && typeof project.agent.options === 'object'
     ? { ...(project.agent.options as Record<string, unknown>) }
@@ -703,6 +751,8 @@ function isLocalSlashCommand(content: string | ChannelInboundMessageContent) {
   const normalized = text.trim().toLowerCase();
   return normalized === '/agent'
     || normalized.startsWith('/agent ')
+    || normalized === '/provider'
+    || normalized.startsWith('/provider ')
     || normalized === '/mode'
     || normalized.startsWith('/mode ');
 }

--- a/services/local-ai-core/src/router/workspace-router.ts
+++ b/services/local-ai-core/src/router/workspace-router.ts
@@ -570,16 +570,42 @@ export class WorkspaceRouter {
   }
 
   private resolveThreadBinding(workspaceId: string, threadId: string, channelRoute?: ChannelRoute) {
-    if (channelRoute) {
-      const platform = channelRoute.type?.replace(/^channel\./, '') || 'lark';
-      return this.store.getPlatformThreadBinding(
-        workspaceId,
-        channelRoute.channelId,
-        channelRoute.participantId || '',
-        platform,
-      );
+    const threadBinding = this.store.getPlatformThreadBindingByThreadId(threadId);
+    if (threadBinding) {
+      return threadBinding;
     }
-    return this.store.getPlatformThreadBindingByThreadId(threadId);
+    if (channelRoute) {
+      const explicitPlatform = typeof channelRoute.metadata?.platform === 'string'
+        ? channelRoute.metadata.platform
+        : '';
+      const platformCandidate = explicitPlatform
+        || (channelRoute.type?.startsWith('channel.') && channelRoute.type !== 'channel.chat'
+          ? channelRoute.type.replace(/^channel\./, '')
+          : '');
+      if (platformCandidate) {
+        const binding = this.store.getPlatformThreadBinding(
+          workspaceId,
+          channelRoute.channelId,
+          channelRoute.participantId || '',
+          platformCandidate,
+        );
+        if (binding) {
+          return binding;
+        }
+      }
+      for (const platform of ['lark', 'weixin']) {
+        const binding = this.store.getPlatformThreadBinding(
+          workspaceId,
+          channelRoute.channelId,
+          channelRoute.participantId || '',
+          platform,
+        );
+        if (binding) {
+          return binding;
+        }
+      }
+    }
+    return undefined;
   }
 
   private async getWorkspaceRoute(workspaceId: string, agentTypeOverride = '', providerIdOverride = ''): Promise<WorkspaceRoute> {

--- a/services/local-ai-core/src/scheduler/scheduled-conversation-executor.ts
+++ b/services/local-ai-core/src/scheduler/scheduled-conversation-executor.ts
@@ -26,6 +26,7 @@ export class ScheduledConversationExecutor {
       const sendResult = await workspaceRouter.sendThreadMessage(target.threadId, prompt, {
         permissionMode: SCHEDULED_RUN_PERMISSION_MODE,
         runtimeEnv: buildPlatformRuntimeEnv(target.platform, target.route),
+        channelRoute: target.route,
       });
       await waitForRunCompletion({
         store: this.options.store,

--- a/services/local-ai-core/src/scheduler/scheduled-conversation-executor.ts
+++ b/services/local-ai-core/src/scheduler/scheduled-conversation-executor.ts
@@ -26,7 +26,13 @@ export class ScheduledConversationExecutor {
       const sendResult = await workspaceRouter.sendThreadMessage(target.threadId, prompt, {
         permissionMode: SCHEDULED_RUN_PERMISSION_MODE,
         runtimeEnv: buildPlatformRuntimeEnv(target.platform, target.route),
-        channelRoute: target.route,
+        channelRoute: {
+          ...target.route,
+          metadata: {
+            ...(target.route?.metadata || {}),
+            platform: target.platform,
+          },
+        },
       });
       await waitForRunCompletion({
         store: this.options.store,

--- a/services/local-ai-core/src/thread/thread-command-service.ts
+++ b/services/local-ai-core/src/thread/thread-command-service.ts
@@ -214,37 +214,73 @@ export class ThreadCommandService {
     }
   }
 
+  private resolveProviderState(workspaceId: string, channel?: ThreadCommandChannelContext) {
+    const defaultProviderId = this.options.getWorkspaceDefaultProviderId
+      ? this.options.getWorkspaceDefaultProviderId(workspaceId)
+      : '';
+    const binding = channel && this.options.getChannelBinding
+      ? this.options.getChannelBinding(workspaceId, channel.chatId, channel.platformUserId, channel.platform)
+      : undefined;
+    const channelProviderId = binding?.preferred_provider_id || '';
+    const currentProviderId = channelProviderId || defaultProviderId;
+    const currentProvider = currentProviderId && this.options.getModelProvider
+      ? this.options.getModelProvider(currentProviderId)
+      : undefined;
+    const defaultProvider = defaultProviderId && this.options.getModelProvider
+      ? this.options.getModelProvider(defaultProviderId)
+      : undefined;
+    const availableProviders = this.options.listModelProviders
+      ? this.options.listModelProviders()
+      : (currentProvider ? [currentProvider] : []);
+    return {
+      defaultProviderId,
+      channelProviderId,
+      currentProviderId,
+      currentProvider,
+      defaultProvider,
+      availableProviders,
+    };
+  }
+
   private executeProviderCommand(
     threadId: string,
     workspaceId: string,
     args: string[],
     channel?: ThreadCommandChannelContext,
   ) {
-    const defaultProviderId = this.options.getWorkspaceDefaultProviderId?.(workspaceId) || '';
-    const binding = channel
-      ? this.options.getChannelBinding?.(workspaceId, channel.chatId, channel.platformUserId, channel.platform)
-      : undefined;
-    const channelProviderId = binding?.preferred_provider_id || '';
-    const currentProviderId = channelProviderId || defaultProviderId;
-    const currentProvider = currentProviderId ? this.options.getModelProvider?.(currentProviderId) : undefined;
-    const defaultProvider = defaultProviderId ? this.options.getModelProvider?.(defaultProviderId) : undefined;
-    const availableProviders = this.options.listModelProviders?.() || (currentProvider ? [currentProvider] : []);
-
+    const state = this.resolveProviderState(workspaceId, channel);
     const [rawAction = '', ...rest] = args;
     const action = String(rawAction || '').trim().toLowerCase();
 
     if (!action || action === 'current') {
-      return this.formatProviderCurrent(channelProviderId, currentProvider, defaultProvider, currentProviderId, defaultProviderId);
+      return this.formatProviderCurrent(state.channelProviderId, state.currentProvider, state.defaultProvider, state.currentProviderId, state.defaultProviderId);
     }
     if (action === 'list') {
-      return this.formatProviderList(availableProviders);
+      return this.formatProviderList(state.availableProviders);
     }
     if (action === 'reset') {
-      return this.executeProviderReset(threadId, workspaceId, channel, channelProviderId, defaultProvider, defaultProviderId);
+      return this.executeProviderReset(threadId, workspaceId, channel, state.channelProviderId, state.defaultProvider, state.defaultProviderId);
+    }
+    if (action === 'help') {
+      return this.formatProviderHelp(state.currentProvider, state.defaultProvider);
     }
 
     const requestedId = (action === 'use' ? rest.join(' ') : args.join(' ')).trim();
-    return this.executeProviderUse(threadId, workspaceId, channel, requestedId, availableProviders, channelProviderId);
+    return this.executeProviderUse(threadId, workspaceId, channel, requestedId, state.availableProviders, state.channelProviderId);
+  }
+
+  private formatProviderHelp(currentProvider: any, defaultProvider: any) {
+    const currentDesc = currentProvider ? `${currentProvider.name} (${currentProvider.id})` : '未配置';
+    const defaultDesc = defaultProvider ? `${defaultProvider.name} (${defaultProvider.id})` : '未配置';
+    return [
+      '使用方式：',
+      '- `/provider current`：查看当前使用的 Provider 与工作区默认设置',
+      '- `/provider list`：查看所有可用的 Model Provider',
+      '- `/provider use <id>`：为当前渠道绑定指定的 Provider',
+      '- `/provider reset`：恢复当前渠道跟随工作区默认 Provider',
+      '',
+      `当前生效：${currentDesc} | 工作区默认：${defaultDesc}`,
+    ].join('\n');
   }
 
   private formatProviderCurrent(
@@ -288,6 +324,9 @@ export class ThreadCommandService {
     defaultProvider: any,
     defaultProviderId: string,
   ) {
+    if (!channel?.chatId || !channel.platformUserId) {
+      return '当前会话未绑定飞书或微信等渠道，无需重置。';
+    }
     if (!channelProviderId) {
       const defaultDesc = defaultProvider ? `${defaultProvider.name} (${defaultProvider.id})` : defaultProviderId;
       return `当前渠道未单独指定 Provider，已在跟随工作区默认：${defaultDesc}。`;
@@ -315,6 +354,10 @@ export class ThreadCommandService {
   ) {
     if (!requestedId) {
       return '请指定 Provider ID，例如：`/provider use provider-5`。使用 `/provider list` 查看可用 Provider。';
+    }
+
+    if (!channel?.chatId || !channel.platformUserId) {
+      return '当前会话未绑定飞书或微信等渠道。`/provider use` 用于设置渠道专用 Provider，桌面/Web 端会话默认使用工作区 Provider，请在工作区设置中切换默认 Provider。';
     }
 
     const matchedProvider = availableProviders.find(

--- a/services/local-ai-core/src/thread/thread-command-service.ts
+++ b/services/local-ai-core/src/thread/thread-command-service.ts
@@ -60,6 +60,18 @@ export class ThreadCommandService {
         ),
       }),
     });
+    this.registry.register({
+      names: ['provider'],
+      execute: (command, input) => ({
+        handled: true,
+        displayText: this.executeProviderCommand(
+          input.threadId,
+          input.workspaceId,
+          command.args,
+          input.channel,
+        ),
+      }),
+    });
   }
 
   async execute(input: ExecuteThreadCommandInput): Promise<ThreadCommandResult> {
@@ -199,6 +211,153 @@ export class ThreadCommandService {
       });
     } catch (error) {
       this.options.log?.(`setChannelPreferredAgent failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private executeProviderCommand(
+    threadId: string,
+    workspaceId: string,
+    args: string[],
+    channel?: ThreadCommandChannelContext,
+  ) {
+    const defaultProviderId = this.options.getWorkspaceDefaultProviderId?.(workspaceId) || '';
+    const binding = channel
+      ? this.options.getChannelBinding?.(workspaceId, channel.chatId, channel.platformUserId, channel.platform)
+      : undefined;
+    const channelProviderId = binding?.preferred_provider_id || '';
+    const currentProviderId = channelProviderId || defaultProviderId;
+    const currentProvider = currentProviderId ? this.options.getModelProvider?.(currentProviderId) : undefined;
+    const defaultProvider = defaultProviderId ? this.options.getModelProvider?.(defaultProviderId) : undefined;
+    const availableProviders = this.options.listModelProviders?.() || (currentProvider ? [currentProvider] : []);
+
+    const [rawAction = '', ...rest] = args;
+    const action = String(rawAction || '').trim().toLowerCase();
+
+    if (!action || action === 'current') {
+      return this.formatProviderCurrent(channelProviderId, currentProvider, defaultProvider, currentProviderId, defaultProviderId);
+    }
+    if (action === 'list') {
+      return this.formatProviderList(availableProviders);
+    }
+    if (action === 'reset') {
+      return this.executeProviderReset(threadId, workspaceId, channel, channelProviderId, defaultProvider, defaultProviderId);
+    }
+
+    const requestedId = (action === 'use' ? rest.join(' ') : args.join(' ')).trim();
+    return this.executeProviderUse(threadId, workspaceId, channel, requestedId, availableProviders, channelProviderId);
+  }
+
+  private formatProviderCurrent(
+    channelProviderId: string,
+    currentProvider: any,
+    defaultProvider: any,
+    currentProviderId: string,
+    defaultProviderId: string,
+  ) {
+    const sourceLabel = channelProviderId ? '渠道偏好设置' : '工作区默认设置';
+    const currentName = currentProvider ? `${currentProvider.name} (${currentProvider.id})` : (currentProviderId || '未配置');
+    const defaultName = defaultProvider ? `${defaultProvider.name} (${defaultProvider.id})` : (defaultProviderId || '未配置');
+    return [
+      `当前使用的 Provider：${currentName}`,
+      `来源：${sourceLabel}`,
+      `工作区默认 Provider：${defaultName}`,
+      '使用 `/provider list` 查看可用 Provider，或 `/provider use <id>` 切换。',
+    ].join('\n');
+  }
+
+  private formatProviderList(availableProviders: any[]) {
+    if (!availableProviders.length) {
+      return '暂无可用 Model Provider。';
+    }
+    const listText = availableProviders
+      .map((p) => `- \`${p.id}\`: ${p.name} (${p.base_url || '内置'})`)
+      .join('\n');
+    return [
+      '可用 Model Provider 列表：',
+      listText,
+      '',
+      '使用 `/provider use <id>` 切换当前渠道使用的 Provider，使用 `/provider reset` 恢复工作区默认。',
+    ].join('\n');
+  }
+
+  private executeProviderReset(
+    threadId: string,
+    workspaceId: string,
+    channel: ThreadCommandChannelContext | undefined,
+    channelProviderId: string,
+    defaultProvider: any,
+    defaultProviderId: string,
+  ) {
+    if (!channelProviderId) {
+      const defaultDesc = defaultProvider ? `${defaultProvider.name} (${defaultProvider.id})` : defaultProviderId;
+      return `当前渠道未单独指定 Provider，已在跟随工作区默认：${defaultDesc}。`;
+    }
+    this.persistChannelPreferredProvider(channel, workspaceId, null);
+    this.options.closeThreadSession?.(threadId);
+    this.options.createAuditEvent({
+      type: 'agent.changed',
+      workspaceId,
+      actor: 'local',
+      summary: `Channel provider reset to default ${defaultProviderId}.`,
+      metadata: { threadId, defaultProviderId, previousProviderId: channelProviderId },
+    });
+    const defaultDesc = defaultProvider ? `${defaultProvider.name} (${defaultProvider.id})` : defaultProviderId;
+    return `已清除当前渠道的 Provider 偏好设置。\n当前渠道已恢复跟随工作区默认 Provider：${defaultDesc}。`;
+  }
+
+  private executeProviderUse(
+    threadId: string,
+    workspaceId: string,
+    channel: ThreadCommandChannelContext | undefined,
+    requestedId: string,
+    availableProviders: any[],
+    channelProviderId: string,
+  ) {
+    if (!requestedId) {
+      return '请指定 Provider ID，例如：`/provider use provider-5`。使用 `/provider list` 查看可用 Provider。';
+    }
+
+    const matchedProvider = availableProviders.find(
+      (p) => p.id.toLowerCase() === requestedId.toLowerCase() || p.name.toLowerCase() === requestedId.toLowerCase(),
+    );
+    if (!matchedProvider) {
+      return `未找到 Provider "${requestedId}"。\n使用 \`/provider list\` 查看所有可用 Provider。`;
+    }
+
+    if (matchedProvider.id === channelProviderId) {
+      return `当前渠道已经在使用 Provider：${matchedProvider.name} (${matchedProvider.id})。`;
+    }
+
+    this.persistChannelPreferredProvider(channel, workspaceId, matchedProvider.id);
+    this.options.closeThreadSession?.(threadId);
+    this.options.createAuditEvent({
+      type: 'agent.changed',
+      workspaceId,
+      actor: 'local',
+      summary: `Channel provider changed to ${matchedProvider.id}.`,
+      metadata: { threadId, providerId: matchedProvider.id, previousProviderId: channelProviderId },
+    });
+    return `已将当前渠道的 Provider 切换为：${matchedProvider.name} (${matchedProvider.id})。\n后续新一轮对话或定时任务将立即生效。`;
+  }
+
+  private persistChannelPreferredProvider(
+    channel: ThreadCommandChannelContext | undefined,
+    workspaceId: string,
+    providerId: string | null,
+  ) {
+    if (!channel?.chatId || !channel.platformUserId) {
+      return;
+    }
+    try {
+      this.options.setChannelPreferredProvider?.({
+        workspaceId,
+        chatId: channel.chatId,
+        platformUserId: channel.platformUserId,
+        platform: channel.platform,
+        providerId,
+      });
+    } catch (error) {
+      this.options.log?.(`setChannelPreferredProvider failed: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 

--- a/services/local-ai-core/src/thread/thread-command-types.ts
+++ b/services/local-ai-core/src/thread/thread-command-types.ts
@@ -1,4 +1,4 @@
-import type { AuditEvent } from '@cc/superai-contracts';
+import type { AuditEvent, DesktopModelProvider } from '@cc/superai-contracts';
 import type { LocalRunRow, LocalThreadRow } from '../acp/store/acp-store-types.js';
 
 export type ThreadCommandResult = {
@@ -28,6 +28,17 @@ export type ThreadCommandServiceOptions = {
     platformUserId: string;
     platform: string;
     agentType: string | null;
+  }) => void;
+  listModelProviders?: () => DesktopModelProvider[];
+  getModelProvider?: (providerId: string) => DesktopModelProvider | undefined;
+  getWorkspaceDefaultProviderId?: (workspaceId: string) => string;
+  getChannelBinding?: (workspaceId: string, chatId: string, platformUserId: string, platform?: string) => { preferred_provider_id?: string | null; preferred_agent_type?: string | null } | undefined;
+  setChannelPreferredProvider?: (input: {
+    workspaceId: string;
+    chatId: string;
+    platformUserId: string;
+    platform: string;
+    providerId: string | null;
   }) => void;
   log?: (message: string) => void;
 };

--- a/services/local-ai-core/src/thread/thread-slash-command-dispatcher.ts
+++ b/services/local-ai-core/src/thread/thread-slash-command-dispatcher.ts
@@ -16,6 +16,7 @@ export const LOCAL_SLASH_COMMANDS: SlashCommandDefinition[] = [
   { names: ['stop'], usage: '/stop', summary: '停止当前正在运行的任务。', group: 'thread' },
   { names: ['mode'], usage: '/mode [default|auto|acceptEdits|dontAsk|plan|yolo]', summary: '查看或切换当前线程权限模式。', group: 'thread' },
   { names: ['agent'], usage: '/agent [list|current|use <agent-id>|reset]', summary: '查看或切换当前线程 Agent。', group: 'thread' },
+  { names: ['provider'], usage: '/provider [list|current|use <id>|reset]', summary: '查看或切换当前渠道 Provider。', group: 'thread' },
   { names: ['new'], usage: '/new [标题]', summary: '新建会话。', group: 'session' },
   { names: ['list', 'sessions'], usage: '/list', summary: '查看会话列表。', group: 'session' },
   { names: ['switch', 'sw'], usage: '/switch <编号 | id前缀 | 标题>', summary: '切换会话。', group: 'session' },

--- a/tests/electron/plugin-kernel.test.ts
+++ b/tests/electron/plugin-kernel.test.ts
@@ -401,6 +401,42 @@ test('thread slash agent reset resolves the workspace default agent through the 
   }
 });
 
+test('thread slash provider commands query and list providers through router', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'agentdock-kernel-provider-'));
+  try {
+    const runtime = bootstrapLocalCoreRuntime({
+      userDataPath,
+      enableKnowledge: false,
+    });
+    runtime.store.upsertModelProvider({
+      id: 'provider-default',
+      name: 'Default Provider',
+      base_url: 'https://default.ai/v1',
+      api_key: 'key-1',
+    });
+    runtime.store.upsertModelProvider({
+      id: 'provider-volcano',
+      name: '火山方舟',
+      base_url: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+      api_key: 'key-2',
+    });
+    await saveConfig(runtime, {
+      projects: [{ name: 'agent-workspace', agent: { type: 'hermes', options: { provider_id: 'provider-default' } } }],
+    });
+    const thread = await runtime.workspaceRouter.createThread('agent-workspace', 'Provider test');
+
+    await runtime.workspaceRouter.sendThreadMessage(thread.id, '/provider current');
+    assert.match(runtime.store.getThread(thread.id, []).messages.at(-1)?.content || '', /Default Provider/);
+
+    await runtime.workspaceRouter.sendThreadMessage(thread.id, '/provider list');
+    assert.match(runtime.store.getThread(thread.id, []).messages.at(-1)?.content || '', /火山方舟/);
+
+    await runtime.stop();
+  } finally {
+    rmSync(userDataPath, { recursive: true, force: true });
+  }
+});
+
 test('hermes agent runtime routes projects through hermes ACP command', async () => {
   const userDataPath = mkdtempSync(join(tmpdir(), 'agentdock-kernel-'));
   try {

--- a/tests/integration/workspace-channel-provider.test.ts
+++ b/tests/integration/workspace-channel-provider.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 import { LocalCoreAcpStore } from '../../services/local-ai-core/src/acp/store/local-core-acp-store.js';
 import { LocalCoreAcpSessionCoordinator } from '../../services/local-ai-core/src/acp/local-core-acp-session-coordinator.js';
+import { bootstrapLocalCoreRuntime } from '../../services/local-ai-core/src/kernel/bootstrap.js';
 
 test('SessionCoordinator skips stale acp_session_id when launch config key changes', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'acp-config-mismatch-'));
@@ -15,7 +16,7 @@ test('SessionCoordinator skips stale acp_session_id when launch config key chang
       agentType: 'hermes',
       model: 'deepseek-v4-flash',
       baseUrl: 'https://opencode.ai/zen/go/v1',
-      apiKey: '',
+      keyHash: '',
     });
     // Simulate previous session saved under old provider
     store.updateThreadSession(thread.id, 'old-session-123', true, oldConfigKey);
@@ -64,7 +65,10 @@ test('SessionCoordinator skips stale acp_session_id when launch config key chang
       workDir: '/tmp/workspace-a',
       command: 'hermes',
       args: ['acp'],
-      env: { OPENAI_BASE_URL: 'https://ark.cn-beijing.volces.com/api/coding/v3' },
+      env: {
+        OPENAI_BASE_URL: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+        OPENAI_API_KEY: 'sk-secret-volcano-api-key-98765',
+      },
       model: 'deepseek-v4-flash',
     };
 
@@ -79,6 +83,11 @@ test('SessionCoordinator skips stale acp_session_id when launch config key chang
     const updatedRow = store.getThreadRow(thread.id);
     assert.equal(updatedRow?.acp_session_id, 'new-session-456');
     assert.ok(updatedRow?.acp_launch_config_key?.includes('ark.cn-beijing.volces.com'));
+    assert.equal(
+      updatedRow?.acp_launch_config_key?.includes('sk-secret-volcano-api-key-98765'),
+      false,
+      'API key must not be stored in plaintext in acp_launch_config_key',
+    );
 
     store.close();
   } finally {
@@ -278,11 +287,98 @@ test('ThreadCommandService handles /provider current, list, use, reset', async (
     assert.ok(resReset.displayText.includes('已清除当前渠道的 Provider 偏好设置'));
 
     const bindingAfterReset = store.getPlatformThreadBinding('workspace-a', 'chat-100', 'user-200', 'lark');
-    assert.equal(bindingAfterReset?.preferred_provider_id, null);
+    // 6. /provider help
+    const resHelp = await service.execute({
+      threadId: thread.id,
+      workspaceId: 'workspace-a',
+      content: '/provider help',
+      defaultAgentType: 'hermes',
+      channel: channelContext,
+    });
+    assert.ok(resHelp.displayText.includes('使用方式：'));
+    assert.ok(resHelp.displayText.includes('/provider use <id>'));
+
+    // 7. /provider use without channel
+    const resNoChannel = await service.execute({
+      threadId: thread.id,
+      workspaceId: 'workspace-a',
+      content: '/provider use provider-volcano',
+      defaultAgentType: 'hermes',
+    });
+    assert.ok(resNoChannel.displayText.includes('未绑定飞书或微信等渠道'));
 
     store.close();
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('WorkspaceRouter resolves channel preferred provider via channelRoute with type channel.chat', async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'agentdock-channel-router-'));
+  try {
+    const runtime = bootstrapLocalCoreRuntime({
+      userDataPath,
+      enableKnowledge: false,
+    });
+    runtime.store.upsertModelProvider({
+      id: 'provider-default',
+      name: 'Default Provider',
+      base_url: 'https://default.ai/v1',
+      api_key: 'key-default',
+    });
+    runtime.store.upsertModelProvider({
+      id: 'provider-volcano',
+      name: '火山方舟',
+      base_url: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+      api_key: 'key-volcano',
+    });
+    await runtime.store.saveRuntimeConfig({
+      projects: [{ name: 'agent-workspace', agent: { type: 'hermes', options: { provider_id: 'provider-default' } } }] as any,
+    });
+
+    const thread = await runtime.workspaceRouter.createThread('agent-workspace', 'Channel route provider test');
+    const now = new Date().toISOString();
+    runtime.store.upsertPlatformThreadBinding({
+      workspace_id: 'agent-workspace',
+      platform: 'lark',
+      chat_id: 'chat-999',
+      platform_user_id: 'user-888',
+      thread_id: thread.id,
+      last_platform_message_id: null,
+      preferred_agent_type: 'hermes',
+      preferred_provider_id: 'provider-volcano',
+      created_at: now,
+      updated_at: now,
+    });
+
+    let capturedConfig: any;
+    (runtime.workspaceRouter as any).localCoreAcp.sendThreadMessage = async (
+      _tid: string,
+      _content: any,
+      config: any,
+    ) => {
+      capturedConfig = config;
+      return { runId: 'run-1' };
+    };
+
+    // When channelRoute is passed with type: 'channel.chat' (as Lark/Weixin gateways do)
+    await runtime.workspaceRouter.sendThreadMessage(thread.id, 'Hello test', {
+      channelRoute: {
+        type: 'channel.chat',
+        channelId: 'chat-999',
+        participantId: 'user-888',
+      },
+    });
+
+    assert.ok(capturedConfig, 'sendThreadMessage must be called');
+    assert.ok(
+      capturedConfig.env?.OPENAI_BASE_URL?.includes('ark.cn-beijing.volces.com'),
+      `Expected Volcano Ark endpoint, but got: ${capturedConfig.env?.OPENAI_BASE_URL}`,
+    );
+
+    await runtime.stop();
+  } finally {
+    rmSync(userDataPath, { recursive: true, force: true });
   }
 });
 

--- a/tests/integration/workspace-channel-provider.test.ts
+++ b/tests/integration/workspace-channel-provider.test.ts
@@ -1,0 +1,288 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { LocalCoreAcpStore } from '../../services/local-ai-core/src/acp/store/local-core-acp-store.js';
+import { LocalCoreAcpSessionCoordinator } from '../../services/local-ai-core/src/acp/local-core-acp-session-coordinator.js';
+
+test('SessionCoordinator skips stale acp_session_id when launch config key changes', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'acp-config-mismatch-'));
+  try {
+    const store = new LocalCoreAcpStore(dir);
+    const thread = store.createThread('workspace-a', 'Test Thread', 'hermes');
+    const oldConfigKey = JSON.stringify({
+      agentType: 'hermes',
+      model: 'deepseek-v4-flash',
+      baseUrl: 'https://opencode.ai/zen/go/v1',
+      apiKey: '',
+    });
+    // Simulate previous session saved under old provider
+    store.updateThreadSession(thread.id, 'old-session-123', true, oldConfigKey);
+    const loadedRow = store.getThreadRow(thread.id);
+    assert.equal(loadedRow?.acp_session_id, 'old-session-123');
+    assert.equal(loadedRow?.acp_launch_config_key, oldConfigKey);
+
+    const calls: string[] = [];
+    const coordinator = new LocalCoreAcpSessionCoordinator({
+      store,
+      transport: {
+        spawnSession(input: any) {
+          return {
+            threadId: input.threadId,
+            bridgeSessionKey: input.bridgeSessionKey,
+            closed: false,
+            sessionId: '',
+            supportsLoad: true,
+            currentRunId: null,
+            currentTurn: null,
+            pendingPermissionByRun: new Map(),
+            schedulerJobCreatedByRun: new Map(),
+            launchPermissionMode: '',
+          };
+        },
+        initializeSession: async () => {},
+        request: async (_session: any, method: string, params: any) => {
+          calls.push(`${method}:${params?.sessionId || ''}`);
+          if (method === 'session/new') {
+            return { sessionId: 'new-session-456' };
+          }
+          return {};
+        },
+        closeSession: () => {},
+        closeSessionWithError: () => {},
+        sendRaw: () => true,
+      } as any,
+      runThreadMap: new Map(),
+      emitBridge: () => {},
+    });
+
+    // Now ensureSession runs with the NEW provider config (火山)
+    const newConfig = {
+      workspaceId: 'workspace-a',
+      agentType: 'hermes',
+      workDir: '/tmp/workspace-a',
+      command: 'hermes',
+      args: ['acp'],
+      env: { OPENAI_BASE_URL: 'https://ark.cn-beijing.volces.com/api/coding/v3' },
+      model: 'deepseek-v4-flash',
+    };
+
+    const session = await coordinator.ensureSession(thread.id, 'session:thread-1', newConfig as any);
+    assert.equal(session.sessionId, 'new-session-456');
+
+    // session/load must NOT have been called with 'old-session-123'!
+    assert.equal(calls.includes('session/load:old-session-123'), false, 'Stale session must not be loaded when config changes');
+    assert.equal(calls.some((c) => c.startsWith('session/new')), true, 'Fresh session must be created on config change');
+
+    // Verify DB was updated with new session and new config key
+    const updatedRow = store.getThreadRow(thread.id);
+    assert.equal(updatedRow?.acp_session_id, 'new-session-456');
+    assert.ok(updatedRow?.acp_launch_config_key?.includes('ark.cn-beijing.volces.com'));
+
+    store.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('Platform thread binding supports preferred_provider_id', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'platform-provider-binding-'));
+  try {
+    const store = new LocalCoreAcpStore(dir);
+    const now = new Date().toISOString();
+    store.upsertPlatformThreadBinding({
+      workspace_id: 'workspace-a',
+      platform: 'lark',
+      chat_id: 'chat-1',
+      platform_user_id: 'user-1',
+      thread_id: 'thread-1',
+      last_platform_message_id: null,
+      preferred_agent_type: 'hermes',
+      preferred_provider_id: 'provider-volcano',
+      created_at: now,
+      updated_at: now,
+    });
+
+    let binding = store.getPlatformThreadBinding('workspace-a', 'chat-1', 'user-1', 'lark');
+    assert.equal(binding?.preferred_provider_id, 'provider-volcano');
+
+    store.updatePlatformThreadPreferredProvider('workspace-a', 'chat-1', 'user-1', 'provider-deepseek', 'lark');
+    binding = store.getPlatformThreadBinding('workspace-a', 'chat-1', 'user-1', 'lark');
+    assert.equal(binding?.preferred_provider_id, 'provider-deepseek');
+
+    store.updatePlatformThreadPreferredProvider('workspace-a', 'chat-1', 'user-1', null, 'lark');
+    binding = store.getPlatformThreadBinding('workspace-a', 'chat-1', 'user-1', 'lark');
+    assert.equal(binding?.preferred_provider_id, null);
+
+    store.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('upsertModelProvider clears existing thread sessions when credentials change', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'provider-change-invalidation-'));
+  try {
+    const store = new LocalCoreAcpStore(dir);
+    store.upsertModelProvider({
+      id: 'provider-1',
+      name: 'Old Provider',
+      base_url: 'https://old.provider.com/v1',
+      api_key: 'old-key',
+    });
+
+    const thread = store.createThread('workspace-a', 'Test Thread', 'hermes');
+    store.updateThreadSession(thread.id, 'session-abc', true, 'old-key-hash');
+
+    let row = store.getThreadRow(thread.id);
+    assert.equal(row?.acp_session_id, 'session-abc');
+
+    // Updating same provider with same credentials does NOT clear sessions
+    store.upsertModelProvider({
+      id: 'provider-1',
+      name: 'Old Provider Renamed',
+      base_url: 'https://old.provider.com/v1',
+      api_key: 'old-key',
+    });
+    row = store.getThreadRow(thread.id);
+    assert.equal(row?.acp_session_id, 'session-abc');
+
+    // Updating provider base_url/api_key (e.g. opencode -> 火山) clears thread sessions
+    store.upsertModelProvider({
+      id: 'provider-1',
+      name: 'Volcano Provider',
+      base_url: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+      api_key: 'ark-new-key',
+    });
+    row = store.getThreadRow(thread.id);
+    assert.equal(row?.acp_session_id, null, 'acp_session_id must be cleared on provider credentials update');
+    assert.equal(row?.acp_launch_config_key, null, 'acp_launch_config_key must be cleared');
+
+    store.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ThreadCommandService handles /provider current, list, use, reset', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'provider-slash-command-'));
+  try {
+    const store = new LocalCoreAcpStore(dir);
+    store.upsertModelProvider({
+      id: 'provider-default',
+      name: 'Default Provider',
+      base_url: 'https://default.ai/v1',
+      api_key: 'key-1',
+    });
+    store.upsertModelProvider({
+      id: 'provider-volcano',
+      name: '火山方舟',
+      base_url: 'https://ark.cn-beijing.volces.com/api/coding/v3',
+      api_key: 'key-2',
+    });
+
+    const thread = store.createThread('workspace-a', 'Test Thread', 'hermes');
+    const channelContext = {
+      chatId: 'chat-100',
+      platformUserId: 'user-200',
+      platform: 'lark',
+    };
+    const now = new Date().toISOString();
+    store.upsertPlatformThreadBinding({
+      workspace_id: 'workspace-a',
+      platform: 'lark',
+      chat_id: 'chat-100',
+      platform_user_id: 'user-200',
+      thread_id: thread.id,
+      last_platform_message_id: null,
+      created_at: now,
+      updated_at: now,
+    });
+
+    const { ThreadCommandService } = await import('../../services/local-ai-core/src/thread/thread-command-service.js');
+    const service = new ThreadCommandService({
+      getThreadRow: (id) => store.getThreadRow(id),
+      updateThreadAgentMode: (id, mode) => store.updateThreadAgentMode(id, mode),
+      updateThreadAgentType: (id, type) => store.updateThreadAgentType(id, type),
+      getLatestRunForThread: () => undefined,
+      createAuditEvent: () => {},
+      listModelProviders: () => store.listModelProviders(),
+      getModelProvider: (id) => store.getModelProvider(id),
+      getWorkspaceDefaultProviderId: () => 'provider-default',
+      getChannelBinding: (ws, chat, user, plat) => store.getPlatformThreadBinding(ws, chat, user, plat),
+      setChannelPreferredProvider: (input) => store.updatePlatformThreadPreferredProvider(
+        input.workspaceId,
+        input.chatId,
+        input.platformUserId,
+        input.providerId,
+        input.platform,
+      ),
+    });
+
+    // 1. /provider current when inheriting default
+    const resCurrentDefault = await service.execute({
+      threadId: thread.id,
+      workspaceId: 'workspace-a',
+      content: '/provider current',
+      defaultAgentType: 'hermes',
+      channel: channelContext,
+    });
+    assert.ok(resCurrentDefault.displayText.includes('Default Provider'));
+    assert.ok(resCurrentDefault.displayText.includes('工作区默认设置'));
+
+    // 2. /provider list
+    const resList = await service.execute({
+      threadId: thread.id,
+      workspaceId: 'workspace-a',
+      content: '/provider list',
+      defaultAgentType: 'hermes',
+      channel: channelContext,
+    });
+    assert.ok(resList.displayText.includes('provider-default'));
+    assert.ok(resList.displayText.includes('provider-volcano'));
+
+    // 3. /provider use provider-volcano
+    const resUse = await service.execute({
+      threadId: thread.id,
+      workspaceId: 'workspace-a',
+      content: '/provider use provider-volcano',
+      defaultAgentType: 'hermes',
+      channel: channelContext,
+    });
+    assert.ok(resUse.displayText.includes('火山方舟'));
+
+    // Verify channel binding now has preferred_provider_id
+    const bindingAfterUse = store.getPlatformThreadBinding('workspace-a', 'chat-100', 'user-200', 'lark');
+    assert.equal(bindingAfterUse?.preferred_provider_id, 'provider-volcano');
+
+    // 4. /provider current now reflects channel override
+    const resCurrentOverride = await service.execute({
+      threadId: thread.id,
+      workspaceId: 'workspace-a',
+      content: '/provider current',
+      defaultAgentType: 'hermes',
+      channel: channelContext,
+    });
+    assert.ok(resCurrentOverride.displayText.includes('火山方舟'));
+    assert.ok(resCurrentOverride.displayText.includes('渠道偏好设置'));
+
+    // 5. /provider reset
+    const resReset = await service.execute({
+      threadId: thread.id,
+      workspaceId: 'workspace-a',
+      content: '/provider reset',
+      defaultAgentType: 'hermes',
+      channel: channelContext,
+    });
+    assert.ok(resReset.displayText.includes('已清除当前渠道的 Provider 偏好设置'));
+
+    const bindingAfterReset = store.getPlatformThreadBinding('workspace-a', 'chat-100', 'user-200', 'lark');
+    assert.equal(bindingAfterReset?.preferred_provider_id, null);
+
+    store.close();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+


### PR DESCRIPTION
## Summary

This PR resolves an issue where scheduled tasks and channel conversations continued using stale model provider credentials / endpoints after switching providers, leading to 401 authentication errors (such as Hermes attempting to call OpenCode with a Volcano API key). It introduces hierarchical provider resolution (channel override -> workspace default fallback), session provider fingerprinting, and an interactive `/provider` slash command.

### Key Changes

1. **ACP Session Provider Fingerprint & Anti-Pollution**:
   - Added `acp_launch_config_key` column to `threads` table and schema migrations.
   - Implemented `buildSessionProviderKey(config)` in `LocalCoreAcpSessionCoordinator` to track provider identity (`agentType`, `model`, `baseUrl`, `apiKey`).
   - Mismatches between the stored fingerprint and the current configuration now skip `session/load` and fall through to a clean `session/new`, preventing persistent agent runtimes (e.g. Hermes) from restoring stale URLs from internal state databases.
   - Updating provider credentials (`upsertModelProvider` / `deleteModelProvider`) actively invalidates cached thread sessions across all threads.

2. **Hierarchical Workspace + Channel Provider Resolution**:
   - Added `preferred_provider_id` column to `platform_thread_bindings` table and schema migrations.
   - Expanded `WorkspaceThreadMessageOptions` to accept `channelRoute`, `providerIdOverride`, and `agentTypeOverride`.
   - Wired `channelRoute` into `ScheduledConversationExecutor`, `LocalCoreLarkGateway`, and `LocalCoreWeixinGateway`.
   - `WorkspaceRouter.getThreadWorkspaceRoute` prioritizes channel-level `preferred_provider_id`, falling back to workspace default (`project.agent.options.provider_id`) via `withProviderOverride`.

3. **Interactive `/provider` Slash Command**:
   - Added `/provider` command across channel gateways and ACP backend:
     - `/provider current`: shows active provider, resolution source (channel override vs workspace default), and workspace default.
     - `/provider list`: lists available model providers.
     - `/provider use <id>`: sets channel-specific provider preference and resets thread session.
     - `/provider reset`: clears channel provider preference to follow workspace default.
   - Includes audit logging on provider switches.

4. **Release Notes**:
   - Updated `README.md` under `## New` with 2026-09-02 entry.

## Validation Performed

- `pnpm typecheck` (0 errors)
- `pnpm lint:gates` (clean: complexity <= 108 baseline, 0 circular dependencies, 0 new duplicates)
- `pnpm test` (710 tests passing, 80 BDD scenarios passing)
- Deployed and verified on `agentdock-ubuntu` production server:
  - Triggered scheduled job `6377b64f` ("ETF动量日报").
  - Verified Hermes called Volcano Ark endpoint (`https://ark.cn-beijing.volces.com/api/coding/v3`) with model `deepseek-v4-flash`.
  - Full analysis and tool calls succeeded in 47s, and complete rich card was delivered to Feishu.