### PR TITLE
Extract shared provider command options factory

### DIFF
--- a/services/local-ai-core/src/acp/local-core-acp-backend.ts
+++ b/services/local-ai-core/src/acp/local-core-acp-backend.ts
@@ -23,6 +23,7 @@ import { stripObservedToolTranscriptsFromAssistantText } from './local-core-acp-
 import { resolveAgentAcpBehavior } from '../agents/index.js';
 import { routeFromPlatformThreadBinding } from '../scheduler/scheduled-job-route.js';
 import { ThreadSlashCommandDispatcher } from '../thread/thread-slash-command-dispatcher.js';
+import { createProviderCommandOptions } from '../thread/thread-command-service.js';
 import { formatUserError, toLocalCoreErrorInfo } from '../kernel/local-core-errors.js';
 import { ACP_PROMPT_TIMEOUT_MS } from '../agents/shared/execution-timeouts.js';
 import { isThreadAllowAllRevokeIntent } from './local-core-acp-permission-lifecycle.js';
@@ -171,21 +172,7 @@ export class LocalCoreAcpBackend {
         setThreadMode: (threadId, mode) => this.sessionCoordinator.setThreadMode(threadId, mode),
         closeThreadSession: (threadId) => this.sessionCoordinator.closeThreadSession(threadId),
         interruptRun: (runId) => this.sessionCoordinator.interruptRun(runId),
-        listModelProviders: () => this.options.store.listModelProviders(),
-        getModelProvider: (providerId) => this.options.store.getModelProvider(providerId),
-        getWorkspaceDefaultProviderId: (workspaceId) => {
-          const config = this.options.store.readRuntimeConfig().config;
-          const project = config?.projects?.find((p: any) => p.name === workspaceId || p.workspace_id === workspaceId);
-          return String(project?.agent?.options?.provider_id || '').trim();
-        },
-        getChannelBinding: (workspaceId, chatId, platformUserId, platform) => this.options.store.getPlatformThreadBinding(workspaceId, chatId, platformUserId, platform),
-        setChannelPreferredProvider: (input) => this.options.store.updatePlatformThreadPreferredProvider(
-          input.workspaceId,
-          input.chatId,
-          input.platformUserId,
-          input.providerId,
-          input.platform,
-        ),
+        ...createProviderCommandOptions(this.options.store),
         log: options.log,
       },
     });

--- a/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
+++ b/services/local-ai-core/src/channel/shared/base-channel-gateway.ts
@@ -25,6 +25,7 @@ import { createChannelThreadMessageInput } from '../shared/content.js';
 import { buildChannelFileSendPayload } from '../../runtime/channel-service-helpers.js';
 import { channelPlatformKey, extractChannelInstanceId } from '../shared/channel-keys.js';
 import { ChannelSessionCommandRuntime, type ChannelSessionCommandInput } from '../shared/session-command-runtime.js';
+import { createProviderCommandOptions } from '../../thread/thread-command-service.js';
 import { resolveChannelThreadRoute } from '../shared/thread-routing.js';
 import type { SessionCommandResult } from '../../thread/session-command-service.js';
 import { ThreadSlashCommandDispatcher } from '../../thread/thread-slash-command-dispatcher.js';
@@ -143,21 +144,7 @@ export abstract class BaseChannelGateway<
           input.agentType,
           input.platform,
         ),
-        listModelProviders: () => options.store.listModelProviders(),
-        getModelProvider: (providerId) => options.store.getModelProvider(providerId),
-        getWorkspaceDefaultProviderId: (workspaceId) => {
-          const config = options.store.readRuntimeConfig().config;
-          const project = config?.projects?.find((p: any) => p.name === workspaceId || p.workspace_id === workspaceId);
-          return String(project?.agent?.options?.provider_id || '').trim();
-        },
-        getChannelBinding: (workspaceId, chatId, platformUserId, platform) => options.store.getPlatformThreadBinding(workspaceId, chatId, platformUserId, platform),
-        setChannelPreferredProvider: (input) => options.store.updatePlatformThreadPreferredProvider(
-          input.workspaceId,
-          input.chatId,
-          input.platformUserId,
-          input.providerId,
-          input.platform,
-        ),
+        ...createProviderCommandOptions(options.store),
         log: options.log,
       },
     });

--- a/services/local-ai-core/src/thread/thread-command-service.ts
+++ b/services/local-ai-core/src/thread/thread-command-service.ts
@@ -1,4 +1,4 @@
-import type { AuditEvent } from '@cc/superai-contracts';
+import type { AuditEvent, DesktopModelProvider } from '@cc/superai-contracts';
 import type { LocalRunRow, LocalThreadRow } from '../router/workspace-router-types.js';
 import {
   agentHelpText,
@@ -19,6 +19,34 @@ export type ThreadCommandChannelContext = {
   chatId: string;
   platformUserId: string;
   platform: string;
+};
+
+export type ProviderCommandStoreLike = {
+  listModelProviders(): DesktopModelProvider[];
+  getModelProvider(providerId: string): DesktopModelProvider | undefined;
+  readRuntimeConfig(): { config?: { projects?: unknown[] } | undefined };
+  getPlatformThreadBinding(
+    workspaceId: string,
+    chatId: string,
+    platformUserId: string,
+    platform?: string,
+  ): { preferred_provider_id?: string | null; preferred_agent_type?: string | null } | undefined;
+  updatePlatformThreadPreferredProvider(
+    workspaceId: string,
+    chatId: string,
+    platformUserId: string,
+    providerId: string | null,
+    platform?: string,
+  ): void;
+};
+
+export type ProviderCommandState = {
+  defaultProviderId: string;
+  channelProviderId: string;
+  currentProviderId: string;
+  currentProvider?: DesktopModelProvider;
+  defaultProvider?: DesktopModelProvider;
+  availableProviders: DesktopModelProvider[];
 };
 
 export type ExecuteThreadCommandInput = {
@@ -214,7 +242,7 @@ export class ThreadCommandService {
     }
   }
 
-  private resolveProviderState(workspaceId: string, channel?: ThreadCommandChannelContext) {
+  private resolveProviderState(workspaceId: string, channel?: ThreadCommandChannelContext): ProviderCommandState {
     const defaultProviderId = this.options.getWorkspaceDefaultProviderId
       ? this.options.getWorkspaceDefaultProviderId(workspaceId)
       : '';
@@ -253,7 +281,7 @@ export class ThreadCommandService {
     const action = String(rawAction || '').trim().toLowerCase();
 
     if (!action || action === 'current') {
-      return this.formatProviderCurrent(state.channelProviderId, state.currentProvider, state.defaultProvider, state.currentProviderId, state.defaultProviderId);
+      return this.formatProviderCurrent(state);
     }
     if (action === 'list') {
       return this.formatProviderList(state.availableProviders);
@@ -269,7 +297,7 @@ export class ThreadCommandService {
     return this.executeProviderUse(threadId, workspaceId, channel, requestedId, state.availableProviders, state.channelProviderId);
   }
 
-  private formatProviderHelp(currentProvider: any, defaultProvider: any) {
+  private formatProviderHelp(currentProvider: DesktopModelProvider | undefined, defaultProvider: DesktopModelProvider | undefined) {
     const currentDesc = currentProvider ? `${currentProvider.name} (${currentProvider.id})` : '未配置';
     const defaultDesc = defaultProvider ? `${defaultProvider.name} (${defaultProvider.id})` : '未配置';
     return [
@@ -283,16 +311,14 @@ export class ThreadCommandService {
     ].join('\n');
   }
 
-  private formatProviderCurrent(
-    channelProviderId: string,
-    currentProvider: any,
-    defaultProvider: any,
-    currentProviderId: string,
-    defaultProviderId: string,
-  ) {
-    const sourceLabel = channelProviderId ? '渠道偏好设置' : '工作区默认设置';
-    const currentName = currentProvider ? `${currentProvider.name} (${currentProvider.id})` : (currentProviderId || '未配置');
-    const defaultName = defaultProvider ? `${defaultProvider.name} (${defaultProvider.id})` : (defaultProviderId || '未配置');
+  private formatProviderCurrent(state: ProviderCommandState) {
+    const sourceLabel = state.channelProviderId ? '渠道偏好设置' : '工作区默认设置';
+    const currentName = state.currentProvider
+      ? `${state.currentProvider.name} (${state.currentProvider.id})`
+      : (state.currentProviderId || '未配置');
+    const defaultName = state.defaultProvider
+      ? `${state.defaultProvider.name} (${state.defaultProvider.id})`
+      : (state.defaultProviderId || '未配置');
     return [
       `当前使用的 Provider：${currentName}`,
       `来源：${sourceLabel}`,
@@ -301,7 +327,7 @@ export class ThreadCommandService {
     ].join('\n');
   }
 
-  private formatProviderList(availableProviders: any[]) {
+  private formatProviderList(availableProviders: DesktopModelProvider[]) {
     if (!availableProviders.length) {
       return '暂无可用 Model Provider。';
     }
@@ -321,7 +347,7 @@ export class ThreadCommandService {
     workspaceId: string,
     channel: ThreadCommandChannelContext | undefined,
     channelProviderId: string,
-    defaultProvider: any,
+    defaultProvider: DesktopModelProvider | undefined,
     defaultProviderId: string,
   ) {
     if (!channel?.chatId || !channel.platformUserId) {
@@ -349,7 +375,7 @@ export class ThreadCommandService {
     workspaceId: string,
     channel: ThreadCommandChannelContext | undefined,
     requestedId: string,
-    availableProviders: any[],
+    availableProviders: DesktopModelProvider[],
     channelProviderId: string,
   ) {
     if (!requestedId) {
@@ -433,4 +459,28 @@ export class ThreadCommandService {
     const latestRun = this.options.getLatestRunForThread(threadId);
     return Boolean(latestRun && ['queued', 'running', 'awaiting_input'].includes(latestRun.status));
   }
+}
+
+export function createProviderCommandOptions(store: ProviderCommandStoreLike): Pick<
+  ThreadCommandServiceOptions,
+  'listModelProviders' | 'getModelProvider' | 'getWorkspaceDefaultProviderId' | 'getChannelBinding' | 'setChannelPreferredProvider'
+> {
+  return {
+    listModelProviders: () => store.listModelProviders(),
+    getModelProvider: (providerId) => store.getModelProvider(providerId),
+    getWorkspaceDefaultProviderId: (workspaceId) => {
+      const config = store.readRuntimeConfig().config;
+      const project = config?.projects?.find((p: any) => p.name === workspaceId || p.workspace_id === workspaceId) as
+        { agent?: { options?: { provider_id?: string } } } | undefined;
+      return String(project?.agent?.options?.provider_id || '').trim();
+    },
+    getChannelBinding: (workspaceId, chatId, platformUserId, platform) => store.getPlatformThreadBinding(workspaceId, chatId, platformUserId, platform),
+    setChannelPreferredProvider: (input) => store.updatePlatformThreadPreferredProvider(
+      input.workspaceId,
+      input.chatId,
+      input.platformUserId,
+      input.providerId,
+      input.platform,
+    ),
+  };
 }

--- a/services/local-ai-core/src/thread/thread-command-service.ts
+++ b/services/local-ai-core/src/thread/thread-command-service.ts
@@ -1,4 +1,4 @@
-import type { AuditEvent, DesktopModelProvider } from '@cc/superai-contracts';
+import type { AuditEvent, DesktopModelProvider, RuntimeConfigState } from '@cc/superai-contracts';
 import type { LocalRunRow, LocalThreadRow } from '../router/workspace-router-types.js';
 import {
   agentHelpText,
@@ -24,7 +24,7 @@ export type ThreadCommandChannelContext = {
 export type ProviderCommandStoreLike = {
   listModelProviders(): DesktopModelProvider[];
   getModelProvider(providerId: string): DesktopModelProvider | undefined;
-  readRuntimeConfig(): { config?: { projects?: unknown[] } | undefined };
+  readRuntimeConfig(): RuntimeConfigState;
   getPlatformThreadBinding(
     workspaceId: string,
     chatId: string,
@@ -287,14 +287,14 @@ export class ThreadCommandService {
       return this.formatProviderList(state.availableProviders);
     }
     if (action === 'reset') {
-      return this.executeProviderReset(threadId, workspaceId, channel, state.channelProviderId, state.defaultProvider, state.defaultProviderId);
+      return this.executeProviderReset(threadId, workspaceId, channel, state);
     }
     if (action === 'help') {
       return this.formatProviderHelp(state.currentProvider, state.defaultProvider);
     }
 
     const requestedId = (action === 'use' ? rest.join(' ') : args.join(' ')).trim();
-    return this.executeProviderUse(threadId, workspaceId, channel, requestedId, state.availableProviders, state.channelProviderId);
+    return this.executeProviderUse(threadId, workspaceId, channel, requestedId, state);
   }
 
   private formatProviderHelp(currentProvider: DesktopModelProvider | undefined, defaultProvider: DesktopModelProvider | undefined) {
@@ -346,10 +346,9 @@ export class ThreadCommandService {
     threadId: string,
     workspaceId: string,
     channel: ThreadCommandChannelContext | undefined,
-    channelProviderId: string,
-    defaultProvider: DesktopModelProvider | undefined,
-    defaultProviderId: string,
+    state: ProviderCommandState,
   ) {
+    const { channelProviderId, defaultProvider, defaultProviderId } = state;
     if (!channel?.chatId || !channel.platformUserId) {
       return '当前会话未绑定飞书或微信等渠道，无需重置。';
     }
@@ -375,9 +374,9 @@ export class ThreadCommandService {
     workspaceId: string,
     channel: ThreadCommandChannelContext | undefined,
     requestedId: string,
-    availableProviders: DesktopModelProvider[],
-    channelProviderId: string,
+    state: ProviderCommandState,
   ) {
+    const { availableProviders, channelProviderId } = state;
     if (!requestedId) {
       return '请指定 Provider ID，例如：`/provider use provider-5`。使用 `/provider list` 查看可用 Provider。';
     }
@@ -468,11 +467,12 @@ export function createProviderCommandOptions(store: ProviderCommandStoreLike): P
   return {
     listModelProviders: () => store.listModelProviders(),
     getModelProvider: (providerId) => store.getModelProvider(providerId),
+    // Runtime config projects match by either stable workspace_id or display name,
+    // unlike projectWorkspaceId() which only handles the stable id.
     getWorkspaceDefaultProviderId: (workspaceId) => {
-      const config = store.readRuntimeConfig().config;
-      const project = config?.projects?.find((p: any) => p.name === workspaceId || p.workspace_id === workspaceId) as
-        { agent?: { options?: { provider_id?: string } } } | undefined;
-      return String(project?.agent?.options?.provider_id || '').trim();
+      const { config } = store.readRuntimeConfig();
+      const project = config.projects?.find((p) => p.name === workspaceId || p.workspace_id === workspaceId);
+      return String(project?.agent.options?.provider_id || '').trim();
     },
     getChannelBinding: (workspaceId, chatId, platformUserId, platform) => store.getPlatformThreadBinding(workspaceId, chatId, platformUserId, platform),
     setChannelPreferredProvider: (input) => store.updatePlatformThreadPreferredProvider(

--- a/tests/integration/workspace-channel-provider.test.ts
+++ b/tests/integration/workspace-channel-provider.test.ts
@@ -209,24 +209,15 @@ test('ThreadCommandService handles /provider current, list, use, reset', async (
       updated_at: now,
     });
 
-    const { ThreadCommandService } = await import('../../services/local-ai-core/src/thread/thread-command-service.js');
+    const { ThreadCommandService, createProviderCommandOptions } = await import('../../services/local-ai-core/src/thread/thread-command-service.js');
     const service = new ThreadCommandService({
       getThreadRow: (id) => store.getThreadRow(id),
       updateThreadAgentMode: (id, mode) => store.updateThreadAgentMode(id, mode),
       updateThreadAgentType: (id, type) => store.updateThreadAgentType(id, type),
       getLatestRunForThread: () => undefined,
       createAuditEvent: () => {},
-      listModelProviders: () => store.listModelProviders(),
-      getModelProvider: (id) => store.getModelProvider(id),
+      ...createProviderCommandOptions(store),
       getWorkspaceDefaultProviderId: () => 'provider-default',
-      getChannelBinding: (ws, chat, user, plat) => store.getPlatformThreadBinding(ws, chat, user, plat),
-      setChannelPreferredProvider: (input) => store.updatePlatformThreadPreferredProvider(
-        input.workspaceId,
-        input.chatId,
-        input.platformUserId,
-        input.providerId,
-        input.platform,
-      ),
     });
 
     // 1. /provider current when inheriting default


### PR DESCRIPTION
## Category
b) 代码复用 + d) 代码质量 (code reuse + quality)

## Motivation
PR #124 wired the same 5-option `/provider` block (listModelProviders / getModelProvider / getWorkspaceDefaultProviderId / getChannelBinding / setChannelPreferredProvider) verbatim into both `LocalCoreAcpBackend` and `BaseChannelGateway` — jscpd already flags it as an 11-line clone. This extracts `createProviderCommandOptions(store)` into `thread-command-service.ts` and spreads it at both call sites. It also collapses `formatProviderCurrent`'s 5-param signature (provider + id passed redundantly) onto `ProviderCommandState`, passes `state` to `executeProviderReset`/`executeProviderUse` instead of derived scalars, and replaces `any`-typed provider params with `DesktopModelProvider`.

## Review rounds & conclusions
- Round 1 (3 parallel agents: Code Reuse / Code Quality / Efficiency): Efficiency clean. Reuse flagged the test file re-wiring 4 options by hand → now uses the factory. Quality flagged the hand-rolled `readRuntimeConfig` shape forcing a cast + `any` → now typed `RuntimeConfigState`; flagged state-derived scalar params → now take `state`.
- Round-1 fixes applied reviewers' prescriptions verbatim, so no round 2 needed (consistent with prior daily runs).

## Validation
- `pnpm test`: 712 tests / 711 pass / **fail = 0** / 1 skipped, 80 BDD scenarios passed (exit 0)
- `npx tsc -p tsconfig.electron.json --noEmit`: clean

## Declined / noted
- Removing the stray root-level mirror dirs in the working tree: foreign WIP, not touched.
- `WorkspaceRouter.getWorkspaceDefaultProviderId` duplicates the project→provider_id lookup: pre-existing/untouched, sync-vs-async shapes differ; revisit if a third consumer appears.
- Pre-existing double `getModelProvider` SQLite lookup when channel id == default id: minor, left as is.