### PR TITLE
Harden webhook monitor trigger auth and error mapping

### DIFF
--- a/services/local-ai-core/src/automation/automation-monitor-service.ts
+++ b/services/local-ai-core/src/automation/automation-monitor-service.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import type {
   AutomationMonitor,
   AutomationMonitorCreateInput,
@@ -72,6 +72,21 @@ type AutomationMonitorServiceOptions = {
 };
 const PROVIDER_EVENT_CONCURRENCY = 4;
 type MonitorLifecycleState = 'starting' | 'running' | 'stopping' | 'stopped';
+
+export class WebhookTriggerError extends Error {
+  constructor(message: string, readonly status: 400 | 401 | 404) {
+    super(message);
+    this.name = 'WebhookTriggerError';
+  }
+}
+
+// Hashing both sides first keeps the comparison constant-time regardless of
+// token length, so a wrong-length guess cannot short-circuit or throw.
+function webhookTokenEquals(provided: string, expected: string): boolean {
+  const providedDigest = createHash('sha256').update(provided).digest();
+  const expectedDigest = createHash('sha256').update(expected).digest();
+  return timingSafeEqual(providedDigest, expectedDigest);
+}
 
 export class AutomationMonitorService {
   private timer: NodeJS.Timeout | null = null;
@@ -379,16 +394,16 @@ export class AutomationMonitorService {
     const cleanHookId = String(hookId || '').trim();
     const monitor = this.getMonitorByHookId(cleanHookId);
     if (!monitor) {
-      throw new Error(`Webhook monitor not found: ${cleanHookId}`);
+      throw new WebhookTriggerError(`Webhook monitor not found: ${cleanHookId}`, 404);
     }
     if (!monitor.enabled) {
-      throw new Error(`Webhook monitor is disabled: ${cleanHookId}`);
+      throw new WebhookTriggerError(`Webhook monitor is disabled: ${cleanHookId}`, 400);
     }
 
     const expectedToken = String(monitor.sourceConfig?.token || '').trim();
     const cleanToken = String(token || '').trim();
-    if (!cleanToken || cleanToken !== expectedToken) {
-      throw new Error('Invalid or missing webhook token.');
+    if (!cleanToken || !expectedToken || !webhookTokenEquals(cleanToken, expectedToken)) {
+      throw new WebhookTriggerError('Invalid or missing webhook token.', 401);
     }
 
     const body = (typeof payload === 'object' && payload !== null)

--- a/services/local-ai-core/src/runtime/handlers/automation-handler.ts
+++ b/services/local-ai-core/src/runtime/handlers/automation-handler.ts
@@ -1,6 +1,6 @@
 import type { RouteHandler } from '../server-helpers.js';
 import { json, rawJson, readJsonBody, readRawBody } from '../server-helpers.js';
-import type { AutomationMonitorService } from '../../automation/automation-monitor-service.js';
+import { WebhookTriggerError, type AutomationMonitorService } from '../../automation/automation-monitor-service.js';
 import type { AutomationMonitorCreateInput, AutomationMonitorUpdateInput } from '@cc/superai-contracts';
 import { validateBody } from '../request-validation.js';
 
@@ -17,7 +17,7 @@ function extractWebhookToken(req: Parameters<RouteHandler>[1], url?: URL): strin
 }
 
 async function readWebhookPayload(req: Parameters<RouteHandler>[1]): Promise<unknown> {
-  const raw = await readRawBody(req);
+  const raw = await readRawBody(req, 1 << 20);
   if (!raw.length) {
     return {};
   }
@@ -34,16 +34,8 @@ async function readWebhookPayload(req: Parameters<RouteHandler>[1]): Promise<unk
 }
 
 function handleWebhookError(res: Parameters<RouteHandler>[2], error: unknown): void {
-  const message = error instanceof Error ? error.message : String(error);
-  let status = 500;
-  if (message.includes('Invalid or missing webhook token')) {
-    status = 401;
-  } else if (message.includes('Webhook monitor not found')) {
-    status = 404;
-  } else if (message.includes('Webhook monitor is disabled')) {
-    status = 400;
-  }
-  rawJson(res, status, { error: message });
+  const status = error instanceof WebhookTriggerError ? error.status : 500;
+  rawJson(res, status, { error: error instanceof Error ? error.message : String(error) });
 }
 
 export function registerAutomationHandlers(

--- a/tests/electron/webhook-monitor.test.ts
+++ b/tests/electron/webhook-monitor.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
-import { AutomationMonitorService } from '../../services/local-ai-core/src/automation/automation-monitor-service.js';
+import { AutomationMonitorService, WebhookTriggerError } from '../../services/local-ai-core/src/automation/automation-monitor-service.js';
 import { AutomationService } from '../../services/local-ai-core/src/automation/automation-service.js';
 import { WebhookMonitorProvider } from '../../services/local-ai-core/src/automation/webhook-provider.js';
 import { LocalCoreAcpStore } from '../../services/local-ai-core/src/acp/local-core-acp-store.js';
@@ -161,6 +161,42 @@ test('triggerWebhook authenticates token and evaluates condition', async () => {
     );
     assert.equal(cooldownResult.decision, 'skipped_cooldown');
     assert.equal(context.executedActions.length, 1); // No new execution
+  } finally {
+    await context.monitors.stop();
+    context.close();
+  }
+});
+
+test('triggerWebhook token compare rejects wrong-length tokens with 401', async () => {
+  const context = fixture();
+  try {
+    await context.monitors.createMonitor({
+      workspaceId: 'workspace-a',
+      title: 'Length Mismatch Hook',
+      sourceType: 'webhook',
+      sourceConfig: {
+        hookId: 'length-hook',
+        token: 'sec-deploy-token-999',
+      },
+      condition: { metric: 'always', operator: '==', value: true },
+      promptTemplate: 'Hello',
+      cooldownMs: 60_000,
+    });
+
+    // Shorter and longer wrong tokens must both reject with the typed 401
+    // error — the timing-safe compare must not throw on length mismatch.
+    await assert.rejects(
+      () => context.monitors.triggerWebhook('length-hook', { event: 't' }, 'x'),
+      (error: unknown) => error instanceof WebhookTriggerError && error.status === 401,
+    );
+    await assert.rejects(
+      () => context.monitors.triggerWebhook(
+        'length-hook',
+        { event: 't' },
+        'x'.repeat(64),
+      ),
+      (error: unknown) => error instanceof WebhookTriggerError && error.status === 401,
+    );
   } finally {
     await context.monitors.stop();
     context.close();


### PR DESCRIPTION
## Category
d) Quality — security hardening of the webhook trigger path introduced by #129

## Motivation
- The HTTP handler mapped trigger failures to status codes by substring-matching error messages. Replaced with a typed `WebhookTriggerError` (401 invalid token / 404 unknown hookId / 400 disabled monitor), mirroring the existing `ArtifactContentError` pattern in workspace-router.ts.
- Hook token comparison used `===`, which short-circuits on length mismatch, leaking token length and throwing on malformed input. Replaced with `webhookTokenEquals`: sha256 both sides, then `crypto.timingSafeEqual` on the fixed 32-byte digests — constant-time regardless of input length.
- `readWebhookPayload` buffered the request body with no size cap before authentication. Now capped at 1 MiB via `readRawBody(req, 1 << 20)`; oversized bodies are rejected 400 centrally by the RequestValidationError mapping in server.ts.

## Review rounds
1 round with 3 parallel reviewers on `git diff main...HEAD`:
- Reviewer A (reuse): no reuse issues. Optional consolidation declined as follow-up: shared `HttpStatusError` base + `httpStatusFromError` helper — this would be the third occurrence alongside task-handler.ts:52 and ArtifactContentError, but A itself rated it low priority for a hardening PR.
- Reviewer B (quality): clean. Verified compare equivalence for all edge cases and no status-mapping loss.
- Reviewer C (efficiency): diff adds no per-request cost. Two pre-existing findings logged as follow-ups rather than blocking: (a) authenticate/resolve hook before reading the body and before the `getMonitorByHookId` listMonitors() fan-out; (b) 404 vs 401 vs 400 response ordering is an enumeration oracle — consider collapsing 404/401 and adding an O(1) hookId lookup.

Accepted fix applied verbatim: the 1 MiB pre-auth body cap. Round 2 skipped per convention (fix applied reviewer's prescription exactly).

## Validation
- `pnpm test`: 739 tests, 738 pass, 0 fail, 1 skipped; 80/80 BDD scenarios pass.
- `pnpm typecheck` and electron tsconfig typecheck: clean.
- eslint on changed source files: clean; complexity gate unchanged (106 warnings vs 108 limit, no new warning entries).
- New regression test: wrong-length tokens (short and 64-char) reject with typed 401.