### PR TITLE
Bound decision log retention and fix disk parse order

### DIFF
--- a/services/local-ai-core/src/automation/decision-log-service.ts
+++ b/services/local-ai-core/src/automation/decision-log-service.ts
@@ -1,8 +1,18 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type {
   AutomationDecisionRecord,
 } from '@cc/superai-contracts';
+
+// Completed decisions beyond MAX_COMPLETED_DECISIONS are evicted (newest
+// kept); everything is additionally capped at MAX_RETAINED_DECISIONS so
+// never-retrospected (pending) decisions cannot grow the log unbounded.
+const MAX_COMPLETED_DECISIONS = 100;
+const MAX_RETAINED_DECISIONS = 200;
+// Mirrors the retro bullet rendered by appendRetrospectiveSection; the
+// two-space indent keeps free-form agent text (thesis, lessons) that merely
+// mentions "Status: completed" from being classified as a completed retro.
+const COMPLETED_RETRO_PATTERN = /^ {2}- Status: completed/m;
 
 export interface DecisionLogServiceOptions {
   rootDir?: string;
@@ -33,11 +43,7 @@ export class DecisionLogService {
       || (workspaceId && this.getWorkspacePath ? this.getWorkspacePath(workspaceId) : undefined)
       || this.rootDir
       || process.cwd();
-    const target = join(base, '.agentdock', 'decisions');
-    if (!existsSync(target)) {
-      mkdirSync(target, { recursive: true });
-    }
-    return target;
+    return join(base, '.agentdock', 'decisions');
   }
 
   resolveFilePath(monitorId: string, workspaceId?: string, explicitWorkspacePath?: string): string {
@@ -49,25 +55,23 @@ export class DecisionLogService {
   async appendDecision(record: AutomationDecisionRecord, explicitWorkspacePath?: string): Promise<void> {
     const list = this.memoryRecords.get(record.monitorId) || [];
     list.unshift(record);
-    this.memoryRecords.set(record.monitorId, list);
+    this.memoryRecords.set(record.monitorId, trimDecisionRecords(list));
 
     const filePath = this.resolveFilePath(record.monitorId, record.workspaceId, explicitWorkspacePath);
     let existing = '';
-    if (existsSync(filePath)) {
-      try {
-        existing = readFileSync(filePath, 'utf8');
-      } catch {
-        existing = '';
-      }
+    try {
+      existing = readFileSync(filePath, 'utf8');
+    } catch {
+      existing = '';
     }
 
-    if (!existing.trim()) {
-      existing = `# Decision Log: ${record.monitorId}\n\n`;
-    }
-
+    const parsed = existing.trim()
+      ? splitDecisionSections(existing)
+      : { header: `# Decision Log: ${record.monitorId}`, sections: [] as string[] };
     const section = renderDecisionMarkdownSection(record);
-    const updated = `${existing.trimEnd()}\n\n${section}\n`;
-    writeFileSync(filePath, updated, 'utf8');
+    const retained = retainDecisionSections([...parsed.sections, section]);
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, [parsed.header, ...retained].join('\n\n') + '\n', 'utf8');
   }
 
   async recordRetrospective(
@@ -87,6 +91,7 @@ export class DecisionLogService {
         retrospectiveEvaluatedAt: now,
         retrospectiveOutcome: outcome,
       };
+      this.memoryRecords.set(monitorId, trimDecisionRecords(list));
     }
 
     const filePath = this.resolveFilePath(monitorId, list[0]?.workspaceId, explicitWorkspacePath);
@@ -199,7 +204,7 @@ function renderDecisionMarkdownSection(record: AutomationDecisionRecord): string
 }
 
 function parseRetrospectiveOutcome(sec: string): AutomationDecisionRecord['retrospectiveOutcome'] | undefined {
-  if (!sec.includes('Status: completed')) {
+  if (!COMPLETED_RETRO_PATTERN.test(sec)) {
     return undefined;
   }
   const accuracyMatch = sec.match(/Accuracy:\s*(correct|incorrect|neutral)/);
@@ -219,12 +224,48 @@ function parseRetrospectiveOutcome(sec: string): AutomationDecisionRecord['retro
   };
 }
 
+function splitDecisionSections(content: string): { header: string; sections: string[] } {
+  const chunks = content.split(/\n(?=## Decision `)/);
+  if (chunks[0]?.startsWith('## Decision `')) {
+    return { header: '', sections: chunks.map((chunk) => chunk.trim()) };
+  }
+  return { header: (chunks[0] || '').trim(), sections: chunks.slice(1).map((chunk) => chunk.trim()) };
+}
+
+function retainDecisionSections(chronologicalSections: string[]): string[] {
+  const retained: string[] = [];
+  let completed = 0;
+  for (let index = chronologicalSections.length - 1; index >= 0; index--) {
+    const section = chronologicalSections[index].trim();
+    if (retained.length >= MAX_RETAINED_DECISIONS) break;
+    const isCompleted = COMPLETED_RETRO_PATTERN.test(section);
+    if (isCompleted) {
+      if (completed >= MAX_COMPLETED_DECISIONS) continue;
+      completed++;
+    }
+    retained.unshift(section);
+  }
+  return retained;
+}
+
+function trimDecisionRecords(newestFirst: AutomationDecisionRecord[]): AutomationDecisionRecord[] {
+  const retained: AutomationDecisionRecord[] = [];
+  let completed = 0;
+  for (const record of newestFirst) {
+    if (retained.length >= MAX_RETAINED_DECISIONS) break;
+    if (record.retrospectiveStatus === 'completed') {
+      if (completed >= MAX_COMPLETED_DECISIONS) continue;
+      completed++;
+    }
+    retained.push(record);
+  }
+  return retained;
+}
+
 function parseDecisionsFromMarkdown(content: string, monitorId: string): AutomationDecisionRecord[] {
   const records: AutomationDecisionRecord[] = [];
-  const sections = content.split(/\n(?=## Decision `)/);
 
-  for (const sec of sections) {
-    if (!sec.startsWith('## Decision `')) continue;
+  for (const sec of splitDecisionSections(content).sections) {
     const headerMatch = sec.match(/^## Decision `([^`]+)`\s*-\s*([^\n]+)/);
     if (!headerMatch) continue;
 
@@ -258,5 +299,5 @@ function parseDecisionsFromMarkdown(content: string, monitorId: string): Automat
     });
   }
 
-  return records;
+  return records.reverse();
 }

--- a/tests/electron/decision-workflow.test.ts
+++ b/tests/electron/decision-workflow.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -185,6 +185,147 @@ test('DecisionLogService records decisions and retrospectives to markdown log', 
     const lessons = await service.getPriorLessons(monitorId);
     assert.equal(lessons.length, 1);
     assert.equal(lessons[0], 'Weekly Bollinger lower band is highly predictive for AAPL.');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('DecisionLogService lists disk-persisted decisions newest-first including the first logged section', async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'agentdock-decision-order-test-'));
+  try {
+    const writer = new DecisionLogService({ rootDir: tempDir });
+    const monitorId = 'mon_test_order';
+    await writer.appendDecision({
+      id: 'dec_first_0001',
+      monitorId,
+      workspaceId: 'ws_test',
+      action: 'BUY',
+      confidence: 60,
+      thesis: 'First entry at the lower band.',
+      bullPoints: [],
+      bearPoints: [],
+      keyAssumptions: [],
+      dataSnapshot: {},
+      createdAt: '2026-09-11T08:00:00.000Z',
+      retrospectiveStatus: 'pending',
+    });
+    await writer.appendDecision({
+      id: 'dec_second_002',
+      monitorId,
+      workspaceId: 'ws_test',
+      action: 'HOLD',
+      confidence: 50,
+      thesis: 'Waiting for the retest.',
+      bullPoints: [],
+      bearPoints: [],
+      keyAssumptions: [],
+      dataSnapshot: {},
+      createdAt: '2026-09-11T09:00:00.000Z',
+      retrospectiveStatus: 'pending',
+    });
+
+    const reader = new DecisionLogService({ rootDir: tempDir });
+    const decisions = await reader.listDecisions(monitorId);
+    assert.equal(decisions.length, 2);
+    assert.equal(decisions[0].id, 'dec_second_002');
+    assert.equal(decisions[1].id, 'dec_first_0001');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('DecisionLogService bounds retained decisions and always keeps pending retrospectives', async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'agentdock-decision-retention-test-'));
+  try {
+    const service = new DecisionLogService({ rootDir: tempDir });
+    const monitorId = 'mon_test_retention';
+    const record = (index: number, status: 'pending' | 'completed') => ({
+      id: `dec_retention_${String(index).padStart(4, '0')}`,
+      monitorId,
+      workspaceId: 'ws_test',
+      action: 'WATCH' as const,
+      confidence: 50,
+      thesis: `Decision ${index}.`,
+      bullPoints: [],
+      bearPoints: [],
+      keyAssumptions: [],
+      dataSnapshot: {},
+      createdAt: new Date(Date.parse('2026-09-11T00:00:00.000Z') + index * 60_000).toISOString(),
+      retrospectiveStatus: status,
+      ...(status === 'completed' ? {
+        retrospectiveOutcome: {
+          accuracy: 'correct' as const,
+          realizedOutcome: `Outcome ${index}.`,
+          reflection: `Reflection ${index}.`,
+          lessons: [],
+        },
+      } : {}),
+    });
+
+    // First record stays pending forever; the rest complete their retrospectives.
+    await service.appendDecision(record(0, 'pending'));
+    for (let index = 1; index <= 104; index++) {
+      const current = record(index, 'completed');
+      await service.appendDecision(current);
+      await service.recordRetrospective(monitorId, current.id, {
+        accuracy: 'correct',
+        realizedOutcome: `Outcome ${index}.`,
+        reflection: `Reflection ${index}.`,
+        lessons: [],
+      });
+    }
+
+    const reader = new DecisionLogService({ rootDir: tempDir });
+    const decisions = await reader.listDecisions(monitorId);
+    const completed = decisions.filter((d) => d.retrospectiveStatus === 'completed');
+    assert.equal(completed.length, 100, 'completed decisions are capped at 100');
+    assert.ok(decisions.some((d) => d.id === 'dec_retention_0000'), 'pending-retrospective decision is always retained');
+    assert.ok(!decisions.some((d) => d.id === 'dec_retention_0001'), 'oldest completed decision is evicted');
+    assert.ok(decisions.some((d) => d.id === 'dec_retention_0104'), 'newest decision is retained');
+    assert.equal(decisions[0].id, 'dec_retention_0104', 'list is newest-first');
+
+    // The in-memory path enforces the same retention policy as disk.
+    const inMemory = await service.listDecisions(monitorId);
+    assert.equal(inMemory.filter((d) => d.retrospectiveStatus === 'completed').length, 100);
+    assert.ok(inMemory.some((d) => d.id === 'dec_retention_0000'));
+
+    // Never-retrospected (pending) decisions are bounded by the total cap too.
+    const floodMonitorId = 'mon_test_flood';
+    const floodRecord = (index: number) => ({
+      id: `dec_flood_${String(index).padStart(4, '0')}`,
+      monitorId: floodMonitorId,
+      workspaceId: 'ws_test',
+      action: 'WATCH' as const,
+      confidence: 50,
+      thesis: `Flood ${index}.`,
+      bullPoints: [],
+      bearPoints: [],
+      keyAssumptions: [],
+      dataSnapshot: {},
+      createdAt: new Date(Date.parse('2026-09-11T00:00:00.000Z') + index * 60_000).toISOString(),
+      retrospectiveStatus: 'pending' as const,
+    });
+    for (let index = 0; index < 205; index++) {
+      await service.appendDecision(floodRecord(index));
+    }
+    const floodMemory = await service.listDecisions(floodMonitorId);
+    assert.equal(floodMemory.length, 200, 'pending-only logs are capped at the total limit');
+    assert.equal(floodMemory[0].id, 'dec_flood_0204');
+    const floodDisk = await new DecisionLogService({ rootDir: tempDir }).listDecisions(floodMonitorId);
+    assert.equal(floodDisk.length, 200);
+    assert.ok(!floodDisk.some((d) => d.id === 'dec_flood_0000'), 'oldest pending decision is evicted');
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('DecisionLogService reads do not create the decisions directory', async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'agentdock-decision-readonly-test-'));
+  try {
+    const reader = new DecisionLogService({ rootDir: tempDir });
+    const decisions = await reader.listDecisions('mon_test_missing');
+    assert.equal(decisions.length, 0);
+    assert.equal(existsSync(join(tempDir, '.agentdock')), false, 'no .agentdock directory is created by reads');
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Category
c) Performance + d) Quality — DecisionLogService growth and read-path correctness (follow-ups from #134's review)

## Motivation
Three defects in the decision markdown log (`<base>/.agentdock/decisions/<monitorId>.md`, from #130):
1. **First decision silently lost on disk parse**: the file header (`# Decision Log: …`) and the first `## Decision` section landed in one split chunk, which the parser's `startsWith('## Decision')` check skipped — every disk parse dropped the oldest decision, and parsed order was oldest-first while the in-memory list is newest-first, so the decisions API order flipped across restart.
2. **Unbounded growth**: `memoryRecords` leaked per decision and the markdown file grew without limit (append = full read-modify-write of an ever-growing file).
3. **Read side effects**: `resolveDecisionsDir` ran `existsSync`+`mkdirSync`, so a GET for an unknown monitor created the decisions directory.

Fixes:
- Retention bounded per monitor: 100 completed decisions, 200 total (pending-retrospective decisions get the wider window so a scheduled retrospective can still find its target section), enforced identically on the memory list and the markdown sections at append time.
- Completed-section classification now uses an anchored pattern (`/^ {2}- Status: completed/m`) shared by the retention and parse paths, so free-form agent text mentioning "Status: completed" cannot affect eviction or fabricate retro outcomes.
- `listDecisions` returns newest-first from both memory and disk.
- Reads are side-effect-free (pure path resolution; only the write path mkdirs); redundant `existsSync` before `readFileSync` removed.
- Memory list is re-trimmed after a retrospective flips pending → completed.

Tests: newest-first order including the first section; retention caps (104 completed + 1 pending; 205 pending flood) asserted on both memory and fresh-reader disk paths; reads do not create directories.

## Review rounds
1 round with 3 parallel reviewers, then fixes:
- Accepted (applied verbatim): anchored completed-marker constant (A+B, convergent); total cap in addition to the completed cap — pending-only logs were still unbounded (C, the blocking finding); memory re-trim after retro flip (B); drop redundant `existsSync` (C); memory-path + flood test coverage (B).
- Declined as follow-ups: `memoryRecords` Map keys are never deleted when a monitor is deleted (needs a cleanup hook in the monitor delete flow); file header embeds the raw (unsanitized) monitorId while the filename sanitizes (header is never parsed; cosmetic).
- Reviewer A verified the mirrored retention loops do not trip the jscpd duplicate gate and found no reusable bounded-collection utility in the repo; no shared abstraction warranted.

## Validation
- `pnpm test`: 757 tests, 756 pass, 0 fail, 1 skipped; BDD suite pass.
- `pnpm typecheck` + electron tsconfig `--noEmit`: clean.
- `pnpm lint:complexity:gate`: pass. eslint on changed files: clean.