### PR TITLE
Authenticate webhook before body read; forget decision memory on delete

### DIFF
--- a/services/local-ai-core/src/automation/automation-monitor-service.ts
+++ b/services/local-ai-core/src/automation/automation-monitor-service.ts
@@ -387,26 +387,20 @@ export class AutomationMonitorService {
     return evaluated;
   }
 
-  async triggerWebhook(hookId: string, payload: unknown, token?: string): Promise<{
+  async triggerWebhook(hookId: string, payload: unknown, token?: string, authenticated?: AutomationMonitor): Promise<{
     success: boolean;
     monitorId: string;
     run: AutomationMonitorRun;
     decision: string;
   }> {
     const cleanHookId = String(hookId || '').trim();
-    const monitor = this.getMonitorByHookId(cleanHookId);
-    if (!monitor) {
-      throw new WebhookTriggerError(`Webhook monitor not found: ${cleanHookId}`, 404);
-    }
-    if (!monitor.enabled) {
-      throw new WebhookTriggerError(`Webhook monitor is disabled: ${cleanHookId}`, 400);
-    }
-
-    const expectedToken = String(monitor.sourceConfig?.token || '').trim();
-    const cleanToken = String(token || '').trim();
-    if (!cleanToken || !expectedToken || !webhookTokenEquals(cleanToken, expectedToken)) {
-      throw new WebhookTriggerError('Invalid or missing webhook token.', 401);
-    }
+    // Reuse an already-authenticated monitor only when it demonstrably maps to
+    // this hookId; otherwise fall back to the full authentication path.
+    const monitor = (authenticated
+      && authenticated.sourceType === 'webhook'
+      && (authenticated.sourceConfig?.hookId === cleanHookId || authenticated.id === cleanHookId))
+      ? authenticated
+      : this.authenticateWebhook(cleanHookId, token);
 
     const body = (typeof payload === 'object' && payload !== null)
       ? payload as Record<string, unknown>
@@ -438,6 +432,29 @@ export class AutomationMonitorService {
       run,
       decision,
     };
+  }
+
+  // Pre-flight hook authentication (existence, enabled state, token) so the
+  // HTTP layer can reject before reading the request body.
+  authenticateWebhook(hookId: string, token?: string): AutomationMonitor {
+    const cleanHookId = String(hookId || '').trim();
+    const monitor = this.getMonitorByHookId(cleanHookId);
+    if (!monitor) {
+      throw new WebhookTriggerError(`Webhook monitor not found: ${cleanHookId}`, 404);
+    }
+    if (!monitor.enabled) {
+      throw new WebhookTriggerError(`Webhook monitor is disabled: ${cleanHookId}`, 400);
+    }
+    this.assertWebhookToken(monitor, token);
+    return monitor;
+  }
+
+  private assertWebhookToken(monitor: AutomationMonitor, token?: string): void {
+    const expectedToken = String(monitor.sourceConfig?.token || '').trim();
+    const cleanToken = String(token || '').trim();
+    if (!cleanToken || !expectedToken || !webhookTokenEquals(cleanToken, expectedToken)) {
+      throw new WebhookTriggerError('Invalid or missing webhook token.', 401);
+    }
   }
 
   listMonitorsForThread(threadId: string): AutomationMonitor[] {

--- a/services/local-ai-core/src/automation/decision-log-service.ts
+++ b/services/local-ai-core/src/automation/decision-log-service.ts
@@ -156,6 +156,10 @@ export class DecisionLogService {
     }
     return lessons.slice(0, 10);
   }
+
+  forgetMonitor(monitorId: string): void {
+    this.memoryRecords.delete(monitorId);
+  }
 }
 
 function appendBulletList(lines: string[], heading: string, items?: string[]): void {

--- a/services/local-ai-core/src/runtime/handlers/automation-handler.ts
+++ b/services/local-ai-core/src/runtime/handlers/automation-handler.ts
@@ -82,7 +82,11 @@ export function registerAutomationHandlers(
     json(res, 200, await automationMonitors.updateMonitor((route as { monitorId: string }).monitorId, body));
   });
   map.set('automation.monitor.delete', async (route, _req, res) => {
-    json(res, 200, await automationMonitors.deleteMonitor((route as { monitorId: string }).monitorId));
+    const monitorId = (route as { monitorId: string }).monitorId;
+    const internalId = automationMonitors.resolveRequiredMonitorId(monitorId);
+    const result = await automationMonitors.deleteMonitor(internalId);
+    decisionLogService?.forgetMonitor(internalId);
+    json(res, 200, result);
   });
   map.set('automation.monitor.decisions', async (route, _req, res) => {
     const monitorId = (route as { monitorId: string }).monitorId;
@@ -101,10 +105,23 @@ export function registerAutomationHandlers(
   map.set('automation.hooks.trigger', async (route, req, res, url) => {
     const hookId = (route as { hookId: string }).hookId;
     const token = extractWebhookToken(req, url);
+
+    // Authenticate before consuming the request body so unauthenticated
+    // requests never pay (or abuse) the full 1 MiB buffering cost. The body
+    // read stays outside the catch: RequestValidationError must still reach
+    // the central handler for its 400 mapping.
+    let monitor: ReturnType<typeof automationMonitors.authenticateWebhook>;
+    try {
+      monitor = automationMonitors.authenticateWebhook(hookId, token);
+    } catch (error) {
+      handleWebhookError(res, error);
+      return;
+    }
+
     const payload = await readWebhookPayload(req);
 
     try {
-      const result = await automationMonitors.triggerWebhook(hookId, payload, token);
+      const result = await automationMonitors.triggerWebhook(hookId, payload, token, monitor);
       rawJson(res, 200, result);
     } catch (error) {
       handleWebhookError(res, error);

--- a/tests/electron/webhook-monitor.test.ts
+++ b/tests/electron/webhook-monitor.test.ts
@@ -205,6 +205,43 @@ test('triggerWebhook token compare rejects wrong-length tokens with 401', async 
   }
 });
 
+test('authenticateWebhook enforces hook existence, enabled state, and token before any payload work', async () => {
+  const context = fixture();
+  try {
+    const monitor = await context.monitors.createMonitor({
+      workspaceId: 'workspace-a',
+      title: 'Pre-Auth Hook',
+      sourceType: 'webhook',
+      sourceConfig: { hookId: 'pre-auth-hook', token: 'sec-pre-auth' },
+      condition: { metric: 'always', operator: '==', value: true },
+      promptTemplate: 'Hello',
+    });
+
+    assert.throws(
+      () => context.monitors.authenticateWebhook('missing-hook', 'sec-pre-auth'),
+      (error: unknown) => error instanceof WebhookTriggerError && error.status === 404,
+    );
+    assert.throws(
+      () => context.monitors.authenticateWebhook('pre-auth-hook', 'wrong'),
+      (error: unknown) => error instanceof WebhookTriggerError && error.status === 401,
+    );
+    assert.throws(
+      () => context.monitors.authenticateWebhook('pre-auth-hook', undefined),
+      (error: unknown) => error instanceof WebhookTriggerError && error.status === 401,
+    );
+    await context.monitors.updateMonitor(monitor.id, { enabled: false });
+    assert.throws(
+      () => context.monitors.authenticateWebhook('pre-auth-hook', 'sec-pre-auth'),
+      (error: unknown) => error instanceof WebhookTriggerError && error.status === 400,
+    );
+    await context.monitors.updateMonitor(monitor.id, { enabled: true });
+    assert.doesNotThrow(() => context.monitors.authenticateWebhook('pre-auth-hook', 'sec-pre-auth'));
+  } finally {
+    await context.monitors.stop();
+    context.close();
+  }
+});
+
 test('triggerWebhook rejects when monitor is disabled', async () => {
   const context = fixture();
   try {
@@ -357,6 +394,113 @@ test('HTTP automation.hooks.trigger handler supports Bearer, X-Hook-Token, and q
     context.close();
   }
 });
+
+test('webhook trigger authenticates before consuming the request body', async () => {
+  const context = fixture();
+  try {
+    await context.monitors.createMonitor({
+      workspaceId: 'workspace-a',
+      title: 'Auth Order Hook',
+      sourceType: 'webhook',
+      sourceConfig: { hookId: 'auth-order-hook', token: 'sec-order' },
+      condition: { metric: 'always', operator: '==', value: true },
+      promptTemplate: 'Hello',
+    });
+
+    const handlers = new Map<string, RouteHandler>();
+    registerAutomationHandlers(handlers, context.monitors);
+    const handler = handlers.get('automation.hooks.trigger');
+    assert.ok(handler, 'automation.hooks.trigger handler must be registered');
+
+    function mockReq(body: unknown, headers: Record<string, string>) {
+      const stream = Readable.from(Buffer.from(JSON.stringify(body))) as any;
+      stream.headers = headers;
+      return stream;
+    }
+
+    // Invalid token + oversized payload: the 401 must win before the body is
+    // buffered or the 1 MiB cap produces a 400.
+    const oversized = { event: 'x'.repeat(2 << 20) };
+    const res = mockJsonRes();
+    await handler(
+      { name: 'automation.hooks.trigger', hookId: 'auth-order-hook' } as any,
+      mockReq(oversized, { authorization: 'Bearer wrong' }),
+      res as any,
+      new URL('http://127.0.0.1/api/local/v1/automation/hooks/auth-order-hook'),
+    );
+    assert.equal(res.statusCode, 401);
+    assert.match(String(res.body?.error || ''), /Invalid or missing webhook token/);
+
+    // Valid token + oversized payload still surfaces the body-cap 400 via the
+    // central request-validation mapping (rejected, not stored or executed).
+    const resTooLarge = mockJsonRes();
+    await assert.rejects(
+      () => handler(
+        { name: 'automation.hooks.trigger', hookId: 'auth-order-hook' } as any,
+        mockReq(oversized, { authorization: 'Bearer sec-order' }),
+        resTooLarge as any,
+        new URL('http://127.0.0.1/api/local/v1/automation/hooks/auth-order-hook'),
+      ),
+      /Request body exceeds/,
+    );
+  } finally {
+    await context.monitors.stop();
+    context.close();
+  }
+});
+
+test('automation.monitor.delete forgets the monitor decision memory', async () => {
+  const context = fixture();
+  try {
+    const monitor = await context.monitors.createMonitor({
+      workspaceId: 'workspace-a',
+      title: 'Forgotten Hook',
+      sourceType: 'webhook',
+      sourceConfig: { hookId: 'forget-hook', token: 'sec-forget' },
+      condition: { metric: 'always', operator: '==', value: true },
+      promptTemplate: 'Hello',
+    });
+
+    // Route the delete through the public short id so the test proves the
+    // handler resolves it to the internal id used as the decision-memory key.
+    const publicId = toPublicAutomationMonitorId(monitor.id);
+    assert.notEqual(publicId, monitor.id);
+
+    const forgotten: string[] = [];
+    const decisionService = {
+      listDecisions: async () => [],
+      forgetMonitor: (monitorId: string) => { forgotten.push(monitorId); },
+    };
+    const handlers = new Map<string, RouteHandler>();
+    registerAutomationHandlers(handlers, context.monitors, decisionService as any);
+    const handler = handlers.get('automation.monitor.delete');
+    assert.ok(handler, 'automation.monitor.delete handler must be registered');
+
+    const res = mockJsonRes();
+    await handler(
+      { name: 'automation.monitor.delete', monitorId: publicId } as any,
+      {} as any,
+      res as any,
+      new URL(`http://127.0.0.1/api/local/v1/automation/monitors/${publicId}`),
+    );
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(forgotten, [monitor.id]);
+  } finally {
+    await context.monitors.stop();
+    context.close();
+  }
+});
+
+function mockJsonRes() {
+  return {
+    statusCode: 200,
+    bodyData: '',
+    setHeader() {},
+    writeHead(code: number) { this.statusCode = code; },
+    end(data?: unknown) { this.bodyData = String(data || ''); },
+    get body() { return this.bodyData ? JSON.parse(this.bodyData) : null; },
+  };
+}
 
 test('parseMonitorCondition correctly parses quoted string literals without double escaping', () => {
   const parsed = parseMonitorCondition('status == "failed"');


### PR DESCRIPTION
## Category

d) quality (security hardening + resource-leak follow-up), with a c) performance overlap

## Motivation

Two follow-ups from the webhook/decision-log hardening line (#133, #135):

1. **Authenticate before body read.** `automation.hooks.trigger` buffered up to 1 MiB of request body *before* authenticating the hook — unauthenticated callers could make the server pay (or be made to pay) the full buffering cost on every request. Hook existence (404), enabled state (400), and token (401) are now verified before a single body byte is read.
2. **Decision-memory leak.** `DecisionLogService.memoryRecords` Map entries were never removed when a monitor was deleted, so deleted monitors' cached decision records stayed resident forever. Monitor delete now resolves the internal id and calls the new `forgetMonitor` (while the monitor still exists), keeping cache lifetime tied to monitor lifetime.

## Changes

- `AutomationMonitorService.authenticateWebhook(hookId, token)` (public): 404/400/401 pre-flight; token compare extracted to private `assertWebhookToken` and reused by `triggerWebhook` (behavior-identical for existing callers)
- `triggerWebhook` accepts an optional pre-authenticated monitor (hookId-matched guard) so the handler's pre-flight does not double the `getMonitorByHookId` lookup on the success path
- Handler: auth in its own try/catch before `readWebhookPayload`; the body read deliberately stays outside the catch so `RequestValidationError` still reaches the central 400 mapping
- Handler `automation.monitor.delete`: resolve internal id → `deleteMonitor(internalId)` (single resolution) → `decisionLogService?.forgetMonitor(internalId)`
- `DecisionLogService.forgetMonitor(monitorId)`

## Review rounds

- Round 1: 3 parallel reviewers (reuse / quality / efficiency) on the full diff. 4 findings, all fixed: (a) delete test routed through the public short id with an `assert.notEqual` guard so it genuinely proves public→internal resolution; (b) duplicate id resolution removed (`deleteMonitor(internalId)`); (c) success-path double hook lookup removed via the guarded `authenticated` param; (d) duplicated mock res helper collapsed into one shared `mockJsonRes`. No round 2 needed — round-1 fixes apply the prescriptions directly.

## Validation

- Baseline main @ be190eb: 757 tests, 0 fail, 1 skip. Branch: full `pnpm test` exit 0 (twice: pre- and post-review-fixes), both typechecks exit 0
- New regression test validated in red state: reverting the auth/body order makes `webhook trigger authenticates before consuming the request body` fail
- Gates: `lint:complexity:gate` 105 warnings (≤108, none new — all 3 warnings in `automation-monitor-service.ts` are pre-existing), `lint:circular`, `lint:file-size`, `lint:function-length` all exit 0
- Known environmental gap: `lint:dead-code` (knip) fails locally on this machine regardless of branch (unparseable knip output); CI's lint:gates run is authoritative. The diff adds no unused exports