### PR TITLE
Remove dead knowledge plugin option plumbing

### DIFF
--- a/packages/knowledge-api/src/index.ts
+++ b/packages/knowledge-api/src/index.ts
@@ -24,12 +24,6 @@ export interface KnowledgeProvider extends KnowledgeRuntime {}
 
 export interface KnowledgeAttachmentStore extends ThreadKnowledgeAttachmentStore {}
 
-export interface KnowledgePluginFactoryOptions {
-  userDataPath: string;
-  getConfig: () => KnowledgeConfig;
-  setConfig: (input: Partial<KnowledgeConfig>) => Promise<KnowledgeConfig> | KnowledgeConfig;
-}
-
 export interface KnowledgePluginRuntime extends KnowledgeRuntimeRegistration {}
 
 const DEFAULT_CONFIG: KnowledgeConfig = {

--- a/services/local-ai-core/src/kernel/bootstrap.ts
+++ b/services/local-ai-core/src/kernel/bootstrap.ts
@@ -33,7 +33,6 @@ import {
   createKernelBuiltinPlugins,
   createRuntimeAgentPlugins,
   createRuntimeChannelPlugins,
-  createRuntimeKnowledgePlugin,
   createRuntimeMonitorPlugins,
   createRuntimeSchedulerPlugins,
 } from '../plugins/builtin/catalog.js';
@@ -234,12 +233,7 @@ export function bootstrapLocalCoreRuntime(options: {
   });
   const channelPlugin = channelPlugins.lark;
   const weixinChannelPlugin = channelPlugins.weixin;
-  const knowledgePlugin = createRuntimeKnowledgePlugin({
-    enableKnowledge: options.enableKnowledge,
-    userDataPath: options.userDataPath,
-    getConfig: () => state.getKnowledgeConfig(),
-    setConfig: (input) => state.updateKnowledgeConfig(input),
-  });
+  const knowledgePlugin = createBuiltinNoopKnowledgePlugin();
   const schedulerPlugins = createRuntimeSchedulerPlugins({
     store,
     getWorkspaceRouter: () => workspaceRouter,

--- a/services/local-ai-core/src/plugins/builtin/catalog.ts
+++ b/services/local-ai-core/src/plugins/builtin/catalog.ts
@@ -1,9 +1,8 @@
-import type { DesktopConnectConfig, KnowledgeConfig } from '@cc/superai-contracts';
+import type { DesktopConnectConfig } from '@cc/superai-contracts';
 import type {
   AgentPlugin,
   ChannelPlugin,
   ChannelRuntime,
-  KnowledgePlugin,
   MonitorPlugin,
   RuntimePlugin,
   SchedulerPlugin,
@@ -60,15 +59,6 @@ export function createRuntimeChannelPlugins(options: {
     lark: createBuiltinLarkChannelPlugin(options),
     weixin: createBuiltinWeixinChannelPlugin(options),
   };
-}
-
-export function createRuntimeKnowledgePlugin(_options?: {
-  enableKnowledge?: boolean;
-  userDataPath?: string;
-  getConfig?: () => KnowledgeConfig;
-  setConfig?: (input: Partial<KnowledgeConfig>) => Promise<KnowledgeConfig> | KnowledgeConfig;
-}): KnowledgePlugin {
-  return createBuiltinNoopKnowledgePlugin();
 }
 
 export function createRuntimeSchedulerPlugins(options: {

--- a/services/local-ai-core/src/runtime/local-core-runtime-state.ts
+++ b/services/local-ai-core/src/runtime/local-core-runtime-state.ts
@@ -3,7 +3,6 @@ import { dirname, join } from 'node:path';
 import type {
   DesktopSettings,
   DesktopSettingsInput,
-  KnowledgeConfig,
 } from '@cc/superai-contracts';
 import { AgentDockRotatingLogger, inferLogLevel, type AgentDockLogEntry, type AgentDockLogFile } from '../kernel/rotating-logger.js';
 
@@ -29,8 +28,6 @@ export interface LocalCoreRuntimeState {
   readonly logPath: string;
   getSettings(): DesktopSettings;
   saveSettings(input: DesktopSettingsInput): Promise<DesktopSettings>;
-  getKnowledgeConfig(): KnowledgeConfig;
-  updateKnowledgeConfig(input: Partial<KnowledgeConfig>): Promise<KnowledgeConfig>;
   getLogs(limit?: number): string[];
   getLogEntries(level?: string, limit?: number): AgentDockLogEntry[];
   pushLog(message: string): void;
@@ -96,22 +93,6 @@ class FileBackedLocalCoreRuntimeState implements LocalCoreRuntimeState {
     };
     this.persistSettings();
     return this.settings;
-  }
-
-  getKnowledgeConfig(): KnowledgeConfig {
-    return this.settings.knowledge;
-  }
-
-  async updateKnowledgeConfig(input: Partial<KnowledgeConfig>): Promise<KnowledgeConfig> {
-    this.settings = {
-      ...this.settings,
-      knowledge: {
-        ...this.settings.knowledge,
-        ...input,
-      },
-    };
-    this.persistSettings();
-    return this.settings.knowledge;
   }
 
   getLogs(limit = 200): string[] {


### PR DESCRIPTION
## Category
d) Code quality

## Motivation
After the vector-DB engine removal (#127), the knowledge plugin became a permanent noop — but dead plumbing survived:

- `createRuntimeKnowledgePlugin(_options?)` in `catalog.ts` accepted 4 options and ignored all of them; `bootstrap.ts` still wired `enableKnowledge`, `userDataPath`, `getConfig`, `setConfig` into it.
- The runtime-state accessors `getKnowledgeConfig`/`updateKnowledgeConfig` had exactly one caller — that dead wiring (verified repo-wide). Their removal also drops a synchronous `writeFileSync` from the knowledge config update path.
- `KnowledgePluginFactoryOptions` in `@cc/knowledge-api` was an unused twin of the same dead options shape (zero usages).
- The now zero-arg factory was a pure passthrough with one caller; bootstrap constructs the noop plugin directly instead (matching the existing fallback path).

Found during the 2026-09-07 daily log review + optimization pass (no bugs found in logs; baseline green).

## Review rounds
1 review round (3 parallel reviewers: reuse / quality / efficiency):
- Quality: clean — confirmed no other implementers/consumers of the removed interface members; HTTP knowledge endpoints route through the plugin `KnowledgeRuntime`, unaffected.
- Efficiency: clean — strictly less bootstrap allocation; no recompute regression.
- Reuse: 4 findings; 2 accepted and applied verbatim (`KnowledgePluginFactoryOptions` deletion, direct noop construction replacing the passthrough wrapper + unused `KnowledgePlugin` import). 2 declined as scope-widening: the `settings.knowledge` persistence path (`DesktopSettings.knowledge` + `saveSettings` merge + load/persist) is now consumerless but spans shared contracts, persisted settings format, and tests — filed as a follow-up candidate, not bundled here.

Round 2 skipped: round-1 fixes applied prescriptions verbatim.

## Validation
- `pnpm test`: 730 tests, 729 pass, 0 fail, 1 skipped; 80/80 BDD scenarios (identical to baseline before the change)
- `pnpm typecheck` + `tsc -p tsconfig.electron.json --noEmit`: clean
- `pnpm lint:duplicate`: 3.47% line rate, 298 clone instances (at baseline)
- ESLint on changed files: clean
- Note: `pnpm lint:dead-code` could not run locally (oxc-parser ArrayBuffer OOM on this 3.6GB machine — environmental); the change only removes symbols and adds none.

## Follow-up candidate
Remove the consumerless `settings.knowledge` persistence path (`DesktopSettings.knowledge`, `DesktopSettingsInput.knowledge`, `saveSettings` merge branch, load/persist normalization) and the now-unread `enableKnowledge` bootstrap option (~25 test call sites to sweep).