### PR TITLE
Resolve monitor identity without eager evaluation queries

### DIFF
--- a/services/local-ai-core/src/automation/automation-monitor-service.ts
+++ b/services/local-ai-core/src/automation/automation-monitor-service.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import type {
+  AutomationDefinition,
   AutomationMonitor,
   AutomationMonitorCreateInput,
   AutomationMonitorEventSnapshot,
@@ -226,9 +227,8 @@ export class AutomationMonitorService {
   }
 
   getMonitor(monitorId: string): AutomationMonitor | undefined {
-    const resolved = this.resolveMonitorId(monitorId);
-    const automation = resolved ? this.options.automations.get(resolved) : undefined;
-    return automation?.originKind === 'automation-monitor'
+    const automation = this.resolveMonitorAutomation(monitorId);
+    return automation
       ? automationToMonitor(
         automation,
         latestFinishedEvaluation(this.options.automations.listEvaluations(automation.id)),
@@ -705,14 +705,15 @@ export class AutomationMonitorService {
             callbackLifecycleGeneration === undefined
             || !this.isCurrentLifecycle(callbackLifecycleGeneration, 'running')
           ) return;
-          const latest = this.getMonitor(monitor.id);
+          // Guard directly on the definition: getMonitor would run four more
+          // queries only to read `enabled` (a passthrough of automation.enabled).
           const definition = this.options.automations.get(monitor.id);
           if (
-            latest?.enabled
-            && definition?.health !== 'blocked'
+            definition?.enabled
+            && definition.health !== 'blocked'
             && this.subscriptionHandles.has(monitor.id)
           ) {
-            await this.evaluateEvent(latest.id, event, {
+            await this.evaluateEvent(monitor.id, event, {
               kind: 'subscription', generation, lifecycleGeneration: callbackLifecycleGeneration,
             });
           }
@@ -988,14 +989,25 @@ export class AutomationMonitorService {
     return monitor;
   }
 
-  private resolveMonitorId(monitorId: string): string {
+  private resolveMonitorAutomation(monitorId: string): AutomationDefinition | undefined {
     const direct = this.options.automations.get(monitorId);
-    if (direct?.originKind === 'automation-monitor') return direct.id;
+    if (direct?.originKind === 'automation-monitor') return direct;
     const matches = this.options.automations.list().filter((automation) =>
       automation.originKind === 'automation-monitor' && toPublicAutomationMonitorId(automation.id) === monitorId
     );
     if (matches.length > 1) throw new Error(`Automation monitor id is ambiguous: ${monitorId}`);
-    return matches[0]?.id || '';
+    return matches[0];
+  }
+
+  private resolveMonitorId(monitorId: string): string {
+    return this.resolveMonitorAutomation(monitorId)?.id || '';
+  }
+
+  // Identity-only resolution for callers that need (internal id, workspaceId)
+  // but not the eager evaluation/run/state queries getMonitor performs.
+  getMonitorIdentity(monitorId: string): { id: string; workspaceId: string } | undefined {
+    const automation = this.resolveMonitorAutomation(monitorId);
+    return automation ? { id: automation.id, workspaceId: automation.workspaceId } : undefined;
   }
 
   resolveRequiredMonitorId(monitorId: string): string {

--- a/services/local-ai-core/src/runtime/handlers/automation-handler.ts
+++ b/services/local-ai-core/src/runtime/handlers/automation-handler.ts
@@ -95,12 +95,13 @@ export function registerAutomationHandlers(
       return;
     }
     // Decisions are keyed under the internal monitor id; the API accepts the
-    // public short id (or the internal id) so resolve before lookup.
-    const monitor = automationMonitors.getMonitor(monitorId);
-    if (!monitor) {
+    // public short id (or the internal id). Identity-only resolution avoids
+    // getMonitor's eager evaluation/run/state queries.
+    const identity = automationMonitors.getMonitorIdentity(monitorId);
+    if (!identity) {
       throw new Error(`Automation monitor not found: ${monitorId}`);
     }
-    json(res, 200, { decisions: await decisionLogService.listDecisions(monitor.id, monitor.workspaceId) });
+    json(res, 200, { decisions: await decisionLogService.listDecisions(identity.id, identity.workspaceId) });
   });
   map.set('automation.hooks.trigger', async (route, req, res, url) => {
     const hookId = (route as { hookId: string }).hookId;

--- a/tests/electron/webhook-monitor.test.ts
+++ b/tests/electron/webhook-monitor.test.ts
@@ -576,6 +576,77 @@ test('automation.monitor.decisions resolves public short monitor ids to internal
   }
 });
 
+test('automation.monitor.decisions resolves identity without eager evaluation queries', async () => {
+  const context = fixture();
+  try {
+    const monitor = await context.monitors.createMonitor({
+      workspaceId: 'workspace-a',
+      title: 'Identity Resolution Hook',
+      sourceType: 'webhook',
+      sourceConfig: { hookId: 'identity-hook', token: 'sec-identity' },
+      condition: { metric: 'always', operator: '==', value: true },
+      promptTemplate: 'Analyze the webhook event.',
+    });
+
+    const workspacePath = join(context.path, 'workspace');
+    const decisionService = new DecisionLogService({ getWorkspacePath: () => workspacePath });
+    await decisionService.appendDecision({
+      id: 'dec_b4c5d6e7f8091223',
+      monitorId: monitor.id,
+      workspaceId: 'workspace-a',
+      runId: `run:agentdock::${monitor.id}:1756950000002`,
+      threadId: 'thread:workspace-a::11111111-2222-3333-4444-555555555555',
+      action: 'WATCH',
+      confidence: 50,
+      thesis: 'Identity-only resolution.',
+      bullPoints: [],
+      bearPoints: [],
+      keyAssumptions: [],
+      dataSnapshot: {},
+      createdAt: '2026-09-13T08:00:00.000Z',
+      retrospectiveStatus: 'pending',
+    });
+
+    const handlers = new Map<string, RouteHandler>();
+    registerAutomationHandlers(handlers, context.monitors, decisionService);
+    const handler = handlers.get('automation.monitor.decisions');
+    assert.ok(handler, 'automation.monitor.decisions handler must be registered');
+
+    // Identity resolution must not pay getMonitor's eager evaluation/run/state
+    // queries: the decisions drawer only needs the internal id + workspaceId.
+    const automations = context.automations as any;
+    const eager = { evaluations: 0, runs: 0, state: 0 };
+    for (const [method, counter] of [
+      ['listEvaluations', 'evaluations'],
+      ['listRuns', 'runs'],
+      ['getLatestEvaluationWithState', 'state'],
+    ] as const) {
+      const original = automations[method].bind(context.automations);
+      automations[method] = (...args: unknown[]) => {
+        eager[counter] += 1;
+        return original(...args);
+      };
+    }
+
+    const publicId = toPublicAutomationMonitorId(monitor.id);
+    assert.notEqual(publicId, monitor.id);
+    const res = mockJsonRes();
+    await handler(
+      { name: 'automation.monitor.decisions', monitorId: publicId } as any,
+      {} as any,
+      res as any,
+      new URL(`http://127.0.0.1/api/local/v1/automation/monitors/${publicId}/decisions`),
+    );
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.data.decisions.length, 1);
+    assert.equal(res.body.data.decisions[0].id, 'dec_b4c5d6e7f8091223');
+    assert.deepEqual(eager, { evaluations: 0, runs: 0, state: 0 });
+  } finally {
+    await context.monitors.stop();
+    context.close();
+  }
+});
+
 test('automation.monitor.decisions reads persisted decisions after restart from the workspace dir', async () => {
   const context = fixture();
   try {


### PR DESCRIPTION
## Category

c) performance, with a b) reuse overlap

## Motivation

The `automation.monitor.decisions` endpoint (hit every time the decisions drawer opens in the UI) resolved the monitor through `AutomationMonitorService.getMonitor()` — which eager-runs `listEvaluations` + `listRuns` + `getLatestEvaluationWithState` on top of the resolution itself — but consumed only the internal id and workspaceId. That is 5 SQLite queries per decisions read (6 for public short ids, including a full `automations.list()` scan) where 1-2 suffice, with two unbounded historical-row scans and per-row mapping fully wasted. Round-1 review also surfaced the same waste one layer deeper: the subscription `emit` callback ran full `getMonitor` on *every inbound provider event* just to read `enabled`.

## Changes

- `AutomationMonitorService.getMonitorIdentity(monitorId): { id, workspaceId } | undefined` — identity-only resolution built on the refactored private `resolveMonitorAutomation` (which `resolveMonitorId`/`resolveRequiredMonitorId` now delegate to; single-sourced public-short-id matching)
- Decisions handler uses `getMonitorIdentity` instead of `getMonitor`
- Subscription `emit` callback guards directly on the already-fetched `AutomationDefinition` (`enabled` is a passthrough of `automation.enabled`) instead of calling `getMonitor` — drops 5 of 6 queries per inbound provider event
- `getMonitor` itself delegates to `resolveMonitorAutomation`, removing its internal double `automations.get`

## Review rounds

- Round 1: 3 parallel reviewers (reuse / quality / efficiency). Quality reviewer: clean. Two fixes applied verbatim from reuse+efficiency: (a) `getMonitor` now delegates to `resolveMonitorAutomation` instead of re-fetching the resolved record; (b) emit callback reads `definition.enabled` directly instead of full `getMonitor`. No round 2 — round-1 fixes apply the prescriptions directly.
- Per decisions read: 5→1 queries (internal id) / 6→2 (public short id); per inbound provider event: 6→1.

## Validation

- Baseline main @ 678e428: 760 tests / 759 pass / 1 skip, fail=0. Branch: full `pnpm test` exit 0 (twice: pre- and post-review-fixes), both typechecks exit 0
- New TDD test (validated red first): `automation.monitor.decisions resolves identity without eager evaluation queries` spies `listEvaluations`/`listRuns`/`getLatestEvaluationWithState` and asserts zero calls during decisions resolution
- Gates: `lint:complexity:gate` 105 warnings (≤108, none new), `lint:circular`, `lint:file-size`, `lint:function-length` all exit 0
- Known environmental gap: `lint:dead-code` (knip) fails locally on this machine regardless of branch; CI's lint:gates run is authoritative. The diff adds no unused exports