### PR TITLE
feat: Establish project-setup engineering and architecture baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,21 @@ The codebase uses TypeScript with `strict` mode enabled and the `@` alias for `s
 ## Architecture Boundaries
 Keep the directory structure intentional, with clear ownership and single-purpose modules. Page components should orchestrate UI and data flow, shared components should stay presentation-focused, stores should own state transitions, API modules should isolate transport concerns, and Electron or Local AI Core logic should not leak into renderer code except through shared contracts. Keep dependencies pointing from low level to high level: low-level modules (shared contracts, SDKs, kernel interfaces) must never depend on higher-level modules (UI pages, components, specific plugins, or desktop shell code), and lower renderer layers (stores/API) must not depend on UI page views. Prefer small, cohesive files over broad utility modules, and move reusable behavior to the nearest appropriate shared layer only after a real second use appears. When a code file exceeds 1000 lines, consider splitting it. Keep agent runtime quirks in `services/local-ai-core/src/agents/<agent-id>/` first, and only move behavior into shared ACP/router/storage/renderer layers when the invariant truly applies across agents.
 
+<!-- project-setup:architecture-maintenance:start -->
+## Architecture maintenance
+
+Before implementation, classify Architecture Impact as `Required` or `None`.
+Use `Required` when a change alters module or service responsibilities,
+dependency direction or public protocols, data ownership or flow,
+trust, deployment, process, or network boundaries, external integrations,
+synchronous/asynchronous communication, or adds, removes, splits, or merges
+an architectural component.
+
+When `Required`, read and follow `docs/architecture/maintenance.md` before
+implementation. Completion requires the current architecture facts, one
+change record, provider artifacts and validation, and the README diagram to agree.
+<!-- project-setup:architecture-maintenance:end -->
+
 Architecture and flow diagrams live under `docs/architecture/` as typed Archify JSON specs (`system-architecture.json`, `*.workflow.json`, `*.sequence.json`, `*.lifecycle.json`). Update corresponding diagram specs alongside architectural or core workflow changes, validate via `pnpm lint:arch`, deliver showcase HTML/PNG artifacts, and keep `README.md` and `docs/architecture/overview.md` linked.
 
 When designing or connecting multi-entity models (such as `AutomationRun` wrapping an underlying `acpRunId`, or channel sessions wrapping threads), maintain clear semantic separation between the outer wrapper ID and the inner execution ID. Avoid treating all identifiers as generic strings. Downstream APIs and UI components must explicitly document and consume the precise target ID domain, and backend lookup methods should implement defensive alias resolution where cross-entity lookups are plausible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+<!-- project-setup:shared-agent-rules:start -->
+@AGENTS.md
+<!-- project-setup:shared-agent-rules:end -->
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ React 19 · Electron 35 · Vite · TypeScript · Tailwind CSS · Zustand · i18n
 
 AgentDock 由 Electron 桌面壳、React/Web 渲染入口、Local AI Core、OpenSandbox 云端运行层和外部 Agent API 组成。Electron 只负责桌面生命周期、窗口和本地 core 启动；React/Web 通过 API client 访问 Local AI Core；Local AI Core 统一管理 workspace、thread、run、ACP 流式事件、channel 网关、定时任务、知识库、sandbox 启动与外部系统映射。云端 sandbox 模式通过 OpenSandbox 创建隔离容器，容器内 agent runtime 通过 HTTP NDJSON ACP bridge 与 Local AI Core 通信。外部系统可通过 `/api/local/v1/external/*` 创建或复用项目、发起 agent run，并通过 per-run SSE 订阅过程。
 
+<!-- project-setup:architecture-diagram:start -->
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/architecture/system-architecture.dark.png">
@@ -23,6 +24,9 @@ AgentDock 由 Electron 桌面壳、React/Web 渲染入口、Local AI Core、Open
 </p>
 
 > 💡 **交互式架构图**：可在浏览器中直接打开 [docs/architecture/system-architecture.html](docs/architecture/system-architecture.html)，体验深浅色切换、分步引导导览（01 桌面通信 / 02 会话与沙箱 / 03 调度与渠道）、节点高亮与路径追踪。
+> 
+> 架构事实与规范参见 [架构事实](docs/architecture.md) · [架构全景矩阵](docs/architecture/overview.md) · [架构变更历史](docs/architecture/changes/)。
+<!-- project-setup:architecture-diagram:end -->
 
 后台关键模块说明：
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,126 @@
+# AgentDock Architecture Facts
+
+This document is the provider-neutral source of truth for AgentDock's system architecture, process boundaries, communication protocols, and data ownership.
+
+For visual diagrams and the interactive L1-L3 Architecture Matrix, see [docs/architecture/overview.md](docs/architecture/overview.md).
+For the architecture maintenance policy, see [docs/architecture/maintenance.md](docs/architecture/maintenance.md).
+For diagram provider settings, see [docs/architecture/diagram-provider.yaml](docs/architecture/diagram-provider.yaml).
+For semantic architecture change history, see [docs/architecture/changes/](docs/architecture/changes/).
+
+---
+
+## 1. System Goals & Context
+
+AgentDock is a hybrid Desktop and Web platform designed to orchestrate local and cloud-based autonomous coding and task agents. It integrates desktop workflow acceleration with enterprise collaboration channels (Lark, WeChat Work), secure sandboxing, and background scheduling.
+
+Key capabilities:
+- Multi-agent runtime orchestration via Agent Client Protocol (ACP)
+- Secure isolation via Docker / OpenSandbox container runtimes
+- Channel gateways bridging team messaging to agent sessions
+- Background cron scheduling and automation monitors
+- Local knowledge base indexing and retrieval
+
+---
+
+## 2. Process Boundaries & Public Entry Points
+
+```
+┌────────────────────────────────────────────────────────┐
+│               Electron Shell (electron/)               │
+│  - Spawns Local AI Core child process                  │
+│  - Hosts BrowserWindow / Native menus / App lifecycle  │
+└──────────────────────────┬─────────────────────────────┘
+                           │ (Spawns & monitors)
+                           ▼
+┌────────────────────────────────────────────────────────┐
+│           React Renderer (src/ - Port 5173)            │
+│  - UI views: Threads, Workspaces, Automations, Skills  │
+│  - State: Zustand stores (auth, channel, thread)       │
+└──────────────────────────┬─────────────────────────────┘
+                           │ HTTP REST & WebSocket
+                           │ http://127.0.0.1:9831/api/local/v1/*
+                           ▼
+┌────────────────────────────────────────────────────────┐
+│      Local AI Core Daemon (services/local-ai-core/)    │
+│  - Port 9831 (HTTP server & WebSocket event bus)       │
+│  - Workspace router & thread management                │
+│  - ACP session coordinator & agent process spawner     │
+│  - Cron scheduler & automation triggers                │
+│  - Channel gateways: Lark, WeChat                      │
+│  - SQLite local storage & knowledge index              │
+└────────────┬─────────────────────────────┬─────────────┘
+             │                             │
+             │ HTTP NDJSON Bridge          │ Docker / OpenSandbox API
+             ▼                             ▼
+┌──────────────────────────┐  ┌──────────────────────────┐
+│ Channel Gateways / Users │  │  Sandbox Container Layer │
+│ - Lark Bot Webhooks/WS   │  │  - Agent execution env   │
+│ - WeChat Work Inbound    │  │  - Isolated filesystem   │
+└──────────────────────────┘  └──────────────────────────┘
+```
+
+### Public Entry Points
+
+1. **Desktop App**: Launched via `electron/main.ts`. Spawns `services/local-ai-core/` using Node.js runtime (`ELECTRON_RUN_AS_NODE=1`), polls `http://127.0.0.1:9831/api/local/v1/health`, then opens the renderer window. Note: `electron/preload.ts` exposes no Electron IPC bridge; all frontend-to-backend communication strictly uses HTTP/WebSocket.
+2. **Web Admin UI**: Served via Vite or production bundle. Interacts with Local AI Core via `/api/local/v1/*`.
+3. **Local AI Core REST & WebSocket API**:
+   - `GET /api/local/v1/health`: Daemon health probe
+   - `/api/local/v1/workspaces/*`: Workspace configurations and route bindings
+   - `/api/local/v1/threads/*`: Conversational threads, messages, and permission requests
+   - `/api/local/v1/runs/*`: ACP agent execution runs and streaming events
+   - `/api/local/v1/scheduler/*`: Recurring cron jobs and automated delivery
+   - `/api/local/v1/external/*`: External programmatic integration and per-run SSE streaming
+4. **Channel Gateway Webhooks**: Inbound poller and webhooks for enterprise messaging channels (Lark, WeChat Work).
+
+---
+
+## 3. Component Responsibilities & Module Boundaries
+
+| Component | Path | Responsibilities | Source Evidence |
+|---|---|---|---|
+| **Electron Shell** | `electron/` | Native app lifecycle, window creation, background core child process lifecycle management. | `electron/main.ts` |
+| **Renderer UI** | `src/` | Single-page application rendering threads, workspaces, automations, and settings using React 19, Zustand stores, and TailwindCSS. | `src/pages/`, `src/store/`, `src/components/` |
+| **Local Core Kernel** | `services/local-ai-core/src/kernel/` | Core lifecycle, error domains, configuration management, SQLite database migrations, and telemetry. | `services/local-ai-core/src/kernel/` |
+| **Workspace Router** | `services/local-ai-core/src/router/` | Resolves target workspace, model provider, and channel bindings for incoming requests. | `services/local-ai-core/src/router/workspace-router.ts` |
+| **ACP Runtime** | `services/local-ai-core/src/acp/` | Manages ACP agent processes, session handshakes, capability negotiations, and NDJSON streaming. | `services/local-ai-core/src/acp/` |
+| **Channel Gateways** | `services/local-ai-core/src/channel/` | Inbound message polling, signature verification, message normalization, and outbound card rendering for Lark and WeChat. | `services/local-ai-core/src/channel/` |
+| **Scheduler** | `services/local-ai-core/src/scheduler/` | Parses cron expressions, triggers scheduled runs, and delivers results to target threads/channels. | `services/local-ai-core/src/scheduler/` |
+| **Sandbox Manager**| `services/local-ai-core/src/sandbox/` | Spawns and manages Docker or OpenSandbox containers for isolated code execution. | `services/local-ai-core/src/sandbox/` |
+| **Shared Contracts**| `shared/`, `packages/superai-contracts/` | Cross-process type definitions, shared enums, and API interfaces. | `shared/desktop.ts`, `packages/superai-contracts/` |
+| **Plugin SDK** | `packages/plugin-sdk/` | Extension contracts and interfaces for Local AI Core plugins. | `packages/plugin-sdk/` |
+
+---
+
+## 4. Dependency Direction & Protocol Contracts
+
+1. **One-Way Inward Dependency**:
+   - `src/` (Renderer) depends on `shared/` contracts and `src/api/` client. It does not import Electron main or Local AI Core internals.
+   - `electron/` depends on `shared/` contracts. It launches Local AI Core as an isolated Node child process.
+   - `services/local-ai-core/` depends on `packages/*` and `shared/`. It does not import renderer code.
+   - Shared contracts (`shared/`, `packages/*`) have zero dependencies on higher layers.
+2. **Communication Protocols**:
+   - UI to Local AI Core: HTTP REST + WebSocket (`ws://127.0.0.1:9831/api/local/v1/events`).
+   - Local AI Core to Agents: ACP (Agent Client Protocol) over stdio or HTTP NDJSON bridge.
+   - External Systems to Local AI Core: HTTP REST + Server-Sent Events (SSE).
+
+---
+
+## 5. Data Ownership & Storage
+
+- **Local AI Core SQLite Database**: Primary persistent store for workspaces, thread histories, permission decisions, channel credentials, and scheduler jobs.
+- **Renderer Zustand Stores**: Ephemeral presentation and session state (active workspace, current thread, UI theme, connection status).
+- **Workspace Repositories**: Source code and local configuration files owned by the user in the host filesystem or mounted inside sandboxes.
+
+---
+
+## 6. Architecture Matrix & Specifications
+
+The L1-L3 Architecture Matrix is defined in typed JSON specifications validated via `pnpm lint:arch` with Archify:
+
+- **L1 System Architecture**: [docs/architecture/system-architecture.json](docs/architecture/system-architecture.json)
+- **L2 ACP Session Flow (Sequence)**: [docs/architecture/acp-session-flow.sequence.json](docs/architecture/acp-session-flow.sequence.json)
+- **L2 Scheduled Delivery (Workflow)**: [docs/architecture/scheduled-delivery-workflow.json](docs/architecture/scheduled-delivery-workflow.json)
+- **L2 Skill Router (Workflow)**: [docs/architecture/skill-router.workflow.json](docs/architecture/skill-router.workflow.json)
+- **L3 Agent Run Lifecycle (State Machine)**: [docs/architecture/agent-run.lifecycle.json](docs/architecture/agent-run.lifecycle.json)
+
+For navigation across specs, dual-theme images, and interactive HTML canvases, visit [docs/architecture/overview.md](docs/architecture/overview.md).

--- a/docs/architecture/changes/2026-09-05-bootstrap.md
+++ b/docs/architecture/changes/2026-09-05-bootstrap.md
@@ -1,0 +1,45 @@
+# Architecture Baseline Record: 2026-09-05 Bootstrap
+
+## Metadata
+
+- **Date**: 2026-09-05
+- **Revision / State**: Baseline alignment of existing repository `@kafca/agentdock` (v0.1.81)
+- **Architecture Impact**: `Required` (Establishing formal Architecture Governance and baseline entry points)
+- **Active Provider**: Archify (validated via `node scripts/lint-architecture.mjs`)
+- **Status**: Verified
+
+## Context & Rationale
+
+AgentDock is an existing production-oriented Electron + React desktop application with a Local AI Core daemon. This change establishes the formal Architecture-as-Code governance baseline required by the `project-setup` contract:
+
+1. Unified `docs/architecture.md` system facts entry.
+2. Architecture maintenance policy at `docs/architecture/maintenance.md`.
+3. Diagram provider manifest at `docs/architecture/diagram-provider.yaml`.
+4. Append-only architecture change history under `docs/architecture/changes/`.
+5. Managed agent routing blocks in `AGENTS.md` and `CLAUDE.md`.
+6. Managed architecture diagram block in `README.md`.
+7. Aggregated `pnpm verify` / `pnpm qa` quality gate commands in `package.json`.
+
+## Implemented Architecture Facts
+
+### Component & Process Boundaries
+
+1. **Electron Shell** (`electron/`): Thin desktop lifecycle host. Spawns Local AI Core (`services/local-ai-core/`) as a child process using `ELECTRON_RUN_AS_NODE=1`. Exposes no IPC bridge to the renderer; all communication is pure HTTP / WebSocket.
+2. **React Renderer** (`src/`): Web UI orchestrated with React 19, Zustand stores, and TailwindCSS. Communicates with Local AI Core over `http://127.0.0.1:9831/api/local/v1/*`.
+3. **Local AI Core** (`services/local-ai-core/`): Node.js HTTP/WebSocket server owning workspace management, thread sessions, ACP (Agent Client Protocol) bridging, background task scheduler, channel gateways (Lark, WeChat), and knowledge storage.
+4. **Sandbox Runtime**: Docker / OpenSandbox execution environments spawned on demand for secure agent runs, communicating via HTTP NDJSON ACP bridge.
+5. **Shared Contracts & SDKs** (`packages/`, `shared/`): Type-safe boundaries defining cross-process types (`shared/desktop.ts`), plugin SDK (`@cc/plugin-sdk`), and core contracts (`@cc/superai-contracts`).
+
+### Quality Gates & Invariants
+
+- **Static Quality Gates**: Zero circular dependencies, copy-paste duplicate rate `<= 5%`, knip dead-code ceiling `<= 171`, max file size `<= 1000` lines, max function length `<= 45` lines, ESLint cyclomatic complexity `<= 108` warnings.
+- **Architecture Gate**: `pnpm lint:arch` runs Archify showcase validation across all 5 JSON specifications in `docs/architecture/`.
+- **Test Invariants**: Unit, contracts, integration, and Cucumber BDD tests pass 100%.
+
+## Evidence & Validation
+
+- `pnpm typecheck`: Exit code 0 (zero TypeScript errors)
+- `pnpm lint:gates`: Exit code 0 (zero circular dependencies, duplicates, dead code, file size, or function length violations)
+- `pnpm lint:arch`: Exit code 0 (5/5 specifications passed 9 showcase checks)
+- `pnpm test`: Exit code 0 (729 unit/integration/contract tests passed, 80/80 BDD scenarios passed)
+- `pnpm coverage`: Exit code 0 (meets `.c8rc.json` thresholds: lines >= 68, statements >= 68, functions >= 72, branches >= 66)

--- a/docs/architecture/diagram-provider.yaml
+++ b/docs/architecture/diagram-provider.yaml
@@ -1,0 +1,25 @@
+schema_version: 1
+provider:
+  preferred: archify
+  active: archify
+  fallback: mermaid
+capabilities:
+  validate: required
+  render_readme: required
+  compare: preferred
+outputs:
+  readme: docs/architecture/system-architecture.light.png
+  readme_dark: docs/architecture/system-architecture.dark.png
+  interactive: docs/architecture/system-architecture.html
+  history: docs/architecture/changes
+provider_files:
+  source: docs/architecture/system-architecture.json
+  matrix:
+    - docs/architecture/system-architecture.json
+    - docs/architecture/acp-session-flow.sequence.json
+    - docs/architecture/agent-run.lifecycle.json
+    - docs/architecture/scheduled-delivery-workflow.json
+    - docs/architecture/skill-router.workflow.json
+  receipt: null
+readme:
+  mode: static-image

--- a/docs/architecture/maintenance.md
+++ b/docs/architecture/maintenance.md
@@ -1,0 +1,92 @@
+# Architecture Maintenance
+
+This policy is loaded on demand after the repository's root Agent instructions classify a proposed change as `Architecture Impact: Required`. Code and provider-neutral architecture facts are the sources of truth. A diagram provider is a replaceable renderer, not the owner of architecture semantics.
+
+## Architecture Impact
+
+Classify a change as `Required` when it alters any of the following:
+
+- a runtime component, service, or major module responsibility;
+- dependency direction or a public protocol;
+- data ownership, storage, or a primary data flow;
+- a trust, deployment, process, or network boundary;
+- an external integration or synchronous/asynchronous communication mode;
+- addition, removal, split, or merge of an architectural component.
+
+File count and changed-line count do not decide architectural impact. Use `None` for an internal refactor that preserves responsibilities, boundaries, dependencies, protocols, and data flow. Do not rewrite diagrams for `None` merely to create documentation churn.
+
+## Durable Records
+
+Maintain three separate concerns:
+
+1. `docs/architecture.md` describes the current provider-neutral system facts and repository evidence. `docs/architecture/overview.md` provides the unified L1-L3 Architecture Matrix index, linking typed specs, interactive canvases, and detailed documentation.
+2. `docs/architecture/changes/YYYY-MM-DD-<slug>.md` records one semantic architecture delta and its evidence. The record is append-only after the change is accepted; later corrections use a new record that links back.
+3. `docs/architecture/` typed specifications (`system-architecture.json`, `*.workflow.json`, `*.sequence.json`, `*.lifecycle.json`) contain replaceable provider source, dual-theme images (`.light.png`, `.dark.png`, `.png`), standalone interactive HTML canvases (`.html`), and receipts. Provider files never replace current facts or semantic history.
+
+Each change record states the base revision or working-tree state, affected components and boundaries, added/removed/changed/rerouted facts, rationale or ADR, compatibility or migration consequences when real, code evidence, active provider, and validation result. Do not claim inferred runtime impact, risk, ownership, or merge safety without evidence.
+
+Git retains prior provider source revisions. When the active provider supports comparison, compare the last verified base source with the candidate and retain the checked delta artifact or receipt with the change record. Comparison is supporting evidence, not the history source of truth.
+
+## Diagram Provider Contract
+
+Read `docs/architecture/diagram-provider.yaml` before editing provider files. It declares the active provider, fallback, capabilities, stable public outputs, provider-specific source, receipt paths, and README mode.
+
+Every active provider must:
+
+- render only architecture facts supported by the repository and `docs/architecture.md`;
+- preserve stable component identities across revisions when semantics are unchanged;
+- validate its candidate before replacing the last-known-good artifact;
+- support automated validation via `pnpm lint:arch` (`node scripts/lint-architecture.mjs`, running Archify showcase checks);
+- produce either the stable README image declared by the manifest (PNG/SVG, or dual-theme `<picture>` source) or an explicitly configured inline Mermaid fallback;
+- keep standard matrix specs and rendered assets under `docs/architecture/`;
+- report a non-zero command, failed validation, missing tool, stale output, or unresolved source evidence truthfully.
+
+Archify is the preferred and active provider. Use its typed JSON source, validation, trusted delivery, static export, and interactive HTML generation. Archify remains replaceable: do not encode its internal JSON fields in `docs/architecture.md`, semantic change records, root Agent routing, or the stable README contract.
+
+If no declared provider can produce a current valid README diagram, preserve the last-known-good output, mark the step `[BLOCKED]`, and do not report architecture synchronization as complete.
+
+## Required Workflow
+
+For `Architecture Impact: Required`:
+
+1. Capture the base revision and read current facts, latest relevant change record, provider manifest, and active provider source.
+2. Inspect the changed code and tests. Update `docs/architecture.md` from evidence, not from requested design alone.
+3. Add one change record under `docs/architecture/changes/` describing the semantic delta and evidence.
+4. Update the active provider's source in the L1-L3 Architecture Matrix (`system-architecture.json`, `*.workflow.json`, `*.sequence.json`, `*.lifecycle.json`). Preserve stable component identities and layout where semantics did not change.
+5. Run the provider's required validation via `pnpm lint:arch`.
+6. Publish the validated current artifacts atomically (including `.html` interactive canvas and dual-theme `.light.png` / `.dark.png` / `.png`). A failed candidate must not replace the last-known-good diagram.
+7. Update `docs/architecture/overview.md` to keep the Architecture Matrix synchronized.
+8. Update exactly one managed README block so it directly shows the latest valid static diagram (using dual-theme `<picture>` block) or inline Mermaid fallback.
+9. Run repository documentation/link checks, `pnpm lint:arch`, and the ordinary complete quality suite (`pnpm verify`). Recheck the final diff for agreement among code, current facts, history, provider source, overview matrix, and README.
+
+## README Contract
+
+The root README contains exactly one block bounded by:
+
+```text
+<!-- project-setup:architecture-diagram:start -->
+<!-- project-setup:architecture-diagram:end -->
+```
+
+Inside the block:
+
+- show one current system architecture diagram directly (using `<picture>` tag for dark/light themes);
+- use the manifest's `outputs.readme` and `outputs.readme_dark` paths and confirm the declared image files exist;
+- link readers to `docs/architecture.md`, `docs/architecture/overview.md`, `docs/architecture/changes/`, and the interactive HTML artifact;
+- preserve every README section outside the markers.
+
+Do not add timestamp-only changes. Diagram and README changes must follow a real architecture fact change or correction.
+
+## Completion Evidence
+
+Architecture synchronization is complete only when all applicable checks are true:
+
+- current facts match the implemented code and boundaries;
+- exactly one new semantic change record exists;
+- provider source and stable output describe the same component identities and relationships;
+- required provider validation and `pnpm lint:arch` succeeded (0 errors, 0 warnings);
+- the L1-L3 Architecture Matrix and `docs/architecture/overview.md` match the current codebase;
+- the README block is unique and renders the current valid diagram;
+- local links resolve and no stale provider artifact is presented as current.
+
+Record unavailable external capabilities as `[BLOCKED]`, inapplicable optional capabilities as `[N/A]`, and executed failures as `[FAIL]`. Never convert them to `[PASS]` to finish the task.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -11,6 +11,12 @@ AgentDock now runs as a Local AI Core-first desktop app:
 
 There is no `cc-connect` runtime, management API, or bridge compatibility path in the active architecture.
 
+架构事实与治理规范：
+- 架构事实与系统边界：[docs/architecture.md](../architecture.md)
+- 架构维护策略：[docs/architecture/maintenance.md](maintenance.md)
+- 图表 Provider 配置：[docs/architecture/diagram-provider.yaml](diagram-provider.yaml)
+- 语义变更历史：[docs/architecture/changes/](changes/)
+
 ## Top-Level Flow
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "lint:file-size": "node scripts/lint-file-size.mjs",
     "lint:function-length": "node scripts/lint-function-length.mjs",
     "lint:gates": "node scripts/lint-circular.mjs --fail && JSCPD_MIN_LINES=10 JSCPD_MIN_TOKENS=60 node scripts/lint-duplicate.mjs --fail && node scripts/lint-dead-code.mjs --fail --max-count 171 && node scripts/lint-file-size.mjs --fail && node scripts/lint-function-length.mjs --fail --max-count 45 && pnpm lint:complexity:gate",
+    "verify": "pnpm typecheck && pnpm lint:gates && pnpm lint:arch && pnpm test && pnpm coverage",
+    "qa": "pnpm verify",
     "e2e:smoke": "pnpm build && node scripts/e2e-smoke.mjs",
     "e2e:compose": "node scripts/e2e-compose.mjs",
     "dist:mac": "pnpm build && electron-builder --mac dmg zip --arm64",


### PR DESCRIPTION
## Overview
建立符合 `project-setup` 规范的工程基线与 Architecture-as-Code 架构治理体系，提供统一质量聚合入口与活文档架构维护规范，无缝衔接现有 Electron + React 体系。

## Key Changes
- **聚合验证入口 (`package.json`)**：
  - 新增 `pnpm verify`：按顺序执行 `typecheck`、`lint:gates`、`lint:arch`、`test` 与 `coverage`。
  - 新增 `pnpm qa` 别名。
- **架构事实与治理文档 (`docs/architecture/`)**：
  - `docs/architecture.md`：建立工具无关的系统事实入口（进程边界、协议、模块职责、数据归属）。
  - `docs/architecture/maintenance.md`：建立按需触发的架构维护策略文档。
  - `docs/architecture/diagram-provider.yaml`：声明 Archify 为活跃与首选图表渲染 provider。
  - `docs/architecture/changes/2026-09-05-bootstrap.md`：初始基线记录。
  - `docs/architecture/overview.md`：建立全景矩阵大盘与架构治理双向导航。
- **Agent 路由与 README 契约**：
  - `AGENTS.md`：注入 `<!-- project-setup:architecture-maintenance:start -->` 管理块。
  - `CLAUDE.md`：注入 `<!-- project-setup:shared-agent-rules:start -->`（`@AGENTS.md`）共享引用。
  - `README.md`：以 `<!-- project-setup:architecture-diagram:start -->` 包裹自适应架构图并补充治理索引。

## Validation Commands Run
- `pnpm typecheck` (0 Errors)
- `pnpm lint:gates` (0 Errors, 0 循环依赖, 重复率/函数长度/复杂度符合基线)
- `pnpm lint:arch` (5/5 架构规范全部通过 9 项 Showcase 校验)
- `pnpm test` (729 单元/集成测试 + 80 个 BDD 场景全部通过)
- `pnpm coverage` (覆盖率达到阈值)
- `pnpm verify` (聚合全绿通过)