### PR TITLE
Remove consumerless knowledge settings path

### DIFF
--- a/scripts/e2e-smoke.mjs
+++ b/scripts/e2e-smoke.mjs
@@ -29,13 +29,6 @@ function writeSettings(userDataDir, settings) {
     `${JSON.stringify({
       defaultProject: 'default',
       autoStartService: true,
-      knowledge: {
-        baseUrl: '',
-        authMode: 'none',
-        token: '',
-        headerName: 'X-API-Key',
-        defaultCollection: 'personal_knowledge',
-      },
       plugins: {},
       ...settings,
     }, null, 2)}\n`,

--- a/services/local-ai-core/src/kernel/bootstrap.ts
+++ b/services/local-ai-core/src/kernel/bootstrap.ts
@@ -199,7 +199,6 @@ function isAgentPlugin(plugin: RuntimePlugin | null): plugin is AgentPlugin {
 export function bootstrapLocalCoreRuntime(options: {
   userDataPath: string;
   localCoreBase?: string;
-  enableKnowledge?: boolean;
   log?: (message: string) => void;
 }): LocalCoreRuntimeBootstrap {
   const state = createLocalCoreRuntimeState({

--- a/services/local-ai-core/src/runtime/handlers/runtime-handler.ts
+++ b/services/local-ai-core/src/runtime/handlers/runtime-handler.ts
@@ -77,16 +77,6 @@ export function registerRuntimeHandlers(
       configPath: 'string',
       autoStartService: 'boolean',
       defaultProject: 'string',
-      knowledge: {
-        kind: 'object',
-        fields: {
-          baseUrl: 'string',
-          authMode: { kind: 'string', allowedValues: ['none', 'bearer', 'header'] },
-          token: 'string',
-          headerName: 'string',
-          defaultCollection: 'string',
-        },
-      },
       plugins: {
         kind: 'object',
         valueSchema: {

--- a/services/local-ai-core/src/runtime/local-core-runtime-state.ts
+++ b/services/local-ai-core/src/runtime/local-core-runtime-state.ts
@@ -11,13 +11,6 @@ type RuntimeSettingsFile = {
   defaultProject: string;
   autoStartService: boolean;
   plugins: DesktopSettings['plugins'];
-  knowledge: {
-    baseUrl: string;
-    authMode: 'none' | 'bearer' | 'header';
-    token: string;
-    headerName: string;
-    defaultCollection: string;
-  };
 };
 
 export interface LocalCoreRuntimeState {
@@ -84,12 +77,6 @@ class FileBackedLocalCoreRuntimeState implements LocalCoreRuntimeState {
             }),
           )
         : this.settings.plugins,
-      knowledge: input.knowledge
-        ? {
-            ...this.settings.knowledge,
-            ...input.knowledge,
-          }
-        : this.settings.knowledge,
     };
     this.persistSettings();
     return this.settings;
@@ -123,13 +110,6 @@ class FileBackedLocalCoreRuntimeState implements LocalCoreRuntimeState {
       defaultProject: '',
       autoStartService: true,
       plugins: {},
-      knowledge: {
-        baseUrl: '',
-        authMode: 'none',
-        token: '',
-        headerName: 'X-API-Key',
-        defaultCollection: 'personal_knowledge',
-      },
     };
     if (!existsSync(this.settingsPath)) {
       return {
@@ -141,7 +121,6 @@ class FileBackedLocalCoreRuntimeState implements LocalCoreRuntimeState {
         bridgePort: 0,
         bridgeToken: '',
         bridgePath: '',
-        knowledge: defaults.knowledge,
         plugins: defaults.plugins,
       };
     }
@@ -156,10 +135,6 @@ class FileBackedLocalCoreRuntimeState implements LocalCoreRuntimeState {
       bridgeToken: '',
       bridgePath: '',
       plugins: normalizePluginSettings(raw.plugins),
-      knowledge: {
-        ...defaults.knowledge,
-        ...(raw.knowledge || {}),
-      },
     };
   }
 
@@ -168,7 +143,6 @@ class FileBackedLocalCoreRuntimeState implements LocalCoreRuntimeState {
       defaultProject: this.settings.defaultProject,
       autoStartService: this.settings.autoStartService,
       plugins: this.settings.plugins,
-      knowledge: this.settings.knowledge,
     };
     mkdirSync(dirname(this.settingsPath), { recursive: true });
     writeFileSync(this.settingsPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');

--- a/shared/desktop.ts
+++ b/shared/desktop.ts
@@ -80,7 +80,6 @@ export interface DesktopSettings {
   bridgePort: number;
   bridgeToken: string;
   bridgePath: string;
-  knowledge: DesktopKnowledgeSettings;
   plugins: Record<string, DesktopPluginSettings>;
 }
 
@@ -363,18 +362,7 @@ export interface DesktopSettingsInput {
   configPath?: string;
   autoStartService?: boolean;
   defaultProject?: string;
-  knowledge?: Partial<DesktopKnowledgeSettings>;
   plugins?: Record<string, Partial<DesktopPluginSettings>>;
-}
-
-export type DesktopKnowledgeAuthMode = 'none' | 'bearer' | 'header';
-
-export interface DesktopKnowledgeSettings {
-  baseUrl: string;
-  authMode: DesktopKnowledgeAuthMode;
-  token: string;
-  headerName: string;
-  defaultCollection: string;
 }
 
 export interface DesktopPluginSettings {

--- a/tests/electron/plugin-kernel.test.ts
+++ b/tests/electron/plugin-kernel.test.ts
@@ -312,7 +312,6 @@ test('runtime bootstrap supports a disabled knowledge plugin path', () => {
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
 
     assert.deepEqual(runtime.kernel.getCapabilitySnapshot().adapters.agents, [
@@ -346,7 +345,6 @@ test('codex agent runtime routes projects through the bundled ACP adapter', asyn
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     await saveConfig(runtime, {
       projects: [{ name: 'codex-workspace', agent: { type: 'codex' } }],
@@ -381,7 +379,6 @@ test('thread slash agent reset resolves the workspace default agent through the 
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     await saveConfig(runtime, {
       projects: [{ name: 'agent-workspace', agent: { type: 'codex' } }],
@@ -406,7 +403,6 @@ test('thread slash provider commands query and list providers through router', a
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     runtime.store.upsertModelProvider({
       id: 'provider-default',
@@ -442,7 +438,6 @@ test('hermes agent runtime routes projects through hermes ACP command', async ()
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     await saveConfig(runtime, {
       projects: [{ name: 'hermes-workspace', agent: { type: 'hermes' } }],
@@ -478,7 +473,6 @@ test('hermes agent runtime injects provider API key, base URL, and model into la
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     runtime.store.upsertModelProvider({
       id: 'provider-opencode-go',
@@ -528,7 +522,6 @@ test('hermes agent runtime does not silently fallback to first provider when spe
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     // Add a default provider that should NOT be selected if unmatched provider_id is requested
     runtime.store.upsertModelProvider({
@@ -564,7 +557,6 @@ test('pi agent runtime routes projects through bundled pi ACP and coding agent',
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     runtime.store.upsertModelProvider({
       id: 'provider-openai',
@@ -625,7 +617,6 @@ test('pi agent runtime writes provider auth and default model into Pi config dir
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     runtime.store.upsertModelProvider({
       id: 'deepseek',
@@ -683,7 +674,6 @@ test('pi agent runtime normalizes DeepSeek provider when provider name is the mo
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     runtime.store.upsertModelProvider({
       id: 'deepseek-v4-flash',
@@ -731,9 +721,7 @@ test('runtime bootstrap knowledge capabilities come from the selected provider p
       userDataPath: enabledUserDataPath,
     });
     const disabledRuntime = bootstrapLocalCoreRuntime({
-      userDataPath: disabledUserDataPath,
-      enableKnowledge: false,
-    });
+      userDataPath: disabledUserDataPath,    });
 
     assert.deepEqual(
       enabledRuntime.kernel.getCapabilitySnapshot().snapshot.knowledge.map((capability) => capability.sourceType),
@@ -764,13 +752,6 @@ test('runtime bootstrap keeps disabled plugins diagnosable without contributing 
       JSON.stringify({
         defaultProject: 'default',
         autoStartService: true,
-        knowledge: {
-          baseUrl: '',
-          authMode: 'none',
-          token: '',
-          headerName: 'X-API-Key',
-          defaultCollection: 'personal_knowledge',
-        },
         plugins: {
           'builtin.scheduler-lark': { enabled: false },
         },
@@ -883,13 +864,6 @@ test('LocalCoreController accepts injected bootstrap dependencies', async () => 
         bridgePort: 0,
         bridgeToken: '',
         bridgePath: '',
-        knowledge: {
-          baseUrl: '',
-          authMode: 'none',
-          token: '',
-          headerName: 'X-API-Key',
-          defaultCollection: 'personal_knowledge',
-        },
         plugins: {},
       }),
       getLogs: () => [],
@@ -952,7 +926,6 @@ test('runtime logs are persisted to unified sys and level logs', () => {
     withLogEnv(logDir, () => {
       const runtime = bootstrapLocalCoreRuntime({
         userDataPath,
-        enableKnowledge: false,
         log: () => {},
       });
 
@@ -1081,7 +1054,6 @@ test('controller logs are persisted to sys.log', () => {
     withLogEnv(logDir, () => {
       const runtime = bootstrapLocalCoreRuntime({
         userDataPath,
-        enableKnowledge: false,
       });
       const controller = new LocalCoreController(userDataPath, runtime);
       const emittedLogs: string[] = [];
@@ -1224,10 +1196,6 @@ test('server validates the actual desktop settings contract before dispatch', as
   };
   const server = new LocalAiCoreServer({ controller } as any, { port: 0 });
 
-  const invalidKnowledge = await invokeServer(server, 'POST', '/api/local/v1/runtime/settings', { knowledge: 42 });
-  assert.equal(invalidKnowledge.statusCode, 400);
-  assert.match(invalidKnowledge.body.error, /knowledge/);
-
   const invalidPlugins = await invokeServer(server, 'POST', '/api/local/v1/runtime/settings', { plugins: [] });
   assert.equal(invalidPlugins.statusCode, 400);
   assert.match(invalidPlugins.body.error, /plugins/);
@@ -1237,18 +1205,11 @@ test('server validates the actual desktop settings contract before dispatch', as
   });
   assert.equal(invalidPluginSettings.statusCode, 400);
   assert.match(invalidPluginSettings.body.error, /plugins\.channel\.lark\.enabled/);
-
-  const invalidAuthMode = await invokeServer(server, 'POST', '/api/local/v1/runtime/settings', {
-    knowledge: { authMode: 'cookie' },
-  });
-  assert.equal(invalidAuthMode.statusCode, 400);
-  assert.match(invalidAuthMode.body.error, /knowledge\.authMode/);
   assert.equal(dispatched, false);
 
   const valid = await invokeServer(server, 'POST', '/api/local/v1/runtime/settings', {
     autoStartService: true,
     defaultProject: 'workspace-stable',
-    knowledge: { authMode: 'bearer', token: 'secret' },
     plugins: { 'channel.lark': { enabled: true, config: { appId: 'app-id' } } },
   });
   assert.equal(valid.statusCode, 200);
@@ -1439,13 +1400,6 @@ test('agent runtime selection is registry-based and disabled runtimes do not rou
       JSON.stringify({
         defaultProject: 'default',
         autoStartService: true,
-        knowledge: {
-          baseUrl: '',
-          authMode: 'none',
-          token: '',
-          headerName: 'X-API-Key',
-          defaultCollection: 'personal_knowledge',
-        },
         plugins: {
           'builtin.agent-pi': { enabled: false },
           'builtin.agent-claudecode': { enabled: false },

--- a/tests/electron/runtime-config-store.test.ts
+++ b/tests/electron/runtime-config-store.test.ts
@@ -55,7 +55,6 @@ test('runtime config ignores legacy settings configPath and malformed toml', () 
       configPath: join(userDataPath, 'custom-config', 'agentdock.toml'),
       defaultProject: '',
       autoStartService: true,
-      knowledge: {},
       plugins: {},
     }), 'utf8');
     writeFileSync(legacyPath, '[[projects]\nname = "broken"\n', 'utf8');
@@ -150,7 +149,6 @@ provider_id = "deepseek"
 
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     const controller = new LocalCoreController(userDataPath, runtime);
     const initialConfig = await controller.readRuntimeConfig();
@@ -172,7 +170,6 @@ provider_id = "deepseek"
 
     const reopenedRuntime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     const storeConfig = reopenedRuntime.store.readRuntimeConfig();
     assert.equal(storeConfig.storage, 'sqlite');

--- a/tests/electron/workspace-task-store.test.ts
+++ b/tests/electron/workspace-task-store.test.ts
@@ -45,7 +45,7 @@ test('workspace registry entries persist in LocalCoreAcpStore', () => {
 test('runtime project migration makes workspace registry authoritative and preserves identity across rename', async () => {
   const userDataPath = mkdtempSync(join(tmpdir(), 'workspace-project-migration-'));
   try {
-    const runtime = bootstrapLocalCoreRuntime({ userDataPath, enableKnowledge: false, log: () => {} });
+    const runtime = bootstrapLocalCoreRuntime({ userDataPath, log: () => {} });
     const controller = new LocalCoreController(userDataPath, runtime);
     await controller.saveRuntimeConfig({
       projects: [{
@@ -175,7 +175,6 @@ test('controller stores embedded project providers as-is without migrating them'
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
       log: () => {},
     });
     const controller = new LocalCoreController(userDataPath, runtime);
@@ -213,7 +212,6 @@ test('workspace router resolves projects that select a shared provider', async (
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
       log: () => {},
     });
     const controller = new LocalCoreController(userDataPath, runtime);
@@ -251,7 +249,6 @@ test('scheduler create resolves a Lark delivery route without binding the job to
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
       log: () => {},
     });
     const controller = new LocalCoreController(userDataPath, runtime);
@@ -296,7 +293,6 @@ test('scheduler create from a bound thread preserves channel instance route', as
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
       log: () => {},
     });
     const controller = new LocalCoreController(userDataPath, runtime);
@@ -1364,7 +1360,7 @@ test('scheduler dispatches due jobs without waiting for long-running jobs', asyn
 
 test('scheduler ignores malformed enabled legacy cron jobs during startup and ticks', async () => {
   const userDataPath = mkdtempSync(join(tmpdir(), 'scheduler-malformed-cron-'));
-  const runtime = bootstrapLocalCoreRuntime({ userDataPath, enableKnowledge: false, log: () => {} });
+  const runtime = bootstrapLocalCoreRuntime({ userDataPath, log: () => {} });
   try {
     const job = runtime.store.createScheduledJob({
       workspaceId: 'workspace-a',
@@ -1659,7 +1655,7 @@ test('WorkspaceRouter retrieves artifact content with security boundary checks',
   const userDataPath = mkdtempSync(join(tmpdir(), 'artifact-content-test-'));
   const workspacePath = mkdtempSync(join(tmpdir(), 'workspace-artifact-test-'));
   try {
-    const runtime = bootstrapLocalCoreRuntime({ userDataPath, enableKnowledge: false, log: () => {} });
+    const runtime = bootstrapLocalCoreRuntime({ userDataPath, log: () => {} });
     const controller = new LocalCoreController(userDataPath, runtime);
 
     const workspaceId = 'ws-artifact-test';
@@ -1751,7 +1747,7 @@ test('WorkspaceRouter restricts artifact reads to the run artifacts directory', 
   const workspacePath = mkdtempSync(join(tmpdir(), 'artifact-scope-ws-'));
   const secretPath = join(tmpdir(), `artifact-scope-secret-${process.pid}.txt`);
   try {
-    const runtime = bootstrapLocalCoreRuntime({ userDataPath, enableKnowledge: false, log: () => {} });
+    const runtime = bootstrapLocalCoreRuntime({ userDataPath, log: () => {} });
     const controller = new LocalCoreController(userDataPath, runtime);
 
     const workspaceId = 'ws-artifact-scope';

--- a/tests/integration/workspace-channel-provider.test.ts
+++ b/tests/integration/workspace-channel-provider.test.ts
@@ -309,7 +309,6 @@ test('WorkspaceRouter resolves channel preferred provider via channelRoute with 
   try {
     const runtime = bootstrapLocalCoreRuntime({
       userDataPath,
-      enableKnowledge: false,
     });
     runtime.store.upsertModelProvider({
       id: 'provider-default',


### PR DESCRIPTION
## Category
d) Code quality (completion of the knowledge-removal follow-up filed in #131)

## Motivation
Nothing reads `DesktopSettings.knowledge` anymore: the renderer never touches it, the HTTP `/knowledge/*` endpoints route through the noop plugin's `KnowledgeRuntime` (not runtime-state), and the last consumer of the runtime-state accessors died with #131's factory cleanup. This PR deletes the remaining dead surface:

- `shared/desktop.ts`: `DesktopSettings.knowledge`, `DesktopSettingsInput.knowledge`, `DesktopKnowledgeSettings`, `DesktopKnowledgeAuthMode`
- `local-core-runtime-state.ts`: `RuntimeSettingsFile.knowledge`, `loadSettings` defaults/normalization, `saveSettings` merge branch, `persistSettings` field
- `runtime-handler.ts`: the knowledge validation block in `runtime.settings.save`
- `bootstrap.ts`: the unread `enableKnowledge` option (24 test call sites swept)
- `scripts/e2e-smoke.mjs`: stale knowledge block in the smoke settings fixture

Existing user `local-core-settings.json` files with a stale knowledge block keep loading fine (`JSON.parse` + known-key reads) and self-heal on the next persist. Behavior note: an unknown `knowledge` key posted to `runtime.settings.save` now passes validation (validateBody ignores unknown keys) but is never persisted or echoed.

## Review rounds
1 review round (3 parallel reviewers: reuse / quality / efficiency):
- Efficiency: clean; removal strictly reduces bootstrap allocations, persist payload, and per-request settings serialization.
- Reuse: 2 findings, both accepted and applied verbatim — a third hidden knowledge literal in an `as any` settings mock, and the stale block in `scripts/e2e-smoke.mjs`.
- Quality: 1 accepted finding applied verbatim — line-join damage left by the mechanical `enableKnowledge` deletion (17 sites repaired to one-property-per-line); 1 declined suggestion (re-adding a legacy knowledge fixture to pin tolerance behavior — the tolerance is structural, noted here instead). Also flagged the validation behavior change above, recorded in this description.

Round 2 skipped: all accepted round-1 fixes applied reviewer prescriptions verbatim.

## Validation
- `pnpm test`: 730 tests, 729 pass, 0 fail, 1 skipped; 80/80 BDD scenarios (identical to baseline)
- `pnpm typecheck` + `tsc -p tsconfig.electron.json --noEmit`: clean