### PR TITLE
Fix decisions endpoint workspace resolution and decision-log arg threading

### DIFF
--- a/services/local-ai-core/src/automation/automation-action-executor.ts
+++ b/services/local-ai-core/src/automation/automation-action-executor.ts
@@ -87,7 +87,7 @@ async function resolveExecutionPrompt(
   if (automation.action.workflowTemplate !== 'deep-analysis') {
     return basePrompt;
   }
-  const priorLessons = await decisionService.getPriorLessons(automation.id, workspacePath);
+  const priorLessons = await decisionService.getPriorLessons(automation.id, automation.workspaceId, workspacePath);
   return composeDeepAnalysisPrompt(basePrompt, input.promptVariables, priorLessons, automation.title);
 }
 
@@ -124,7 +124,11 @@ async function openExecutionBridge(
 }
 
 export class AutomationActionExecutor {
-  constructor(private readonly options: AutomationActionExecutorOptions) {}
+  private readonly decisionService: DecisionLogService;
+
+  constructor(private readonly options: AutomationActionExecutorOptions) {
+    this.decisionService = options.decisionLogService ?? new DecisionLogService(options.store);
+  }
 
   async execute(
     input: AutomationActionExecutionInput,
@@ -136,11 +140,9 @@ export class AutomationActionExecutor {
     const workspaceRouter = this.options.getWorkspaceRouter();
     const threadId = await this.resolveThread(automation);
     const workspacePath = this.options.store.getWorkspaceRegistryEntry?.(automation.workspaceId)?.path;
-    const decisionService = this.options.decisionLogService
-      || new DecisionLogService({ getWorkspacePath: (id) => this.options.store.getWorkspaceRegistryEntry?.(id)?.path });
 
     const isDeepAnalysis = automation.action.workflowTemplate === 'deep-analysis';
-    const prompt = await resolveExecutionPrompt(automation, input, decisionService, workspacePath);
+    const prompt = await resolveExecutionPrompt(automation, input, this.decisionService, workspacePath);
 
     const bridge = await openExecutionBridge(
       automation,
@@ -170,7 +172,7 @@ export class AutomationActionExecutor {
         runId: sendResult.runId,
         threadId,
         dataSnapshot: input.promptVariables,
-        decisionService,
+        decisionService: this.decisionService,
         workspacePath,
         isDeepAnalysis,
         getAutomationService: this.options.getAutomationService,

--- a/services/local-ai-core/src/automation/decision-log-service.ts
+++ b/services/local-ai-core/src/automation/decision-log-service.ts
@@ -125,12 +125,12 @@ export class DecisionLogService {
     }
   }
 
-  async listDecisions(monitorId: string, explicitWorkspacePath?: string): Promise<AutomationDecisionRecord[]> {
+  async listDecisions(monitorId: string, workspaceId?: string, explicitWorkspacePath?: string): Promise<AutomationDecisionRecord[]> {
     const fromMemory = this.memoryRecords.get(monitorId);
     if (fromMemory && fromMemory.length > 0) return fromMemory;
 
     // Parse from disk if available
-    const filePath = this.resolveFilePath(monitorId, undefined, explicitWorkspacePath);
+    const filePath = this.resolveFilePath(monitorId, workspaceId, explicitWorkspacePath);
     if (!existsSync(filePath)) return [];
 
     try {
@@ -141,8 +141,8 @@ export class DecisionLogService {
     }
   }
 
-  async getPriorLessons(monitorId: string, explicitWorkspacePath?: string): Promise<string[]> {
-    const decisions = await this.listDecisions(monitorId, explicitWorkspacePath);
+  async getPriorLessons(monitorId: string, workspaceId?: string, explicitWorkspacePath?: string): Promise<string[]> {
+    const decisions = await this.listDecisions(monitorId, workspaceId, explicitWorkspacePath);
     const lessons: string[] = [];
     for (const d of decisions) {
       if (d.retrospectiveOutcome?.lessons) {

--- a/services/local-ai-core/src/runtime/handlers/automation-handler.ts
+++ b/services/local-ai-core/src/runtime/handlers/automation-handler.ts
@@ -92,8 +92,11 @@ export function registerAutomationHandlers(
     }
     // Decisions are keyed under the internal monitor id; the API accepts the
     // public short id (or the internal id) so resolve before lookup.
-    const resolvedId = automationMonitors.resolveRequiredMonitorId(monitorId);
-    json(res, 200, { decisions: await decisionLogService.listDecisions(resolvedId) });
+    const monitor = automationMonitors.getMonitor(monitorId);
+    if (!monitor) {
+      throw new Error(`Automation monitor not found: ${monitorId}`);
+    }
+    json(res, 200, { decisions: await decisionLogService.listDecisions(monitor.id, monitor.workspaceId) });
   });
   map.set('automation.hooks.trigger', async (route, req, res, url) => {
     const hookId = (route as { hookId: string }).hookId;

--- a/tests/electron/decision-action-executor.test.ts
+++ b/tests/electron/decision-action-executor.test.ts
@@ -208,9 +208,114 @@ Phase 3: Final Adjudication
     assert.match(updatedLogContent, /Bollinger lower band is reliable for AAPL\./);
 
     // Verify prior lessons can now be read
-    const lessons = await decisionLogService.getPriorLessons('mon_test_apple', tempDir);
+    const lessons = await decisionLogService.getPriorLessons('mon_test_apple', 'ws_test', tempDir);
     assert.equal(lessons.length, 1);
     assert.equal(lessons[0], 'Bollinger lower band is reliable for AAPL.');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('deep-analysis run includes disk-persisted lessons via workspaceId resolution', async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'agentdock-executor-lessons-test-'));
+  try {
+    const workspacePathFor = (id: string) => (id === 'ws_test' ? tempDir : undefined);
+    const writer = new DecisionLogService({ getWorkspacePath: workspacePathFor });
+    const decision = {
+      id: 'dec_5f6e7d8c9b0a1f2e',
+      monitorId: 'mon_test_tsla',
+      workspaceId: 'ws_test',
+      action: 'SELL' as const,
+      confidence: 65,
+      thesis: 'Rally into resistance fades.',
+      bullPoints: [],
+      bearPoints: [],
+      keyAssumptions: ['Resistance holds above 260'],
+      dataSnapshot: { latestPrice: 258.4 },
+      createdAt: new Date().toISOString(),
+      retrospectiveStatus: 'pending' as const,
+    };
+    await writer.appendDecision(decision);
+    await writer.recordRetrospective(decision.monitorId, decision.id, {
+      accuracy: 'correct',
+      realizedOutcome: 'TSLA faded 4% from resistance.',
+      reflection: 'Resistance retest logic held.',
+      lessons: ['Bollinger upper band is reliable for TSLA.'],
+    });
+
+    let sentMessage = '';
+    const mockStore = {
+      getPlatformThreadBinding: () => undefined,
+      getWorkspaceRegistryEntry: (id: string) => (id === 'ws_test' ? { id, path: tempDir } : undefined),
+      getRun: () => ({ status: 'completed', completed_at: new Date().toISOString() }),
+    } as any;
+    const mockWorkspaceRouter = {
+      listThreads: async () => [],
+      createThread: async () => ({ id: 'th_mock_456', title: 'Test Thread' }),
+      getWorkspaceAgentType: async () => 'mock-agent',
+      sendThreadMessage: async (_threadId: string, message: string) => {
+        sentMessage = message;
+        return { runId: 'run_mock_789' };
+      },
+      getThread: async () => ({
+        id: 'th_mock_456',
+        messages: [
+          { id: 'msg_1', role: 'assistant', kind: 'final', content: 'Neutral analysis with no decision block.' },
+        ],
+      }),
+      interruptRun: async () => {},
+    } as any;
+
+    const executor = new AutomationActionExecutor({
+      store: mockStore,
+      getWorkspaceRouter: () => mockWorkspaceRouter,
+      getChannelRuntime: () => undefined,
+      decisionLogService: new DecisionLogService({ getWorkspacePath: workspacePathFor }),
+    });
+
+    const automation: AutomationDefinition = {
+      id: 'mon_test_tsla',
+      workspaceId: 'ws_test',
+      title: 'TSLA Resistance Watch',
+      enabled: true,
+      health: 'healthy',
+      activation: {
+        kind: 'provider-event',
+        sourceType: 'stock.quote',
+        sourceConfig: { symbol: 'TSLA' },
+      },
+      condition: { kind: 'always' },
+      action: {
+        kind: 'agent-prompt',
+        promptTemplate: 'Analyze {{symbol}}.',
+        executionMode: 'side-thread',
+        workflowTemplate: 'deep-analysis',
+      },
+      delivery: { platform: 'local', route: { type: 'local.thread', channelId: 'ws_test' } },
+      policies: { concurrency: 'skip-if-running', cooldownMs: 0 },
+      consecutiveEvaluationFailures: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      originKind: 'automation-monitor',
+    };
+
+    await executor.execute({
+      automation,
+      evaluation: {
+        id: 'eval_mock_2',
+        automationId: automation.id,
+        status: 'finished',
+        activationKind: 'provider-event',
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date().toISOString(),
+        conditionOutcome: 'matched',
+        triggerDecision: 'triggered',
+      },
+      promptVariables: { symbol: 'TSLA', latestPrice: 258.4 },
+    });
+
+    assert.match(sentMessage, /GROUNDED DATA CONTRACT/);
+    assert.match(sentMessage, /Bollinger upper band is reliable for TSLA\./);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/tests/electron/webhook-monitor.test.ts
+++ b/tests/electron/webhook-monitor.test.ts
@@ -432,3 +432,64 @@ test('automation.monitor.decisions resolves public short monitor ids to internal
   }
 });
 
+test('automation.monitor.decisions reads persisted decisions after restart from the workspace dir', async () => {
+  const context = fixture();
+  try {
+    const monitor = await context.monitors.createMonitor({
+      workspaceId: 'workspace-a',
+      title: 'Restarted Decision Hook',
+      sourceType: 'webhook',
+      sourceConfig: { hookId: 'restart-hook', token: 'sec-restart' },
+      condition: { metric: 'always', operator: '==', value: true },
+      promptTemplate: 'Analyze the webhook event.',
+    });
+
+    const workspacePath = join(context.path, 'workspace');
+    const writer = new DecisionLogService({ getWorkspacePath: () => workspacePath });
+    await writer.appendDecision({
+      id: 'dec_a1b2c3d4e5f60718',
+      monitorId: monitor.id,
+      workspaceId: 'workspace-a',
+      runId: `run:agentdock::${monitor.id}:1756950000001`,
+      threadId: 'thread:workspace-a::11111111-2222-3333-4444-555555555555',
+      action: 'HOLD',
+      confidence: 55,
+      thesis: 'Wait for band retest.',
+      bullPoints: [],
+      bearPoints: [],
+      keyAssumptions: [],
+      dataSnapshot: { symbol: 'MSFT' },
+      createdAt: '2026-09-10T08:00:00.000Z',
+      retrospectiveStatus: 'pending',
+    }, workspacePath);
+
+    const reader = new DecisionLogService({ getWorkspacePath: () => workspacePath });
+    const handlers = new Map<string, RouteHandler>();
+    registerAutomationHandlers(handlers, context.monitors, reader);
+    const handler = handlers.get('automation.monitor.decisions');
+    assert.ok(handler, 'automation.monitor.decisions handler must be registered');
+
+    const res = {
+      statusCode: 200,
+      bodyData: '',
+      setHeader() {},
+      writeHead(code: number) { this.statusCode = code; },
+      end(data?: unknown) { this.bodyData = String(data || ''); },
+      get body() { return this.bodyData ? JSON.parse(this.bodyData) : null; },
+    };
+    await handler(
+      { name: 'automation.monitor.decisions', monitorId: monitor.id } as any,
+      {} as any,
+      res as any,
+      new URL(`http://127.0.0.1/api/local/v1/automation/monitors/${monitor.id}/decisions`),
+    );
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.data.decisions.length, 1);
+    assert.equal(res.body.data.decisions[0].id, 'dec_a1b2c3d4e5f60718');
+    assert.equal(res.body.data.decisions[0].action, 'HOLD');
+  } finally {
+    await context.monitors.stop();
+    context.close();
+  }
+});
+


### PR DESCRIPTION
## Category
d) Quality — correctness hardening of the monitor decision-log data flow landed in #130

## Motivation
The `automation.monitor.decisions` endpoint called `listDecisions(resolvedId)` with no workspace context. `DecisionLogService` then resolved the markdown file against `process.cwd()`/rootDir, while `appendDecision` (executor) writes under the monitor's **workspace** directory (`<workspacePath>/.agentdock/decisions/<monitorId>.md`). The in-memory `memoryRecords` cache masked this whenever reads went through the same service instance that appended — meaning the endpoint silently returned `[]` for every persisted decision after a server restart. Fixes:

- `listDecisions`/`getPriorLessons` now accept `workspaceId` (plus the existing optional explicit workspace path) and the handler passes `monitor.workspaceId`.
- The handler resolves the monitor **once** (`getMonitor` + explicit not-found throw) instead of `resolveRequiredMonitorId` + `getMonitor`, which re-ran alias resolution and eagerly executed three store queries per request.
- Fixed a positional-arg slip the signature change would have caused in the deep-analysis prompt path: `getPriorLessons(automation.id, workspacePath)` would have put a filesystem path in the `workspaceId` slot, re-introducing the same cwd bug for prior-lessons reads. Now `getPriorLessons(automation.id, automation.workspaceId, workspacePath)`.
- `AutomationActionExecutor` assigns its decision log service once in the constructor (`options.decisionLogService ?? new DecisionLogService(options.store)`), instead of rebuilding a fallback per `execute()` call.
- Regression tests: (1) endpoint reads workspace-dir markdown through a **fresh** service instance (restart simulation); (2) deep-analysis run includes disk-persisted lessons via id-sensitive workspace resolution — verified to fail when the positional slip is present and pass with the fix.

## Review rounds
2 rounds with 3 parallel reviewers each:
- Round 1: all three reviewers independently caught the `getPriorLessons` positional-arg regression in my first patch (its only non-test caller was missed), plus the duplicate monitor resolution and the overwrought fallback getter. Round-1 findings on the original bug confirmed the cwd-vs-workspace mismatch.
- Round 2: all fixes applied reviewer prescriptions verbatim; suite re-run green, so round 3 was skipped per convention.

Declined / follow-ups (pre-existing in #130, flagged by reviewers, not behavior-blocking): unbounded `memoryRecords` growth (no eviction); `appendDecision`/`recordRetrospective` are O(file) read-modify-write with unbounded file growth; `resolveDecisionsDir` runs `existsSync`+`mkdirSync` even on read paths (a GET can create the decisions dir); concurrent-append TOCTOU on the markdown log; options-object signature for the read methods (2 of 3 reviewers preferred keeping the positional style).

## Validation
- `pnpm test`: 754 tests, 753 pass, 0 fail, 1 skipped; BDD suite pass.
- `pnpm typecheck` + electron tsconfig `--noEmit`: clean.
- `pnpm lint:complexity:gate`: pass (no new warnings). eslint on changed source files: clean.